### PR TITLE
feat(pools): replace mocked pool data with real contract data

### DIFF
--- a/apps/web-app/src/components/ui/AssetBreakdown.tsx
+++ b/apps/web-app/src/components/ui/AssetBreakdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 import {
   Table,
   TableBody,
@@ -16,10 +16,13 @@ import {
   Box,
   Typography,
   Button,
+  CircularProgress,
 } from "@mui/material";
 import { Info } from "@mui/icons-material";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { useRouter } from "next/navigation";
+import { useLendingPools } from "@/features/lending/hooks/useLendingPools";
+import { useBorrowPools } from "@/features/borrowing/hooks/useBorrowPools";
 
 interface AssetData {
   id: string;
@@ -54,32 +57,84 @@ const lightTheme = createTheme({
 const AssetBreakdown: React.FC = () => {
   const router = useRouter();
 
-  const assets: AssetData[] = [
-    {
-      id: "123456",
-      pool: { token1: "USDC", token2: "NVDA", fee: "1%" },
-      roi: "0.07%",
-      feeApy: "372.70%",
-      liquidity: "$15.21k",
-      isActive: true,
-    },
-    {
-      id: "1234567",
-      pool: { token1: "USDC", token2: "TSLA", fee: "0.01%" },
-      roi: "0.00%",
-      feeApy: "7.20%",
-      liquidity: "$719.39k",
-      isActive: true,
-    },
-    {
-      id: "1234",
-      pool: { token1: "USDC", token2: "GOOG", fee: "0.01%" },
-      roi: "0.00%",
-      feeApy: "7.20%",
-      liquidity: "$719.39k",
-      isActive: true,
-    },
-  ];
+  // Get real lending pools from contract
+  const {
+    data: lendingPools = [],
+    isLoading: isLoadingLending,
+    error: lendingError,
+  } = useLendingPools();
+
+  // Get real borrow pools from contract
+  const {
+    data: borrowPools = [],
+    isLoading: isLoadingBorrow,
+    error: borrowError,
+  } = useBorrowPools();
+
+  const isLoading = isLoadingLending || isLoadingBorrow;
+  const error = lendingError || borrowError;
+
+  // Combine and transform lending and borrow pools into unified AssetData format
+  const assets: AssetData[] = useMemo(() => {
+    const combinedAssets: AssetData[] = [];
+
+    // Add lending pools (single token pools for supplying liquidity)
+    lendingPools.forEach((pool, index) => {
+      // Calculate APY from interest rate
+      const apy =
+        pool.interestRate > 0 ? `${pool.interestRate.toFixed(2)}%` : "0.00%";
+
+      // Format liquidity
+      const balanceNum = parseFloat(pool.poolBalance);
+      const liquidity =
+        balanceNum >= 1000000
+          ? `$${(balanceNum / 1000000).toFixed(2)}M`
+          : balanceNum >= 1000
+            ? `$${(balanceNum / 1000).toFixed(2)}k`
+            : `$${balanceNum.toFixed(2)}`;
+
+      combinedAssets.push({
+        id: `lending-${index}`,
+        pool: {
+          token1: pool.assetCode,
+          token2: "Lending",
+          fee: "0%",
+        },
+        roi: `${pool.interestRate.toFixed(2)}%`,
+        feeApy: apy,
+        liquidity,
+        isActive: pool.isActive,
+      });
+    });
+
+    // Add borrow pools (RWA token + debt asset pairs)
+    borrowPools.forEach((pool, index) => {
+      // Format liquidity
+      const balanceNum = parseFloat(pool.poolBalance);
+      const liquidity =
+        balanceNum >= 1000000
+          ? `$${(balanceNum / 1000000).toFixed(2)}M`
+          : balanceNum >= 1000
+            ? `$${(balanceNum / 1000).toFixed(2)}k`
+            : `$${balanceNum.toFixed(2)}`;
+
+      combinedAssets.push({
+        id: `borrow-${index}`,
+        pool: {
+          token1: pool.assetCode,
+          token2: pool.collateralTokenCode,
+          fee: `${pool.collateralFactor}%`,
+        },
+        roi: `${pool.interestRate.toFixed(2)}%`,
+        feeApy: `${pool.interestRate.toFixed(2)}%`,
+        liquidity,
+        isActive: pool.isActive,
+      });
+    });
+
+    // Limit to 3 items for dashboard display
+    return combinedAssets.slice(0, 3);
+  }, [lendingPools, borrowPools]);
 
   return (
     <ThemeProvider theme={lightTheme}>
@@ -142,100 +197,149 @@ const AssetBreakdown: React.FC = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {assets.map((asset) => (
-                <TableRow
-                  key={asset.id}
-                  sx={{
-                    "&:hover": {
-                      backgroundColor: "rgba(51, 78, 172, 0.1)",
-                    },
-                    "& td": {
-                      borderBottom: "1px solid rgba(51, 78, 172, 0.2)",
-                      py: 2.5,
-                    },
-                  }}
-                >
-                  <TableCell>
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                      <Box
-                        sx={{
-                          width: 8,
-                          height: 8,
-                          borderRadius: "50%",
-                          backgroundColor: asset.isActive
-                            ? "#028733ff"
-                            : "#6b7280",
-                        }}
-                      />
-                      <Typography
-                        sx={{
-                          color: asset.isActive ? "#028733ff" : "#7096D1",
-                          fontWeight: 500,
-                        }}
-                      >
-                        {asset.id}
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        justifyContent: "center",
+                        alignItems: "center",
+                        gap: 2,
+                      }}
+                    >
+                      <CircularProgress size={24} sx={{ color: "#334EAC" }} />
+                      <Typography sx={{ color: "#7096D1" }}>
+                        Loading pools...
                       </Typography>
                     </Box>
                   </TableCell>
-                  <TableCell>
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                      <Box sx={{ position: "relative", width: 40, height: 24 }}>
-                        <Avatar
-                          sx={{
-                            width: 24,
-                            height: 24,
-                            position: "absolute",
-                            left: 0,
-                            border: "2px solid #ffffff",
-                            backgroundColor: "#334EAC",
-                          }}
-                        />
-                        <Avatar
-                          sx={{
-                            width: 24,
-                            height: 24,
-                            position: "absolute",
-                            left: 16,
-                            border: "2px solid #ffffff",
-                            backgroundColor: "#7096D1",
-                          }}
-                        />
-                      </Box>
-                      <Box>
-                        <Typography sx={{ color: "#081F5C", fontWeight: 500 }}>
-                          {asset.pool.token1} / {asset.pool.token2}
-                        </Typography>
-                        <Chip
-                          label={asset.pool.fee}
-                          size="small"
-                          sx={{
-                            backgroundColor: "rgba(51, 78, 172, 0.1)",
-                            color: "#081F5C",
-                            fontWeight: 600,
-                            height: 20,
-                            fontSize: "0.7rem",
-                          }}
-                        />
-                      </Box>
-                    </Box>
-                  </TableCell>
-                  <TableCell>
-                    <Typography sx={{ color: "#081F5C" }}>
-                      {asset.roi}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Typography sx={{ color: "#081F5C" }}>
-                      {asset.feeApy}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Typography sx={{ color: "#081F5C" }}>
-                      {asset.liquidity}
+                </TableRow>
+              ) : error ? (
+                <TableRow>
+                  <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                    <Typography sx={{ color: "#dc2626" }}>
+                      Error loading pools: {String(error)}
                     </Typography>
                   </TableCell>
                 </TableRow>
-              ))}
+              ) : assets.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                    <Typography sx={{ color: "#7096D1" }}>
+                      No pools available
+                    </Typography>
+                    <Typography
+                      sx={{ color: "#7096D1", fontSize: "0.875rem", mt: 1 }}
+                    >
+                      There are currently no active pools in the contract.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                assets.map((asset) => (
+                  <TableRow
+                    key={asset.id}
+                    sx={{
+                      "&:hover": {
+                        backgroundColor: "rgba(51, 78, 172, 0.1)",
+                      },
+                      "& td": {
+                        borderBottom: "1px solid rgba(51, 78, 172, 0.2)",
+                        py: 2.5,
+                      },
+                    }}
+                  >
+                    <TableCell>
+                      <Box
+                        sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                      >
+                        <Box
+                          sx={{
+                            width: 8,
+                            height: 8,
+                            borderRadius: "50%",
+                            backgroundColor: asset.isActive
+                              ? "#028733ff"
+                              : "#6b7280",
+                          }}
+                        />
+                        <Typography
+                          sx={{
+                            color: asset.isActive ? "#028733ff" : "#7096D1",
+                            fontWeight: 500,
+                          }}
+                        >
+                          {asset.id}
+                        </Typography>
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <Box
+                        sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                      >
+                        <Box
+                          sx={{ position: "relative", width: 40, height: 24 }}
+                        >
+                          <Avatar
+                            sx={{
+                              width: 24,
+                              height: 24,
+                              position: "absolute",
+                              left: 0,
+                              border: "2px solid #ffffff",
+                              backgroundColor: "#334EAC",
+                            }}
+                          />
+                          <Avatar
+                            sx={{
+                              width: 24,
+                              height: 24,
+                              position: "absolute",
+                              left: 16,
+                              border: "2px solid #ffffff",
+                              backgroundColor: "#7096D1",
+                            }}
+                          />
+                        </Box>
+                        <Box>
+                          <Typography
+                            sx={{ color: "#081F5C", fontWeight: 500 }}
+                          >
+                            {asset.pool.token1} / {asset.pool.token2}
+                          </Typography>
+                          <Chip
+                            label={asset.pool.fee}
+                            size="small"
+                            sx={{
+                              backgroundColor: "rgba(51, 78, 172, 0.1)",
+                              color: "#081F5C",
+                              fontWeight: 600,
+                              height: 20,
+                              fontSize: "0.7rem",
+                            }}
+                          />
+                        </Box>
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <Typography sx={{ color: "#081F5C" }}>
+                        {asset.roi}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography sx={{ color: "#081F5C" }}>
+                        {asset.feeApy}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography sx={{ color: "#081F5C" }}>
+                        {asset.liquidity}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
             </TableBody>
           </Table>
         </TableContainer>

--- a/apps/web-app/src/features/pools/components/pages/Pools.tsx
+++ b/apps/web-app/src/features/pools/components/pages/Pools.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import React from "react";
+import React, { useMemo } from "react";
+import { useLendingPools } from "@/features/lending/hooks/useLendingPools";
+import { useBorrowPools } from "@/features/borrowing/hooks/useBorrowPools";
 
 interface PoolData {
   id: string;
@@ -16,48 +18,80 @@ interface PoolData {
 
 const Pools: React.FC = () => {
   const router = useRouter();
-  const pools: PoolData[] = [
-    {
-      id: "123456",
-      token1: "USDC",
-      token2: "NVDA",
-      fee: "1%",
-      roi: "0.07%",
-      feeApy: "372.70%",
-      liquidity: "$15.21k",
-      isActive: true,
-    },
-    {
-      id: "1234567",
-      token1: "USDC",
-      token2: "TSLA",
-      fee: "0.01%",
-      roi: "0.00%",
-      feeApy: "7.20%",
-      liquidity: "$719.39k",
-      isActive: true,
-    },
-    {
-      id: "1234",
-      token1: "USDC",
-      token2: "GOOG",
-      fee: "0.01%",
-      roi: "0.00%",
-      feeApy: "7.20%",
-      liquidity: "$719.39k",
-      isActive: true,
-    },
-    {
-      id: "789012",
-      token1: "XLM",
-      token2: "USDC",
-      fee: "0.3%",
-      roi: "0.15%",
-      feeApy: "45.50%",
-      liquidity: "$1.2M",
-      isActive: true,
-    },
-  ];
+
+  // Get real lending pools from contract
+  const {
+    data: lendingPools = [],
+    isLoading: isLoadingLending,
+    error: lendingError,
+  } = useLendingPools();
+
+  // Get real borrow pools from contract
+  const {
+    data: borrowPools = [],
+    isLoading: isLoadingBorrow,
+    error: borrowError,
+  } = useBorrowPools();
+
+  const isLoading = isLoadingLending || isLoadingBorrow;
+  const error = lendingError || borrowError;
+
+  // Combine and transform lending and borrow pools into unified PoolData format
+  const pools: PoolData[] = useMemo(() => {
+    const combinedPools: PoolData[] = [];
+
+    // Add lending pools (single token pools for supplying liquidity)
+    lendingPools.forEach((pool, index) => {
+      // Calculate APY from interest rate
+      const apy =
+        pool.interestRate > 0 ? `${pool.interestRate.toFixed(2)}%` : "0.00%";
+
+      // Format liquidity
+      const balanceNum = parseFloat(pool.poolBalance);
+      const liquidity =
+        balanceNum >= 1000000
+          ? `$${(balanceNum / 1000000).toFixed(2)}M`
+          : balanceNum >= 1000
+            ? `$${(balanceNum / 1000).toFixed(2)}k`
+            : `$${balanceNum.toFixed(2)}`;
+
+      combinedPools.push({
+        id: `lending-${index}`,
+        token1: pool.assetCode,
+        token2: "Lending",
+        fee: "0%",
+        roi: `${pool.interestRate.toFixed(2)}%`,
+        feeApy: apy,
+        liquidity,
+        isActive: pool.isActive,
+      });
+    });
+
+    // Add borrow pools (RWA token + debt asset pairs)
+    borrowPools.forEach((pool, index) => {
+      // Format liquidity
+      const balanceNum = parseFloat(pool.poolBalance);
+      const liquidity =
+        balanceNum >= 1000000
+          ? `$${(balanceNum / 1000000).toFixed(2)}M`
+          : balanceNum >= 1000
+            ? `$${(balanceNum / 1000).toFixed(2)}k`
+            : `$${balanceNum.toFixed(2)}`;
+
+      combinedPools.push({
+        id: `borrow-${index}`,
+        token1: pool.assetCode,
+        token2: pool.collateralTokenCode,
+        fee: `${pool.collateralFactor}%`,
+        roi: `${pool.interestRate.toFixed(2)}%`,
+        feeApy: `${pool.interestRate.toFixed(2)}%`,
+        liquidity,
+        isActive: pool.isActive,
+      });
+    });
+
+    return combinedPools;
+  }, [lendingPools, borrowPools]);
 
   return (
     <div className="w-full min-h-screen">
@@ -73,98 +107,127 @@ const Pools: React.FC = () => {
         </div>
 
         {/* Pool Cards Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-          {pools.map((pool) => (
-            <div
-              key={pool.id}
-              className="rounded-3xl bg-[#294cab] p-6 shadow-lg border border-[#334EAC]/50 hover:border-[#39bfb7] transition-all duration-300 hover:shadow-xl relative overflow-hidden group"
-            >
-              {/* Background decoration */}
-              <div className="absolute -right-10 -top-10 w-32 h-32 bg-[#334EAC]/20 rounded-full blur-2xl pointer-events-none"></div>
-
-              {/* Header with Pool Info */}
-              <div className="relative z-10 mb-6">
-                <div className="flex items-center justify-between mb-4">
-                  <div className="flex items-center gap-3">
-                    <div className="relative w-14 h-8">
-                      <div className="absolute left-0 w-8 h-8 rounded-full bg-[#39bfb7] border-2 border-[#334EAC] flex items-center justify-center text-white text-sm font-bold shadow-md">
-                        {pool.token1[0]}
-                      </div>
-                      <div className="absolute left-6 w-8 h-8 rounded-full bg-[#68f9f2] border-2 border-[#334EAC] flex items-center justify-center text-[#081F5C] text-sm font-bold shadow-md">
-                        {pool.token2[0]}
-                      </div>
-                    </div>
-                    <div>
-                      <h3 className="text-white text-xl font-bold">
-                        {pool.token1} / {pool.token2}
-                      </h3>
-                      <div className="inline-block bg-white/10 text-white text-xs font-semibold px-2 py-1 rounded-md mt-1">
-                        V2
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {/* Stats Grid */}
-              <div className="relative z-10 space-y-4 mb-6">
-                <div className="grid grid-cols-3 gap-3">
-                  <div className="bg-[#294cab] rounded-xl p-3 border border-white/10">
-                    <p className="text-[#BAD6EB] text-xs mb-1">ROI</p>
-                    <p className="text-white text-lg font-bold">{pool.roi}</p>
-                  </div>
-                  <div className="bg-[#294cab] rounded-xl p-3 border border-white/10">
-                    <p className="text-[#BAD6EB] text-xs mb-1">Fee APY</p>
-                    <p className="text-white text-lg font-bold">
-                      {pool.feeApy}
-                    </p>
-                  </div>
-                  <div className="bg-[#294cab] rounded-xl p-3 border border-white/10">
-                    <p className="text-[#BAD6EB] text-xs mb-1">Liquidity</p>
-                    <p className="text-white text-lg font-bold">
-                      {pool.liquidity}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              {/* Pool Details / Dashboard Link */}
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-12 w-12 border-4 border-[#334EAC]/30 border-t-[#334EAC] mx-auto mb-4"></div>
+              <p className="text-[#7096D1] text-lg">Loading pools...</p>
+            </div>
+          </div>
+        ) : error ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="text-center bg-red-50 rounded-2xl p-8 border border-red-200">
+              <p className="text-red-600 text-lg font-semibold mb-2">
+                Error loading pools
+              </p>
+              <p className="text-red-500 text-sm">{String(error)}</p>
+            </div>
+          </div>
+        ) : pools.length === 0 ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="text-center bg-[#f3f4f6] rounded-2xl p-8 border border-[#334EAC]/20">
+              <p className="text-[#081F5C] text-lg font-semibold mb-2">
+                No pools available
+              </p>
+              <p className="text-[#7096D1] text-sm">
+                There are currently no active pools in the contract.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+            {pools.map((pool) => (
               <div
-                className="relative z-10 bg-[#fff] rounded-2xl p-4 mb-4 border border-[#334EAC]/30 hover:bg-[#f3f4f6] cursor-pointer transition-colors duration-200"
-                onClick={() => {
-                  router.push(`/dashboard/pools/${pool.id}`);
-                }}
+                key={pool.id}
+                className="rounded-3xl bg-[#294cab] p-6 shadow-lg border border-[#334EAC]/50 hover:border-[#39bfb7] transition-all duration-300 hover:shadow-xl relative overflow-hidden group"
               >
-                <div className="flex items-center justify-center">
-                  <button className="text-black px-3 py-1 rounded-lg text-sm font-semibold duration-200 flex items-center gap-1">
-                    Pool Details <span className="opacity-70">→</span>
-                  </button>
-                </div>
-              </div>
+                {/* Background decoration */}
+                <div className="absolute -right-10 -top-10 w-32 h-32 bg-[#334EAC]/20 rounded-full blur-2xl pointer-events-none"></div>
 
-              {/* Action Buttons */}
-              <div className="relative z-10 flex">
-                <button
-                  className="flex-1 bg-[#081F5C] hover:bg-[#12328a] text-[#FFF9F0] px-4 py-3 rounded-xl text-sm font-bold transition-colors duration-200 border border-[#334EAC]/30"
+                {/* Header with Pool Info */}
+                <div className="relative z-10 mb-6">
+                  <div className="flex items-center justify-between mb-4">
+                    <div className="flex items-center gap-3">
+                      <div className="relative w-14 h-8">
+                        <div className="absolute left-0 w-8 h-8 rounded-full bg-[#39bfb7] border-2 border-[#334EAC] flex items-center justify-center text-white text-sm font-bold shadow-md">
+                          {pool.token1[0]}
+                        </div>
+                        <div className="absolute left-6 w-8 h-8 rounded-full bg-[#68f9f2] border-2 border-[#334EAC] flex items-center justify-center text-[#081F5C] text-sm font-bold shadow-md">
+                          {pool.token2[0]}
+                        </div>
+                      </div>
+                      <div>
+                        <h3 className="text-white text-xl font-bold">
+                          {pool.token1} / {pool.token2}
+                        </h3>
+                        <div className="inline-block bg-white/10 text-white text-xs font-semibold px-2 py-1 rounded-md mt-1">
+                          V2
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Stats Grid */}
+                <div className="relative z-10 space-y-4 mb-6">
+                  <div className="grid grid-cols-3 gap-3">
+                    <div className="bg-[#294cab] rounded-xl p-3 border border-white/10">
+                      <p className="text-[#BAD6EB] text-xs mb-1">ROI</p>
+                      <p className="text-white text-lg font-bold">{pool.roi}</p>
+                    </div>
+                    <div className="bg-[#294cab] rounded-xl p-3 border border-white/10">
+                      <p className="text-[#BAD6EB] text-xs mb-1">Fee APY</p>
+                      <p className="text-white text-lg font-bold">
+                        {pool.feeApy}
+                      </p>
+                    </div>
+                    <div className="bg-[#294cab] rounded-xl p-3 border border-white/10">
+                      <p className="text-[#BAD6EB] text-xs mb-1">Liquidity</p>
+                      <p className="text-white text-lg font-bold">
+                        {pool.liquidity}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Pool Details / Dashboard Link */}
+                <div
+                  className="relative z-10 bg-[#fff] rounded-2xl p-4 mb-4 border border-[#334EAC]/30 hover:bg-[#f3f4f6] cursor-pointer transition-colors duration-200"
                   onClick={() => {
-                    router.push("/dashboard/lending");
+                    router.push(`/dashboard/pools/${pool.id}`);
                   }}
                 >
-                  Lend
-                </button>
-              </div>
+                  <div className="flex items-center justify-center">
+                    <button className="text-black px-3 py-1 rounded-lg text-sm font-semibold duration-200 flex items-center gap-1">
+                      Pool Details <span className="opacity-70">→</span>
+                    </button>
+                  </div>
+                </div>
 
-              {/* Status Indicator */}
-              <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
-                <div
-                  className={`w-2 h-2 rounded-full ${
-                    pool.isActive ? "bg-[#39bfb7]" : "bg-gray-400"
-                  } animate-pulse`}
-                />
+                {/* Action Buttons */}
+                <div className="relative z-10 flex">
+                  <button
+                    className="flex-1 bg-[#081F5C] hover:bg-[#12328a] text-[#FFF9F0] px-4 py-3 rounded-xl text-sm font-bold transition-colors duration-200 border border-[#334EAC]/30"
+                    onClick={() => {
+                      router.push("/dashboard/lending");
+                    }}
+                  >
+                    Lend
+                  </button>
+                </div>
+
+                {/* Status Indicator */}
+                <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
+                  <div
+                    className={`w-2 h-2 rounded-full ${
+                      pool.isActive ? "bg-[#39bfb7]" : "bg-gray-400"
+                    } animate-pulse`}
+                  />
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
**Description:**

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other

### Description
This PR addresses issue #14 by replacing the hardcoded/mocked pool data in the `/dashboard` and `/dashboard/pools` pages with real data fetched from the RWA lending contract.

**Key Changes:**
* **Pools.tsx:** Now uses `useLendingPools()` and `useBorrowPools()` hooks to fetch real pool data from the contract
* **AssetBreakdown.tsx:** Now uses the same hooks to display real pool data (limited to 3 items for dashboard)
* **Loading State:** Shows spinner with "Loading pools..." message while fetching data
* **Error State:** Displays error message if contract fetch fails
* **Empty State:** Shows "No pools available" when no active pools exist
* **Auto-refresh:** Data refreshes automatically every 30 seconds (configured in hooks)

### Evidence
<img width="1490" height="842" alt="Captura de pantalla 2026-01-23 a la(s) 9 34 12 p  m" src="https://github.com/user-attachments/assets/68eacf09-06e8-4d38-bb16-4eeb6accceb0" />
<img width="1710" height="809" alt="Captura de pantalla 2026-01-23 a la(s) 9 34 01 p  m" src="https://github.com/user-attachments/assets/b7a2de73-28bf-40ca-9e94-fa57b2a7e8dc" />

### Related Issues
Closes #14

### Checklist
- [x] My code follows the code style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have verified the changes locally
- [x] My changes generate no new warnings or errors
- [x] I have added adequate styling matching the design system
