### PR TITLE
refactor(api): move CoW Swap API response types to lib/types

### DIFF
--- a/apps/web-app/src/app/api/cow/orders/[uid]/route.ts
+++ b/apps/web-app/src/app/api/cow/orders/[uid]/route.ts
@@ -8,17 +8,7 @@ import {
   COW_API_BASE_URLS,
   COW_API_ENDPOINTS,
 } from "@/lib/constants/cowswapConfig";
-import type { CowOrder } from "@/lib/types/cowswapTypes";
-
-interface CowOrderStatus {
-  uid: string;
-  status: "open" | "fulfilled" | "cancelled" | "expired";
-  creationDate: string;
-  owner: string;
-  executedBuyAmount: string;
-  executedSellAmount: string;
-  executedFeeAmount: string;
-}
+import type { CowOrder, CowOrderStatus } from "@/lib/types/cowswapTypes";
 
 /**
  * GET /api/cow/orders/[uid] - Get specific order by UID

--- a/apps/web-app/src/app/api/cow/orders/[uid]/status/route.ts
+++ b/apps/web-app/src/app/api/cow/orders/[uid]/status/route.ts
@@ -8,16 +8,7 @@ import {
   COW_API_BASE_URLS,
   COW_API_ENDPOINTS,
 } from "@/lib/constants/cowswapConfig";
-
-interface CowOrderStatus {
-  uid: string;
-  status: "open" | "fulfilled" | "cancelled" | "expired";
-  creationDate: string;
-  owner: string;
-  executedBuyAmount: string;
-  executedSellAmount: string;
-  executedFeeAmount: string;
-}
+import type { CowOrderStatus } from "@/lib/types/cowswapTypes";
 
 /**
  * GET /api/cow/orders/[uid]/status - Get order status

--- a/apps/web-app/src/app/api/cow/trades/route.ts
+++ b/apps/web-app/src/app/api/cow/trades/route.ts
@@ -8,23 +8,7 @@ import {
   COW_API_BASE_URLS,
   COW_API_ENDPOINTS,
 } from "@/lib/constants/cowswapConfig";
-import type { CowTrade, CowOrder } from "@/lib/types/cowswapTypes";
-
-interface CowTradesResponse {
-  trades: CowTrade[];
-  meta?: {
-    total: number;
-    hasMore: boolean;
-  };
-}
-
-interface CowOrdersResponse {
-  orders: CowOrder[];
-  meta?: {
-    total: number;
-    hasMore: boolean;
-  };
-}
+import type { CowTradesResponse } from "@/lib/types/cowswapTypes";
 
 /**
  * GET /api/cow/trades - Get raw trades for a user

--- a/apps/web-app/src/lib/types/cowswapTypes.ts
+++ b/apps/web-app/src/lib/types/cowswapTypes.ts
@@ -144,3 +144,30 @@ export interface CowSwapOrderHistoryResponse {
   orders: CowSwapOrder[];
   hasMore: boolean;
 }
+
+// API Route Response Types
+export interface CowOrdersResponse {
+  orders: CowOrder[];
+  meta?: {
+    total: number;
+    hasMore: boolean;
+  };
+}
+
+export interface CowTradesResponse {
+  trades: CowTrade[];
+  meta?: {
+    total: number;
+    hasMore: boolean;
+  };
+}
+
+export interface CowOrderStatus {
+  uid: string;
+  status: "open" | "fulfilled" | "cancelled" | "expired";
+  creationDate: string;
+  owner: string;
+  executedBuyAmount: string;
+  executedSellAmount: string;
+  executedFeeAmount: string;
+}


### PR DESCRIPTION
Closes #77

## Summary
- `CowOrdersResponse`, `CowTradesResponse`, `CowOrderStatus` movidos a `cowswapTypes.ts`
- Eliminadas las interfaces locales de `trades/route.ts`, `orders/[uid]/route.ts`, `orders/[uid]/status/route.ts`

## Test plan
- [ ] GET `/api/cow/trades` responde correctamente
- [ ] GET `/api/cow/orders/[uid]` responde correctamente
- [ ] GET `/api/cow/orders/[uid]/status` responde correctamente