### PR TITLE
refac: Implement Per Asset Timestamp Tracking

### DIFF
--- a/apps/contracts/stellar-contracts/rwa-oracle/src/error.rs
+++ b/apps/contracts/stellar-contracts/rwa-oracle/src/error.rs
@@ -31,4 +31,3 @@ pub enum Error {
     /// Timestamp is too old or not strictly increasing
     TimestampTooOld = 9,
 }
-

--- a/apps/contracts/stellar-contracts/rwa-oracle/src/lib.rs
+++ b/apps/contracts/stellar-contracts/rwa-oracle/src/lib.rs
@@ -2,14 +2,14 @@
 
 use soroban_sdk::{self, Address, Symbol, contracttype};
 
+mod error;
 pub mod rwa_oracle;
 pub mod rwa_types;
-mod error;
 mod sep40;
 
 pub use error::Error;
-pub use rwa_types::*;
 pub use rwa_oracle::{RWAOracle, RWAOracleClient};
+pub use rwa_types::*;
 
 /// Quoted asset definition (SEP-40 compatible)
 #[contracttype]
@@ -30,4 +30,3 @@ pub struct PriceData {
 }
 
 mod test;
-

--- a/apps/contracts/stellar-contracts/rwa-oracle/src/rwa_types.rs
+++ b/apps/contracts/stellar-contracts/rwa-oracle/src/rwa_types.rs
@@ -101,4 +101,3 @@ pub struct RWAMetadata {
     /// Last update timestamp
     pub updated_at: u64,
 }
-

--- a/apps/contracts/stellar-contracts/rwa-oracle/src/sep40.rs
+++ b/apps/contracts/stellar-contracts/rwa-oracle/src/sep40.rs
@@ -33,4 +33,3 @@ pub trait IsSep40Admin {
     /// Record new price feed history snapshot. Can be invoked only by the admin account.
     fn set_asset_price(env: &Env, asset: Asset, price: i128, timestamp: u64);
 }
-

--- a/apps/contracts/stellar-contracts/rwa-oracle/src/test.rs
+++ b/apps/contracts/stellar-contracts/rwa-oracle/src/test.rs
@@ -604,6 +604,7 @@ fn test_per_asset_timestamps_independent() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #9)")]
 fn test_same_asset_requires_newer_timestamp() {
     let e = Env::default();
     e.mock_all_auths();
@@ -616,23 +617,14 @@ fn test_same_asset_requires_newer_timestamp() {
     let price1: i128 = 150_00000000;
     oracle.set_asset_price(&asset_nvda, &price1, &timestamp1);
 
-    // Try to set NVDA again at t=999 (older timestamp) - should work but not update lastprice
+    // Try to set NVDA again at t=999 (older timestamp) - should panic with TimestampTooOld error
     let timestamp2: u64 = 999_000_000;
     let price2: i128 = 160_00000000;
     oracle.set_asset_price(&asset_nvda, &price2, &timestamp2);
-
-    // The lastprice should still be the most recent one (t=1000)
-    let last_price = oracle.lastprice(&asset_nvda).unwrap();
-    assert_eq!(last_price.timestamp, timestamp1);
-    assert_eq!(last_price.price, price1);
-
-    // But the older price should be retrievable at its specific timestamp
-    let price_at_999 = oracle.price(&asset_nvda, &timestamp2).unwrap();
-    assert_eq!(price_at_999.timestamp, timestamp2);
-    assert_eq!(price_at_999.price, price2);
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #9)")]
 fn test_same_asset_same_timestamp_rejected() {
     let e = Env::default();
     e.mock_all_auths();
@@ -645,14 +637,9 @@ fn test_same_asset_same_timestamp_rejected() {
     let price1: i128 = 150_00000000;
     oracle.set_asset_price(&asset_nvda, &price1, &timestamp);
 
-    // Try to set NVDA again at the same timestamp with different price
+    // Try to set NVDA again at the same timestamp - should panic with TimestampTooOld error
     let price2: i128 = 160_00000000;
     oracle.set_asset_price(&asset_nvda, &price2, &timestamp);
-
-    // The second update should overwrite the first one at the same timestamp
-    let last_price = oracle.lastprice(&asset_nvda).unwrap();
-    assert_eq!(last_price.timestamp, timestamp);
-    assert_eq!(last_price.price, price2);
 }
 
 #[test]


### PR DESCRIPTION

This PR fixes a design issue in the RWA Oracle where a single global `last_timestamp` was used to validate price updates for all assets.

Because different assets can have independent update frequencies and timelines (e.g. stocks vs crypto, different data providers), a global timestamp caused valid updates to be incorrectly rejected.

This change introduces per-asset timestamp tracking while preserving the global timestamp for SEP-40 compatibility.

---

### Problem

Previously:

* `last_timestamp` was stored globally in `RWAOracleStorage`
* Updating one asset advanced the timestamp for all assets
* This caused:

  * First-time updates on other assets to fail
  * Assets with slower update cadences to be blocked
  * Incorrect enforcement of C-02 timestamp validation

Example:

* Update AAPL at `t = 1000`
* Update TSLA at `t = 500` → incorrectly rejected

---

### Solution

This PR introduces per-asset timestamp validation:

* Added `DataKey::LastTimestamp(Asset)` to store timestamps per asset
* Timestamp validation (C-02) now checks the asset’s own last timestamp
* Global `last_timestamp` is still updated for backward compatibility (SEP-40)
* Assets can update independently without interfering with each other

---

### Implementation Details

**New Storage Key**

```
DataKey::LastTimestamp(Asset)

```

**Updated Logic**

* `set_asset_price_internal` now:

  * Validates timestamps per asset
  * Stores per-asset timestamps in persistent storage
  * Continues updating global `last_timestamp` for SEP-40 compatibility

---

### Tests Added

A total of **10 unit tests** now cover all required scenarios.

#### Existing / Core Per-Asset Timestamp Tests

* `test_per_asset_timestamps_independent`
* `test_same_asset_requires_newer_timestamp`
* `test_same_asset_same_timestamp_rejected`
* `test_same_asset_newer_timestamp_accepted`
* `test_global_timestamp_still_updated`

#### Additional Coverage & Compatibility Tests

* `test_independent_timestamps_for_different_assets`
* `test_updating_asset_with_older_timestamp_than_another_asset`
* `test_per_asset_timestamp_retrieval`
* `test_global_timestamp_still_updates`
* `test_backward_compatibility_with_sep40`

All existing tests continue to pass.

---





### Verification

<img width="983" height="331" alt="image" src="https://github.com/user-attachments/assets/9a418699-a2a2-4a13-8e3e-385a0c70a767" />



---
closes #31 



