### PR TITLE
Add Price Validation

### DIFF
--- a/apps/contracts/stellar-contracts/rwa-oracle/src/error.rs
+++ b/apps/contracts/stellar-contracts/rwa-oracle/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
     /// Invalid metadata
     InvalidMetadata = 4,
 
+    /// Invalid price (zero or negative)
+    InvalidPrice = 5,
+
     /// Unauthorized access
     Unauthorized = 6,
 

--- a/apps/contracts/stellar-contracts/rwa-oracle/src/rwa_oracle.rs
+++ b/apps/contracts/stellar-contracts/rwa-oracle/src/rwa_oracle.rs
@@ -101,6 +101,9 @@ impl RWAOracle {
     }
 
     fn set_asset_price_internal(env: &Env, asset_id: Asset, price: i128, timestamp: u64) {
+        if price <= 0 {
+            panic_with_error!(env, Error::InvalidPrice);
+        }
         let mut asset = Self::get_asset_price(env, asset_id.clone()).unwrap_or_else(|| {
             panic_with_error!(env, Error::AssetNotFound);
         });

--- a/apps/contracts/stellar-contracts/rwa-oracle/src/test.rs
+++ b/apps/contracts/stellar-contracts/rwa-oracle/src/test.rs
@@ -231,4 +231,66 @@ fn test_error_handling() {
 
 }
 
-// ========== Issues Test | TODO -> ==========
+// ========== Price validation tests ==========
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_negative_price_rejected() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let oracle = create_rwa_oracle_contract(&e);
+    let asset: Asset = Asset::Other(Symbol::new(&e, "NVDA"));
+    let timestamp: u64 = 1_000_000_000;
+    let negative_price: i128 = -100;
+
+    oracle.set_asset_price(&asset, &negative_price, &timestamp);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_zero_price_rejected() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let oracle = create_rwa_oracle_contract(&e);
+    let asset: Asset = Asset::Other(Symbol::new(&e, "NVDA"));
+    let timestamp: u64 = 1_000_000_000;
+    let zero_price: i128 = 0;
+
+    oracle.set_asset_price(&asset, &zero_price, &timestamp);
+}
+
+#[test]
+fn test_positive_price_accepted() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let oracle = create_rwa_oracle_contract(&e);
+    let asset: Asset = Asset::Other(Symbol::new(&e, "NVDA"));
+    let timestamp: u64 = 1_000_000_000;
+    let price: i128 = 150_00000000;
+
+    oracle.set_asset_price(&asset, &price, &timestamp);
+
+    let last_price = oracle.lastprice(&asset).unwrap();
+    assert_eq!(last_price.price, price);
+    assert_eq!(last_price.timestamp, timestamp);
+}
+
+#[test]
+fn test_min_positive_price_accepted() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let oracle = create_rwa_oracle_contract(&e);
+    let asset: Asset = Asset::Other(Symbol::new(&e, "NVDA"));
+    let timestamp: u64 = 1_000_000_000;
+    let min_price: i128 = 1;
+
+    oracle.set_asset_price(&asset, &min_price, &timestamp);
+
+    let last_price = oracle.lastprice(&asset).unwrap();
+    assert_eq!(last_price.price, min_price);
+    assert_eq!(last_price.timestamp, timestamp);
+}


### PR DESCRIPTION
# Add Price Validation

## Description

The `set_asset_price_internal` function in the RWA Oracle contract previously accepted any `i128` value for prices, including negative numbers and zero. This is a critical security vulnerability.

**Why this matters:**
- A compromised admin could set negative prices, breaking liquidation logic in the lending protocol
- Zero prices would cause division-by-zero errors in dependent contracts
- Incorrect prices could lead to economic exploits and protocol insolvency

This PR adds validation so that only strictly positive prices are accepted.

Closes #24 

## Changes

### 1. Error variant (`error.rs`)
- Added `InvalidPrice = 5` to the `Error` enum
- Used when `price <= 0` is passed to `set_asset_price_internal`

### 2. Validation logic (`rwa_oracle.rs`)
- At the start of `set_asset_price_internal`, before any state changes:
  - If `price <= 0`, the contract panics with `Error::InvalidPrice`
- Validation runs before reading or writing storage

### 3. Unit tests (`test.rs`)
- **test_negative_price_rejected** – `set_asset_price` with `-100` panics with `Error(Contract, #5)`
- **test_zero_price_rejected** – `set_asset_price` with `0` panics with `Error(Contract, #5)`
- **test_positive_price_accepted** – `set_asset_price` with `150_00000000` succeeds; `lastprice()` returns the value
- **test_min_positive_price_accepted** – `set_asset_price` with `1` succeeds; `lastprice()` returns `1`

## Acceptance criteria

- [x] `InvalidPrice` error added to `error.rs` with code 5
- [x] `set_asset_price_internal` panics with `InvalidPrice` when `price <= 0`
- [x] All 4 required tests implemented and passing
- [x] All existing tests still pass
- [x] Contract compiles to WASM without errors

## Files changed

| File | Change |
|------|--------|
| `apps/contracts/stellar-contracts/rwa-oracle/src/error.rs` | Add `InvalidPrice = 5` |
| `apps/contracts/stellar-contracts/rwa-oracle/src/rwa_oracle.rs` | Add `price <= 0` check at start of `set_asset_price_internal` |
| `apps/contracts/stellar-contracts/rwa-oracle/src/test.rs` | Add 4 price validation tests |

## Testing

```bash
cd apps/contracts/stellar-contracts
cargo test -p rwa-oracle
cargo build -p rwa-oracle --target wasm32-unknown-unknown --release
```



## Checklist

- [x] Code follows project style (conventional commits, double quotes, etc.)
- [x] New error variant documented
- [x] No state changes before validation
- [x] Tests cover negative, zero, positive, and minimum positive price
