### PR TITLE
refactor:  validate metadata asset_id matches map key

### DIFF
--- a/apps/contracts/stellar-contracts/rwa-oracle/src/contract.rs
+++ b/apps/contracts/stellar-contracts/rwa-oracle/src/contract.rs
@@ -58,6 +58,12 @@ impl RWAOracle {
         metadata: RWAMetadata,
     ) -> Result<(), Error> {
         Admin::require_admin(env);
+
+        // Validate asset_id consistency
+        if metadata.asset_id != asset_id {
+            return Err(Error::InvalidMetadata);
+        }
+
         let mut state = RWAOracleStorage::get(env);
 
         // Set metadata


### PR DESCRIPTION
Closes #32 

I implemented a data integrity mechanism to prevent the contract from storing contradictory information. By adding this validation, I ensured that the external identifier (the map key) always matches the asset's internal identifier. This closes a vulnerability where an administrator—whether by error or malice—could register data for one asset (e.g., 'Tesla') under the name of another (e.g., 'Nvidia'), which would have caused critical failures for any downstream contract or application consuming the Oracle's data.

Tests:

stellar contract build --package rwa-oracle
<img width="1107" height="473" alt="image" src="https://github.com/user-attachments/assets/4a1aa407-39bd-4403-a4d0-2236c1ac09b8" />

cargo build --package rwa-oracle --target wasm32-unknown-unknown --release
<img width="1104" height="453" alt="image" src="https://github.com/user-attachments/assets/21a4de94-1319-4852-8a55-52b8f0a2ee9c" />

cargo test --package rwa-oracle
<img width="1113" height="471" alt="image" src="https://github.com/user-attachments/assets/7ec09985-f2cb-48bc-bd2d-b68e75423f96" />
