### PR TITLE
refactor(swap): extract constants, split quote hooks, remove dead code

### DIFF
--- a/apps/web-app/src/features/swap/components/ui/LimitOrderForm.tsx
+++ b/apps/web-app/src/features/swap/components/ui/LimitOrderForm.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { sanitizeAmountInput } from "@/lib/helpers/stellar/swapUtils";
 import type { Token } from "@/lib/helpers/stellar/soroswap";
 import type { EVMToken } from "@/lib/types/evmToken";
 
@@ -16,11 +17,7 @@ export const LimitOrderForm: React.FC<LimitOrderFormProps> = ({
   getTokenId,
 }) => {
   const handlePriceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/[^0-9.]/g, "");
-    const parts = value.split(".");
-    const formattedValue =
-      parts.length > 2 ? parts[0] + "." + parts.slice(1).join("") : value;
-    onLimitPriceChange(formattedValue);
+    onLimitPriceChange(sanitizeAmountInput(e.target.value));
   };
 
   return (

--- a/apps/web-app/src/features/swap/components/ui/OrderManagement.tsx
+++ b/apps/web-app/src/features/swap/components/ui/OrderManagement.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import { useAccount, useChainId, useWalletClient } from "wagmi";
 import { ORDER_HISTORY_LIMIT } from "@/features/swap/constants/swapConfig";
+import { EVM_TOKEN_ADDRESS_TO_SYMBOL } from "@/lib/constants/tokenIcons";
 import {
   getCowSwapOpenOrders,
   getCowSwapOrderHistory,
@@ -100,6 +101,10 @@ export const OrderManagement: React.FC = () => {
     }
   };
 
+  const resolveTokenSymbol = (address: string): string =>
+    EVM_TOKEN_ADDRESS_TO_SYMBOL[address.toLowerCase()] ||
+    address.slice(0, 6) + "…";
+
   // Get traffic light color based on progress status
   const getTrafficLightColor = (status: string) => {
     switch (status) {
@@ -189,8 +194,9 @@ export const OrderManagement: React.FC = () => {
                       title={`Status: ${order.progressStatus}`}
                     />
                     <span className="text-sm font-semibold text-white">
-                      {order.kind.toUpperCase()} {order.sellToken} →{" "}
-                      {order.buyToken}
+                      {order.kind.toUpperCase()}{" "}
+                      {resolveTokenSymbol(order.sellToken)} →{" "}
+                      {resolveTokenSymbol(order.buyToken)}
                     </span>
                   </div>
                   <div className="flex gap-2">
@@ -249,8 +255,9 @@ export const OrderManagement: React.FC = () => {
               >
                 <div className="flex items-center justify-between mb-3">
                   <span className="text-sm font-semibold text-white">
-                    {order.kind.toUpperCase()} {order.sellToken} →{" "}
-                    {order.buyToken}
+                    {order.kind.toUpperCase()}{" "}
+                    {resolveTokenSymbol(order.sellToken)} →{" "}
+                    {resolveTokenSymbol(order.buyToken)}
                   </span>
                   <span
                     className={`px-2 py-1 text-xs rounded ${

--- a/apps/web-app/src/features/swap/components/ui/OrderManagement.tsx
+++ b/apps/web-app/src/features/swap/components/ui/OrderManagement.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { useAccount, useChainId } from "wagmi";
+import { useAccount, useChainId, useWalletClient } from "wagmi";
+import { ORDER_HISTORY_LIMIT } from "@/features/swap/constants/swapConfig";
 import {
   getCowSwapOpenOrders,
   getCowSwapOrderHistory,
@@ -17,6 +18,7 @@ import type { CowSwapOrder } from "@/lib/types/cowswapTypes";
 export const OrderManagement: React.FC = () => {
   const { address } = useAccount();
   const chainId = useChainId();
+  const { data: walletClient } = useWalletClient();
   const [activeTab, setActiveTab] = useState<"open" | "history">("open");
   const [openOrders, setOpenOrders] = useState<CowSwapOrderWithPrice[]>([]);
   const [orderHistory, setOrderHistory] = useState<CowSwapOrder[]>([]);
@@ -49,7 +51,7 @@ export const OrderManagement: React.FC = () => {
 
     try {
       const history = await getCowSwapOrderHistory(
-        { owner: address, limit: 20 },
+        { owner: address, limit: ORDER_HISTORY_LIMIT },
         chainId
       );
       setOrderHistory(history.orders || []);
@@ -74,13 +76,13 @@ export const OrderManagement: React.FC = () => {
     orderId: string,
     onChain: boolean = false
   ) => {
-    if (!address) return;
+    if (!address || !walletClient) return;
 
     try {
       const result = await cancelCowSwapOrder(
         { orderId, onChain },
         chainId,
-        {} as any // Would need wallet client
+        walletClient
       );
 
       if (result.success) {
@@ -170,18 +172,7 @@ export const OrderManagement: React.FC = () => {
         <div className="space-y-3">
           {(openOrders || []).length === 0 ? (
             <div className="text-center py-8">
-              <p className="text-gray-400 mb-2">Order Management</p>
-              <p className="text-sm text-gray-500 mb-4">
-                Coming soon - Track and manage your CoW Protocol orders
-              </p>
-              <a
-                href="https://explorer.cow.fi"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-[#334EAC] hover:text-[#081F5C] text-sm font-medium transition-colors"
-              >
-                View on CoW Explorer →
-              </a>
+              <p className="text-gray-400">No open orders</p>
             </div>
           ) : (
             openOrders.map((order) => (
@@ -248,18 +239,7 @@ export const OrderManagement: React.FC = () => {
         <div className="space-y-3">
           {(orderHistory || []).length === 0 ? (
             <div className="text-center py-8">
-              <p className="text-gray-400 mb-2">Order History</p>
-              <p className="text-sm text-gray-500 mb-4">
-                Coming soon - View your completed CoW Protocol orders
-              </p>
-              <a
-                href="https://explorer.cow.fi"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-[#334EAC] hover:text-[#081F5C] text-sm font-medium transition-colors"
-              >
-                View on CoW Explorer →
-              </a>
+              <p className="text-gray-400">No order history</p>
             </div>
           ) : (
             orderHistory.map((order) => (

--- a/apps/web-app/src/features/swap/components/ui/TokenInput.tsx
+++ b/apps/web-app/src/features/swap/components/ui/TokenInput.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { formatSwapAmount } from "@/lib/helpers/stellar/swapUtils";
+import {
+  formatSwapAmount,
+  sanitizeAmountInput,
+} from "@/lib/helpers/stellar/swapUtils";
 import type { Token } from "@/lib/helpers/stellar/soroswap";
 import type { EVMToken } from "@/lib/types/evmToken";
 
@@ -51,11 +54,7 @@ export const TokenInput: React.FC<TokenInputProps> = ({
   const isFrom = type === "from";
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/[^0-9.]/g, "");
-    const parts = value.split(".");
-    const formattedValue =
-      parts.length > 2 ? parts[0] + "." + parts.slice(1).join("") : value;
-    onAmountChange(formattedValue);
+    onAmountChange(sanitizeAmountInput(e.target.value));
   };
 
   return (

--- a/apps/web-app/src/features/swap/components/ui/TokenSelectorModal.tsx
+++ b/apps/web-app/src/features/swap/components/ui/TokenSelectorModal.tsx
@@ -286,17 +286,10 @@ const TokenSelectorModal: React.FC<TokenSelectorModalProps> = ({
   }, [filteredTokens, getTokenBalance]);
 
   const handleTokenClick = (tokenCode: string) => {
-    console.log("handleTokenClick called:", {
-      tokenCode,
-      swapMode,
-      localChainId,
-    });
     if (swapMode === "evm") {
-      console.log("Calling onSelectToken with EVM token:", tokenCode);
       onSelectToken(tokenCode, localChainId);
     } else {
       const token = availableTokens[tokenCode].contract;
-      console.log("Calling onSelectToken with Stellar token:", token);
       onSelectToken(token);
     }
     setSearchQuery("");

--- a/apps/web-app/src/features/swap/components/ui/TokenSelectorModal.tsx
+++ b/apps/web-app/src/features/swap/components/ui/TokenSelectorModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useMemo, useEffect, useCallback } from "react";
 import { useWallet } from "@/hooks/useWallet";
+import { useTokenPrice } from "@/hooks/useTokenPrice";
 import { getAvailableTokens, type Token } from "@/lib/helpers/stellar/soroswap";
 import { getTokenIcon } from "@/lib/helpers/stellar/swapUtils";
 import {
@@ -156,6 +157,7 @@ const TokenSelectorModal: React.FC<TokenSelectorModalProps> = ({
   onChainChange,
 }) => {
   const { balances } = useWallet();
+  const { price: xlmPrice } = useTokenPrice("XLM");
   const [localChainId, setLocalChainId] = useState(selectedChainId);
   const availableTokens = swapMode === "stellar" ? getAvailableTokens() : {};
 
@@ -258,7 +260,7 @@ const TokenSelectorModal: React.FC<TokenSelectorModalProps> = ({
         const balance = parseFloat(
           balances.xlm.balance?.replace(/,/g, "") || "0"
         );
-        const usdValue = balance * 0.1;
+        const usdValue = balance * xlmPrice;
         return {
           balance: balance.toString(),
           usdValue: usdValue.toFixed(2),

--- a/apps/web-app/src/features/swap/constants/swapConfig.ts
+++ b/apps/web-app/src/features/swap/constants/swapConfig.ts
@@ -1,0 +1,17 @@
+/** Debounce delay before firing a quote request (ms) */
+export const DEBOUNCE_MS = 50;
+
+/** Quote auto-refresh interval (ms) */
+export const QUOTE_REFRESH_INTERVAL_MS = 5000;
+
+/** Default slippage tolerance in basis points (500 = 5%) */
+export const DEFAULT_SLIPPAGE_BPS = 500;
+
+/** Maximum route hops for Soroswap quotes */
+export const MAX_HOPS = 1;
+
+/** Threshold above which a swap output is flagged as suspiciously low (%) */
+export const SUSPICIOUS_VALUE_THRESHOLD_PCT = 10;
+
+/** Maximum number of orders shown in order history */
+export const ORDER_HISTORY_LIMIT = 20;

--- a/apps/web-app/src/features/swap/hooks/useEvmQuote.ts
+++ b/apps/web-app/src/features/swap/hooks/useEvmQuote.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 import { usePublicClient, useWalletClient } from "wagmi";
 import { parseUnits, formatUnits } from "viem";
 import type { Token } from "@/lib/helpers/stellar/soroswap";
-import { isEVMToken, type EVMToken } from "@/lib/types/evmToken";
+import type { EVMToken } from "@/lib/types/evmToken";
 import {
   getCowSwapQuote,
   type CowSwapQuoteRequest,
@@ -11,6 +11,7 @@ import { getTokensForChain } from "@/lib/constants/evmConfig";
 import {
   formatSwapAmount,
   fromSmallestUnit,
+  getEvmTokenSymbol,
 } from "@/lib/helpers/stellar/swapUtils";
 
 /**
@@ -44,18 +45,8 @@ export function useEvmQuote(
       return null;
     }
 
-    const tokenInSymbol =
-      typeof tokenIn === "string"
-        ? tokenIn
-        : isEVMToken(tokenIn)
-          ? tokenIn.symbol || "ETH"
-          : "ETH";
-    const tokenOutSymbol =
-      typeof tokenOut === "string"
-        ? tokenOut
-        : isEVMToken(tokenOut)
-          ? tokenOut.symbol || "USDC"
-          : "USDC";
+    const tokenInSymbol = getEvmTokenSymbol(tokenIn, "ETH");
+    const tokenOutSymbol = getEvmTokenSymbol(tokenOut, "USDC");
 
     const tokenInObj = EVM_TOKENS[tokenInSymbol];
     if (!tokenInObj) return null;

--- a/apps/web-app/src/features/swap/hooks/useEvmQuote.ts
+++ b/apps/web-app/src/features/swap/hooks/useEvmQuote.ts
@@ -1,0 +1,100 @@
+import { useCallback, useMemo } from "react";
+import { usePublicClient, useWalletClient } from "wagmi";
+import { parseUnits, formatUnits } from "viem";
+import type { Token } from "@/lib/helpers/stellar/soroswap";
+import { isEVMToken, type EVMToken } from "@/lib/types/evmToken";
+import {
+  getCowSwapQuote,
+  type CowSwapQuoteRequest,
+} from "@/lib/helpers/evm/cowswap";
+import { getTokensForChain } from "@/lib/constants/evmConfig";
+import {
+  formatSwapAmount,
+  fromSmallestUnit,
+} from "@/lib/helpers/stellar/swapUtils";
+
+/**
+ * Fetches a CoW Swap quote for an EVM swap.
+ * Returns `null` when a quote cannot be obtained.
+ */
+export function useEvmQuote(
+  amountIn: string,
+  tokenIn: Token | string | EVMToken,
+  tokenOut: Token | string | EVMToken,
+  selectedEvmChainId: number
+): { fetchEvmQuote: () => Promise<string | null> } {
+  const publicClient = usePublicClient();
+  const { data: walletClient } = useWalletClient();
+  const EVM_TOKENS = useMemo(
+    () => getTokensForChain(selectedEvmChainId),
+    [selectedEvmChainId]
+  );
+
+  const fetchEvmQuote = useCallback(async (): Promise<string | null> => {
+    const trimmedAmount = amountIn?.trim() || "";
+    const parsedAmount = parseFloat(trimmedAmount);
+
+    if (
+      !trimmedAmount ||
+      isNaN(parsedAmount) ||
+      parsedAmount <= 0 ||
+      !publicClient ||
+      !selectedEvmChainId
+    ) {
+      return null;
+    }
+
+    const tokenInSymbol =
+      typeof tokenIn === "string"
+        ? tokenIn
+        : isEVMToken(tokenIn)
+          ? tokenIn.symbol || "ETH"
+          : "ETH";
+    const tokenOutSymbol =
+      typeof tokenOut === "string"
+        ? tokenOut
+        : isEVMToken(tokenOut)
+          ? tokenOut.symbol || "USDC"
+          : "USDC";
+
+    const tokenInObj = EVM_TOKENS[tokenInSymbol];
+    if (!tokenInObj) return null;
+
+    const amountInWei = parseUnits(
+      trimmedAmount,
+      tokenInObj.decimals
+    ).toString();
+    const quoteRequest: CowSwapQuoteRequest = {
+      tokenIn: tokenInSymbol,
+      tokenOut: tokenOutSymbol,
+      amountIn: amountInWei,
+    };
+
+    const quote = await getCowSwapQuote(
+      quoteRequest,
+      selectedEvmChainId,
+      publicClient,
+      walletClient
+    );
+
+    const tokenOutObj = EVM_TOKENS[tokenOutSymbol];
+    if (tokenOutObj) {
+      return (
+        formatUnits(BigInt(quote.amountOut), tokenOutObj.decimals) || "0.0"
+      );
+    }
+
+    const amountOutStr = quote.amountOut.toString();
+    return formatSwapAmount(fromSmallestUnit(amountOutStr, 6), 6);
+  }, [
+    amountIn,
+    tokenIn,
+    tokenOut,
+    selectedEvmChainId,
+    EVM_TOKENS,
+    publicClient,
+    walletClient,
+  ]);
+
+  return { fetchEvmQuote };
+}

--- a/apps/web-app/src/features/swap/hooks/useStellarQuote.ts
+++ b/apps/web-app/src/features/swap/hooks/useStellarQuote.ts
@@ -1,0 +1,89 @@
+import { useRef, useCallback } from "react";
+import type { Token } from "@/lib/helpers/stellar/soroswap";
+import { getQuote, type QuoteRequest } from "@/lib/helpers/stellar/soroswap";
+import { type EVMToken } from "@/lib/types/evmToken";
+import {
+  formatSwapAmount,
+  fromSmallestUnit,
+} from "@/lib/helpers/stellar/swapUtils";
+import {
+  DEFAULT_SLIPPAGE_BPS,
+  MAX_HOPS,
+} from "@/features/swap/constants/swapConfig";
+
+/**
+ * Fetches a Soroswap quote for a Stellar swap.
+ * Manages its own AbortController to cancel in-flight requests.
+ * Returns `null` when a quote cannot be obtained.
+ */
+export function useStellarQuote(
+  amountIn: string,
+  tokenIn: Token | string | EVMToken,
+  tokenOut: Token | string | EVMToken,
+  apiKeyConfigured: boolean
+): {
+  fetchStellarQuote: () => Promise<string | null>;
+  cancelStellarQuote: () => void;
+} {
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const cancelStellarQuote = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+  }, []);
+
+  const fetchStellarQuote = useCallback(async (): Promise<string | null> => {
+    const trimmedAmount = amountIn?.trim() || "";
+    const parsedAmount = parseFloat(trimmedAmount);
+
+    if (!trimmedAmount || isNaN(parsedAmount) || parsedAmount <= 0) return null;
+    if (!apiKeyConfigured) return null;
+
+    cancelStellarQuote();
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+
+    try {
+      const quoteRequest: QuoteRequest = {
+        assetIn: tokenIn as Token | string,
+        assetOut: tokenOut as Token | string,
+        amount: trimmedAmount,
+        tradeType: "EXACT_IN",
+        protocols: ["soroswap"],
+        slippageBps: DEFAULT_SLIPPAGE_BPS,
+        maxHops: MAX_HOPS,
+      };
+
+      const quote = await getQuote(quoteRequest);
+
+      if (abortController.signal.aborted) return null;
+
+      if (quote?.amountOut) {
+        const amountOutStr = quote.amountOut.toString();
+        const amountOutBigInt = BigInt(amountOutStr);
+        if (amountOutBigInt > BigInt(0)) {
+          return formatSwapAmount(fromSmallestUnit(amountOutStr, 7), 6);
+        }
+      }
+
+      return null;
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") return null;
+
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const errorWithCode = error as { code?: string } | null;
+      const isTimeout =
+        errorMessage.includes("timeout") ||
+        errorMessage.includes("ECONNABORTED") ||
+        errorWithCode?.code === "ECONNABORTED";
+
+      if (isTimeout) return null;
+      return null;
+    }
+  }, [amountIn, tokenIn, tokenOut, apiKeyConfigured, cancelStellarQuote]);
+
+  return { fetchStellarQuote, cancelStellarQuote };
+}

--- a/apps/web-app/src/features/swap/hooks/useSwapExecution.ts
+++ b/apps/web-app/src/features/swap/hooks/useSwapExecution.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { usePublicClient, useWalletClient } from "wagmi";
 import { parseUnits } from "viem";
 import type { Token } from "@/lib/helpers/stellar/soroswap";
-import { isEVMToken, type EVMToken } from "@/lib/types/evmToken";
+import type { EVMToken } from "@/lib/types/evmToken";
 import {
   getQuote,
   buildTransaction,
@@ -18,6 +18,7 @@ import {
   type CowSwapLimitOrderRequest,
 } from "@/lib/helpers/evm/cowswap";
 import { getTokensForChain } from "@/lib/constants/evmConfig";
+import { getEvmTokenSymbol } from "@/lib/helpers/stellar/swapUtils";
 import { useWallet } from "@/hooks/useWallet";
 import { isUserRejection } from "@/lib/helpers/isUserRejection";
 
@@ -82,18 +83,8 @@ export function useSwapExecution() {
       ) {
         const EVM_TOKENS = getTokensForChain(selectedEvmChainId);
 
-        const tokenInSymbol: string =
-          typeof tokenIn === "string"
-            ? tokenIn
-            : isEVMToken(tokenIn)
-              ? (tokenIn.symbol ?? "ETH")
-              : "ETH";
-        const tokenOutSymbol: string =
-          typeof tokenOut === "string"
-            ? tokenOut
-            : isEVMToken(tokenOut)
-              ? (tokenOut.symbol ?? "USDC")
-              : "USDC";
+        const tokenInSymbol = getEvmTokenSymbol(tokenIn, "ETH");
+        const tokenOutSymbol = getEvmTokenSymbol(tokenOut, "USDC");
 
         const tokenInObj = EVM_TOKENS[tokenInSymbol];
         if (!tokenInObj) {

--- a/apps/web-app/src/features/swap/hooks/useSwapExecution.ts
+++ b/apps/web-app/src/features/swap/hooks/useSwapExecution.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/helpers/evm/cowswap";
 import { getTokensForChain } from "@/lib/constants/evmConfig";
 import { useWallet } from "@/hooks/useWallet";
+import { isUserRejection } from "@/lib/helpers/isUserRejection";
 
 export interface SwapExecutionParams {
   swapMode: "evm" | "stellar";
@@ -203,19 +204,7 @@ export function useSwapExecution() {
             address: address,
           });
         } catch (error) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-          const errorString = errorMessage.toLowerCase();
-          if (
-            errorString.includes("user denied") ||
-            errorString.includes("user rejected") ||
-            errorString.includes("user cancelled") ||
-            errorString.includes("user canceled") ||
-            errorString.includes("cancelled") ||
-            errorString.includes("canceled")
-          ) {
-            throw new Error("USER_REJECTED");
-          }
+          if (isUserRejection(error)) throw new Error("USER_REJECTED");
           throw error;
         }
 

--- a/apps/web-app/src/features/swap/hooks/useSwapPrices.ts
+++ b/apps/web-app/src/features/swap/hooks/useSwapPrices.ts
@@ -3,6 +3,7 @@ import { useTokenPrice } from "@/hooks/useTokenPrice";
 import { useEVMTokenPrice } from "@/hooks/useEVMTokenPrice";
 import type { Token } from "@/lib/helpers/stellar/soroswap";
 import type { EVMToken } from "@/lib/types/evmToken";
+import { SUSPICIOUS_VALUE_THRESHOLD_PCT } from "@/features/swap/constants/swapConfig";
 
 export interface SwapPrices {
   tokenInPrice: number;
@@ -111,8 +112,9 @@ export function useSwapPrices(
     const differencePercent =
       ((expectedOutput - outputAmount) / expectedOutput) * 100;
 
-    // Consider the swap suspiciously low if output is more than 10% lower than expected
-    const isSuspiciouslyLow = differencePercent > 10;
+    // Consider the swap suspiciously low if output is more than threshold% lower than expected
+    const isSuspiciouslyLow =
+      differencePercent > SUSPICIOUS_VALUE_THRESHOLD_PCT;
 
     return {
       expectedOutput,

--- a/apps/web-app/src/features/swap/hooks/useSwapQuote.ts
+++ b/apps/web-app/src/features/swap/hooks/useSwapQuote.ts
@@ -1,23 +1,13 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { usePublicClient, useWalletClient } from "wagmi";
-import { parseUnits, formatUnits } from "viem";
+import { useState, useEffect, useRef, useCallback } from "react";
 import type { Token } from "@/lib/helpers/stellar/soroswap";
-import { isEVMToken, type EVMToken } from "@/lib/types/evmToken";
+import { hasApiKey } from "@/lib/helpers/stellar/soroswap";
+import { type EVMToken } from "@/lib/types/evmToken";
+import { useEvmQuote } from "./useEvmQuote";
+import { useStellarQuote } from "./useStellarQuote";
 import {
-  hasApiKey,
-  getQuote,
-  type QuoteRequest,
-} from "@/lib/helpers/stellar/soroswap";
-import {
-  getCowSwapQuote,
-  type CowSwapQuoteRequest,
-} from "@/lib/helpers/evm/cowswap";
-import { getTokensForChain } from "@/lib/constants/evmConfig";
-import {
-  formatSwapAmount,
-  fromSmallestUnit,
-} from "@/lib/helpers/stellar/swapUtils";
-import { QUOTE_TIMEOUT_MS } from "@/lib/constants/cowswapConfig";
+  DEBOUNCE_MS,
+  QUOTE_REFRESH_INTERVAL_MS,
+} from "@/features/swap/constants/swapConfig";
 
 export interface SwapQuoteState {
   amountOut: string;
@@ -40,19 +30,23 @@ export function useSwapQuote(
   const [amountOut, setAmountOut] = useState<string>("0.0");
   const [isLoadingQuote, setIsLoadingQuote] = useState<boolean>(false);
   const [apiKeyConfigured, setApiKeyConfigured] = useState<boolean>(false);
-  const publicClient = usePublicClient();
-  const { data: walletClient } = useWalletClient();
 
   const quoteTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
   const quoteIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  const EVM_TOKENS = useMemo(
-    () => getTokensForChain(selectedEvmChainId),
-    [selectedEvmChainId]
+  const { fetchEvmQuote } = useEvmQuote(
+    amountIn,
+    tokenIn,
+    tokenOut,
+    selectedEvmChainId
+  );
+  const { fetchStellarQuote, cancelStellarQuote } = useStellarQuote(
+    amountIn,
+    tokenIn,
+    tokenOut,
+    apiKeyConfigured
   );
 
-  // Check if API key is configured on mount
   useEffect(() => {
     setApiKeyConfigured(hasApiKey());
   }, []);
@@ -74,208 +68,25 @@ export function useSwapQuote(
       return;
     }
 
-    // Define token symbols for both EVM and Stellar modes
-    const tokenInSymbol: string =
-      typeof tokenIn === "string"
-        ? tokenIn
-        : isEVMToken(tokenIn)
-          ? tokenIn.symbol || "ETH"
-          : "ETH";
-    const tokenOutSymbol: string =
-      typeof tokenOut === "string"
-        ? tokenOut
-        : isEVMToken(tokenOut)
-          ? tokenOut.symbol || "USDC"
-          : "USDC";
-
-    // EVM swap quote (CoW Swap)
-    if (swapMode === "evm" && publicClient && selectedEvmChainId) {
-      try {
-        const tokenInObj = EVM_TOKENS[tokenInSymbol];
-        if (!tokenInObj) {
-          setAmountOut("0.0");
-          setIsLoadingQuote(false);
-          return;
-        }
-
-        const amountInWei = parseUnits(
-          trimmedAmount,
-          tokenInObj.decimals
-        ).toString();
-
-        const quoteRequest: CowSwapQuoteRequest = {
-          tokenIn: tokenInSymbol,
-          tokenOut: tokenOutSymbol,
-          amountIn: amountInWei,
-        };
-
-        const quote = await getCowSwapQuote(
-          quoteRequest,
-          selectedEvmChainId,
-          publicClient,
-          walletClient
-        );
-
-        const tokenOutObj = EVM_TOKENS[tokenOutSymbol];
-        if (tokenOutObj) {
-          const amountOutFormatted = formatUnits(
-            BigInt(quote.amountOut),
-            tokenOutObj.decimals
-          );
-          setAmountOut(amountOutFormatted || "0.0");
-        } else {
-          // Fallback: format the amount even without token info
-          const amountOutStr = quote.amountOut.toString();
-          const amountOutFormatted = fromSmallestUnit(amountOutStr, 6);
-          setAmountOut(formatSwapAmount(amountOutFormatted, 6));
-        }
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        console.error("Quote error:", errorMessage);
-        setAmountOut("0.0");
-      } finally {
-        setIsLoadingQuote(false);
-      }
-      return;
-    }
-
-    // Stellar swap quote
-    if (swapMode === "stellar" && !apiKeyConfigured) {
-      setAmountOut("0.0");
-      setIsLoadingQuote(false);
-      return;
-    }
-
-    // Cancel previous request if exists
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-
-    // Create new abort controller for this request
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
-
-    // Store current input values to verify later
-    const currentAmountIn = trimmedAmount;
-    const currentTokenIn = tokenIn;
-    const currentTokenOut = tokenOut;
-
-    // For testing, ensure we have a reasonable amount
-    if (!trimmedAmount || parseFloat(trimmedAmount) <= 0) {
-      setAmountOut("0.0");
-      setIsLoadingQuote(false);
-      return;
-    }
-
-    setIsLoadingQuote(true);
     try {
-      const quoteRequest: QuoteRequest = {
-        assetIn: tokenIn as Token | string,
-        assetOut: tokenOut as Token | string,
-        amount: trimmedAmount,
-        tradeType: "EXACT_IN",
-        // Start with single protocol for testing
-        protocols: ["soroswap"],
-        slippageBps: 500, // 5% slippage (more generous)
-        maxHops: 1, // Reduce to direct routes only for testing
-      };
-
-      const quote = await getQuote(quoteRequest);
-
-      // Check if request was aborted or values changed
-      if (abortController.signal.aborted) {
-        return;
-      }
-
-      // Verify we're still looking at the same values
-      const currentAmountTrimmed = amountIn?.trim() || "";
-      const valuesMatch =
-        currentAmountIn === currentAmountTrimmed &&
-        currentTokenIn === tokenIn &&
-        currentTokenOut === tokenOut;
-
-      if (!valuesMatch) {
-        return;
-      }
-
-      // Process the quote result
-      if (quote && quote.amountOut) {
-        try {
-          const amountOutStr = quote.amountOut.toString();
-          const amountOutBigInt = BigInt(amountOutStr);
-
-          if (amountOutBigInt > BigInt(0)) {
-            const tokenOutObj = EVM_TOKENS[tokenOutSymbol];
-            let amountOutFormatted: string;
-
-            if (tokenOutObj) {
-              // EVM tokens - use token's decimals
-              amountOutFormatted = formatUnits(
-                amountOutBigInt,
-                tokenOutObj.decimals
-              );
-            } else {
-              // Stellar tokens use 7 decimals
-              amountOutFormatted = fromSmallestUnit(amountOutStr, 7);
-            }
-
-            const formatted = formatSwapAmount(amountOutFormatted, 6);
-            setAmountOut(formatted);
-          } else {
-            setAmountOut("0.0");
-          }
-        } catch {
-          setAmountOut("0.0");
-        }
-      } else {
-        setAmountOut("0.0");
-      }
-    } catch (error) {
-      // Ignore aborted requests
-      if (error instanceof Error && error.name === "AbortError") {
-        return;
-      }
-
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      const errorWithCode = error as { code?: string } | null | undefined;
-      const isTimeout =
-        errorMessage.includes("timeout") ||
-        errorMessage.includes("ECONNABORTED") ||
-        errorWithCode?.code === "ECONNABORTED";
-
-      if (isTimeout) {
-        setIsLoadingQuote(false);
-        return;
-      }
-
+      const result =
+        swapMode === "evm" ? await fetchEvmQuote() : await fetchStellarQuote();
+      setAmountOut(result ?? "0.0");
+    } catch {
       setAmountOut("0.0");
     } finally {
-      if (!abortController.signal.aborted) {
-        setIsLoadingQuote(false);
-      }
+      setIsLoadingQuote(false);
     }
-  }, [
-    address,
-    amountIn,
-    tokenIn,
-    tokenOut,
-    apiKeyConfigured,
-    swapMode,
-    publicClient,
-    selectedEvmChainId,
-    EVM_TOKENS,
-    walletClient,
-  ]);
+  }, [address, amountIn, swapMode, fetchEvmQuote, fetchStellarQuote]);
 
-  // Debounced live quote update
+  // Debounced quote trigger
   useEffect(() => {
     if (quoteTimeoutRef.current) {
       clearTimeout(quoteTimeoutRef.current);
       quoteTimeoutRef.current = null;
     }
 
+    cancelStellarQuote();
     setIsLoadingQuote(false);
 
     const trimmedAmount = amountIn?.trim() || "";
@@ -292,38 +103,27 @@ export function useSwapQuote(
 
     if (!isValid || !address) {
       setAmountOut("0.0");
-      setIsLoadingQuote(false);
       return;
     }
 
     if (swapMode === "stellar" && !apiKeyConfigured) {
       setAmountOut("0.0");
-      setIsLoadingQuote(false);
       return;
     }
 
     setAmountOut("0.0");
-
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-      abortControllerRef.current = null;
-    }
-
     setIsLoadingQuote(true);
 
     quoteTimeoutRef.current = setTimeout(() => {
       void fetchLiveQuote();
-    }, 50);
+    }, DEBOUNCE_MS);
 
     return () => {
       if (quoteTimeoutRef.current) {
         clearTimeout(quoteTimeoutRef.current);
         quoteTimeoutRef.current = null;
       }
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-        abortControllerRef.current = null;
-      }
+      cancelStellarQuote();
       setIsLoadingQuote(false);
     };
   }, [
@@ -334,9 +134,10 @@ export function useSwapQuote(
     apiKeyConfigured,
     fetchLiveQuote,
     swapMode,
+    cancelStellarQuote,
   ]);
 
-  // Auto-update quotes every 5 seconds for price fluctuations
+  // Auto-refresh quotes every interval while valid inputs exist
   useEffect(() => {
     if (
       address &&
@@ -350,7 +151,7 @@ export function useSwapQuote(
       }
       quoteIntervalRef.current = setInterval(() => {
         void fetchLiveQuote();
-      }, 5000);
+      }, QUOTE_REFRESH_INTERVAL_MS);
     } else {
       if (quoteIntervalRef.current) {
         clearInterval(quoteIntervalRef.current);

--- a/apps/web-app/src/features/swap/hooks/useSwapState.ts
+++ b/apps/web-app/src/features/swap/hooks/useSwapState.ts
@@ -54,16 +54,6 @@ export function useSwapState(
     defaultTokenOut
   );
 
-  // Wrapper functions to ensure state updates are detected
-  const setTokenInWrapper = useCallback((token: Token | string | EVMToken) => {
-    console.log("setTokenInWrapper called with:", token);
-    setTokenIn(token);
-  }, []);
-
-  const setTokenOutWrapper = useCallback((token: Token | string | EVMToken) => {
-    console.log("setTokenOutWrapper called with:", token);
-    setTokenOut(token);
-  }, []);
   const [limitPrice, setLimitPrice] = useState<string>("");
   const [twapParts, setTwapParts] = useState<string>("10");
   const [twapFrequency, setTwapFrequency] = useState<string>("3600");

--- a/apps/web-app/src/features/swap/hooks/useTokenSelection.ts
+++ b/apps/web-app/src/features/swap/hooks/useTokenSelection.ts
@@ -1,9 +1,13 @@
 import { useState, useMemo, useCallback } from "react";
 import { useChainId, useSwitchChain } from "wagmi";
 import type { Token } from "@/lib/helpers/stellar/soroswap";
-import { isEVMToken, type EVMToken } from "@/lib/types/evmToken";
+import type { EVMToken } from "@/lib/types/evmToken";
 import { getTokensForChain, DEFAULT_CHAIN_ID } from "@/lib/constants/evmConfig";
-import { getAvailableTokens, TOKENS } from "@/lib/helpers/stellar/soroswap";
+import { getAvailableTokens } from "@/lib/helpers/stellar/soroswap";
+import {
+  getTokenId as getTokenIdUtil,
+  getTokenIcon,
+} from "@/lib/helpers/stellar/swapUtils";
 
 export interface TokenSelectionState {
   tokenSelectorOpen: boolean;
@@ -56,49 +60,13 @@ export function useTokenSelection(
   }, []);
 
   const getTokenId = useCallback(
-    (token: Token | string | EVMToken): string => {
-      if (isEVMToken(token)) {
-        return token.symbol || "";
-      }
-
-      if (typeof token === "string") {
-        // Check if it's an EVM token symbol
-        if (EVM_TOKENS[token]) {
-          return token;
-        }
-        // Token is already a string (contract address)
-        // Find which token code matches this contract address
-        for (const [code, info] of Object.entries(availableTokens)) {
-          if (info.contract === token) {
-            return code;
-          }
-        }
-        return token;
-      }
-
-      // Token is an object (legacy format)
-      if (token.type === "native") return "XLM";
-      if (token.contract) {
-        // Find matching token code
-        for (const [code, info] of Object.entries(availableTokens)) {
-          if (info.contract === token.contract) {
-            return code;
-          }
-        }
-        return token.contract;
-      }
-      if (token.code) return token.code;
-      return "";
-    },
+    (token: Token | string | EVMToken): string =>
+      getTokenIdUtil(token, availableTokens, EVM_TOKENS),
     [EVM_TOKENS, availableTokens]
   );
 
   const getTokenIconUrl = useCallback(
-    (token: Token | string | EVMToken): string | null => {
-      // Import getTokenIcon dynamically to avoid circular dependencies
-      const { getTokenIcon } = require("@/lib/helpers/stellar/swapUtils");
-      return getTokenIcon(token as Token | string | EVMToken);
-    },
+    (token: Token | string | EVMToken): string | null => getTokenIcon(token),
     []
   );
 
@@ -154,25 +122,13 @@ export function useTokenSelection(
 
   const selectToken = useCallback(
     async (token: Token | string, chainId?: number) => {
-      console.log("selectToken called:", {
-        token,
-        chainId,
-        tokenSelectorType,
-        currentTokenIn: tokenIn,
-        currentTokenOut: tokenOut,
-        selectedEvmChainId,
-      });
-
       // Update chain if provided, but preserve the token we want to select
       if (chainId && chainId !== selectedEvmChainId) {
-        console.log("Chain change needed");
         try {
-          // Switch wallet chain first
           if (switchChainAsync) {
             await switchChainAsync({ chainId });
           }
           setSelectedEvmChainId(chainId);
-          // Don't reset tokens here - we'll set them below
         } catch (err: unknown) {
           const errorMessage = err instanceof Error ? err.message : String(err);
           const isUserRejection =
@@ -189,32 +145,18 @@ export function useTokenSelection(
       const currentTokenInId = getTokenId(tokenIn);
       const currentTokenOutId = getTokenId(tokenOut);
 
-      console.log("Token IDs:", {
-        newTokenId,
-        currentTokenInId,
-        currentTokenOutId,
-      });
-
-      // Always update the token - force update by creating a new reference if needed
       if (tokenSelectorType === "from") {
-        // If trying to select the same token as tokenOut, swap them
         if (newTokenId === currentTokenOutId && newTokenId !== "") {
-          console.log("Swapping tokens (from matches out)");
           setTokenOut(tokenIn);
           setTokenIn(token);
         } else {
-          console.log("Setting tokenIn to:", token);
-          // Force update by ensuring it's a new value
           setTokenIn(token);
         }
       } else {
-        // If trying to select the same token as tokenIn, swap them
         if (newTokenId === currentTokenInId && newTokenId !== "") {
-          console.log("Swapping tokens (to matches in)");
           setTokenIn(tokenOut);
           setTokenOut(token);
         } else {
-          console.log("Setting tokenOut to:", token);
           setTokenOut(token);
         }
       }

--- a/apps/web-app/src/features/swap/hooks/useTokenSelection.ts
+++ b/apps/web-app/src/features/swap/hooks/useTokenSelection.ts
@@ -8,6 +8,7 @@ import {
   getTokenId as getTokenIdUtil,
   getTokenIcon,
 } from "@/lib/helpers/stellar/swapUtils";
+import { isUserRejection } from "@/lib/helpers/isUserRejection";
 
 export interface TokenSelectionState {
   tokenSelectorOpen: boolean;
@@ -94,14 +95,7 @@ export function useTokenSelection(
           resetSwap();
           setTxHash(null);
         } catch (err: unknown) {
-          // Check if user rejected the request - this is not an error, just user cancellation
-          const errorMessage = err instanceof Error ? err.message : String(err);
-          const isUserRejection =
-            errorMessage.toLowerCase().includes("user rejected") ||
-            errorMessage.toLowerCase().includes("user denied") ||
-            errorMessage.includes("4001");
-
-          if (!isUserRejection) {
+          if (!isUserRejection(err)) {
             console.error("Failed to switch chain:", err);
             throw new Error(
               "Failed to switch network. Please switch manually in your wallet."
@@ -130,12 +124,7 @@ export function useTokenSelection(
           }
           setSelectedEvmChainId(chainId);
         } catch (err: unknown) {
-          const errorMessage = err instanceof Error ? err.message : String(err);
-          const isUserRejection =
-            errorMessage.toLowerCase().includes("user rejected") ||
-            errorMessage.toLowerCase().includes("user denied") ||
-            errorMessage.includes("4001");
-          if (!isUserRejection) {
+          if (!isUserRejection(err)) {
             console.error("Failed to switch chain:", err);
           }
         }

--- a/apps/web-app/src/lib/constants/tokenIcons.ts
+++ b/apps/web-app/src/lib/constants/tokenIcons.ts
@@ -1,0 +1,76 @@
+/** Maps lowercase EVM token addresses to their symbol */
+export const EVM_TOKEN_ADDRESS_TO_SYMBOL: Record<string, string> = {
+  // Ethereum
+  "0x0000000000000000000000000000000000000000": "ETH",
+  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": "ETH",
+  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "ETH",
+  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": "USDC",
+  "0xdac17f958d2ee523a2206206994597c13d831ec7": "USDT",
+  "0x2d1f7226bd1f780af6b9a49dcc0ae00e8df4bdee": "NVDAon",
+  "0xf6b1117ec07684d3958cad8beb1b302bfd21103f": "TSLAon",
+  "0x14c3abf95cb9c93a8b82c1cdcb76d72cb87b2d4c": "AAPLon",
+  "0xb812837b81a3a6b81d7cd74cfb19a7f2784555e5": "MSFTon",
+  "0xbb8774fb97436d23d74c1b882e8e9a69322cfd31": "AMZNon",
+  "0x59644165402b611b350645555b50afb581c71eb2": "METAon",
+  "0x590f21186489ca1612f49a4b1ff5c66acd6796a9": "SPOTon",
+  "0x908266c1192628371cff7ad2f5eba4de061a0ac5": "SHOPon",
+  "0xa29dc2102dfc2a0a4a5dcb84af984315567c9858": "MAon",
+  "0x032dec3372f25c41ea8054b4987a7c4832cdb338": "NFLXon",
+  // BNB Chain
+  "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c": "BNB",
+  "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d": "USDC",
+  "0x55d398326f99059ff775485246999027b3197955": "USDT",
+  "0xa9ee28c80f960b889dfbd1902055218cba016f75": "NVDAon",
+  "0x2494b603319d4d9f9715c9f4496d9e0364b59d93": "TSLAon",
+  "0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4": "AAPLon",
+  "0x6bfe75d1ad432050ea973c3a3dcd88f02e2444c3": "MSFTon",
+  "0x4553cfe1c09f37f38b12dc509f676964e392f8fc": "AMZNon",
+  "0xd7df5863a3e742f0c767768cdfcb63f09e0422f6": "METAon",
+  "0x50356167a4dbc38bea6779c045e24e25facedfdc": "SPOTon",
+  "0x43d0b380c33cd004a6a69abd61843881a2de4113": "SHOPon",
+  "0x25ffda07f585c39848db6573e533d7585679c52d": "MAon",
+  "0x7048f5227b032326cc8dbc53cf3fddd947a2c757": "NFLXon",
+};
+
+/** Maps EVM token symbols to their icon paths */
+export const EVM_TOKEN_ICON_MAP: Record<string, string> = {
+  ETH: "/crypto/svg/ethereum-eth-logo.svg",
+  BNB: "/crypto/svg/BNB.svg",
+  USDC: "/crypto/svg/USDC.svg",
+  USDT: "/crypto/svg/USDT.svg",
+  NVDAon: "/stocks/svg/NVDAON.svg",
+  TSLAon: "/stocks/svg/TSLAON.svg",
+  AAPLon: "/stocks/svg/AAPLON.svg",
+  MSFTon: "/stocks/svg/MSFTON.svg",
+  AMZNon: "/stocks/svg/AMZNON.svg",
+  METAon: "/stocks/svg/METAON.svg",
+  SPOTon: "/stocks/svg/SPOTON.svg",
+  SHOPon: "/stocks/svg/SHOPON.svg",
+  MAon: "/stocks/svg/MAON.svg",
+  NFLXon: "/stocks/svg/NFLXON.svg",
+};
+
+/** Maps Stellar token symbols to their icon paths */
+export const STELLAR_TOKEN_ICON_MAP: Record<string, string> = {
+  XLM: "/crypto/svg/stellar-xlm-logo.svg",
+  USDC: "/crypto/png/usd-coin-usdc-logo.png",
+  NVDA: "/stocks/nvda.png",
+  AAPL: "/stocks/aapl.png",
+  PLTR: "/stocks/pltr.png",
+  TSLA: "/stocks/tsla.png",
+  META: "/stocks/meta.png",
+  MSFT: "/stocks/msft.png",
+};
+
+/** Hardcoded Stellar contract address → symbol fallback (used when getAvailableTokens fails) */
+export const STELLAR_FALLBACK_CONTRACTS: Record<string, string> = {
+  CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC: "XLM",
+  CB3TLW74NBIOT3BUWOZ3TUM6RFDF6A4GVIRUQRQZABG5KPOUL4JJOV2F: "USDC",
+  CDMLFMKMMD7MWZP3FKUBZPVHTUEDLSX4BYGYKH4GCESXYHS3IHQ4EIG4: "XLM",
+  CAXPYMWLMZRSPNM6NE6DGIZRZABQ6TYQASARRJTOKIIJ3ZJCBFRAPW3F: "USDC",
+  CBTPNPK5HDORKWSOVM22FCJXDVAMRA6Y2J4COGFWAU7O6VHJ6PV2KSUY: "NVDA",
+  CB7ICLBZWLGCULENOTKZAW57WDVM4A5ENFCQ7HRNW4S4SSPGAFY6T26P: "AAPL",
+  CBDCAAID46PGO2BXPOCQJVODXGDNWYFUHCMRRHOP56PZZCOVAIOEGA3C: "PLTR",
+  CANDL3RC3BWGGQEXIOH76ZFWOGPLCNXEUJG25BAQKCRN7WLXXXHUC35O: "TSLA",
+  CAVCEHVJYV4R6LO3YXDOYHZJEPI4B4R4JUX4BLH4OBVNIFDWD77RSJLN: "META",
+};

--- a/apps/web-app/src/lib/helpers/isUserRejection.ts
+++ b/apps/web-app/src/lib/helpers/isUserRejection.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns true if the error represents a user-initiated wallet rejection/cancellation.
+ * Used across EVM hooks and services to avoid surfacing cancellations as errors.
+ */
+export function isUserRejection(error: unknown): boolean {
+  if (!error) return false;
+
+  const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
+
+  return (
+    lower.includes("user denied") ||
+    lower.includes("user rejected") ||
+    lower.includes("user cancelled") ||
+    lower.includes("user canceled") ||
+    lower.includes("rejected by user") ||
+    lower.includes("denied by user") ||
+    lower.includes("action_cancelled") ||
+    message.includes("4001")
+  );
+}

--- a/apps/web-app/src/lib/helpers/stellar/swapUtils.ts
+++ b/apps/web-app/src/lib/helpers/stellar/swapUtils.ts
@@ -2,7 +2,15 @@
  * Utility functions for swap operations
  */
 
+import { isEVMToken, type EVMToken } from "@/lib/types/evmToken";
 import { getAvailableTokens } from "./soroswap";
+import type { Token } from "./soroswap";
+import {
+  EVM_TOKEN_ADDRESS_TO_SYMBOL,
+  EVM_TOKEN_ICON_MAP,
+  STELLAR_TOKEN_ICON_MAP,
+  STELLAR_FALLBACK_CONTRACTS,
+} from "@/lib/constants/tokenIcons";
 
 /**
  * Format amount based on token decimals
@@ -67,8 +75,6 @@ export const getTokenDisplayName = (
     | string
 ): string => {
   if (typeof token === "string") {
-    // Token is a contract address string
-    // Compare with known addresses from Soroswap
     if (token === "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC") {
       return "XLM";
     }
@@ -93,43 +99,53 @@ export const getExplorerUrl = (txHash: string, network?: string): string => {
 };
 
 /**
- * Mapping of EVM token addresses to their symbols
+ * Strips non-numeric characters and prevents multiple decimal points.
+ * Suitable for amount input fields.
  */
-const EVM_TOKEN_ADDRESS_TO_SYMBOL: Record<string, string> = {
-  // Ethereum
-  "0x0000000000000000000000000000000000000000": "ETH",
-  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": "ETH",
-  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "ETH",
-  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": "USDC",
-  "0xdac17f958d2ee523a2206206994597c13d831ec7": "USDT",
-  "0x2d1f7226bd1f780af6b9a49dcc0ae00e8df4bdee": "NVDAon",
-  "0xf6b1117ec07684d3958cad8beb1b302bfd21103f": "TSLAon",
-  "0x14c3abf95cb9c93a8b82c1cdcb76d72cb87b2d4c": "AAPLon",
-  "0xb812837b81a3a6b81d7cd74cfb19a7f2784555e5": "MSFTon",
-  "0xbb8774fb97436d23d74c1b882e8e9a69322cfd31": "AMZNon",
-  "0x59644165402b611b350645555b50afb581c71eb2": "METAon",
-  "0x590f21186489ca1612f49a4b1ff5c66acd6796a9": "SPOTon",
-  "0x908266c1192628371cff7ad2f5eba4de061a0ac5": "SHOPon",
-  "0xa29dc2102dfc2a0a4a5dcb84af984315567c9858": "MAon",
-  "0x032dec3372f25c41ea8054b4987a7c4832cdb338": "NFLXon",
-  // BNB Chain
-  "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c": "BNB",
-  "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d": "USDC",
-  "0x55d398326f99059ff775485246999027b3197955": "USDT",
-  "0xa9ee28c80f960b889dfbd1902055218cba016f75": "NVDAon",
-  "0x2494b603319d4d9f9715c9f4496d9e0364b59d93": "TSLAon",
-  "0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4": "AAPLon",
-  "0x6bfe75d1ad432050ea973c3a3dcd88f02e2444c3": "MSFTon",
-  "0x4553cfe1c09f37f38b12dc509f676964e392f8fc": "AMZNon",
-  "0xd7df5863a3e742f0c767768cdfcb63f09e0422f6": "METAon",
-  "0x50356167a4dbc38bea6779c045e24e25facedfdc": "SPOTon",
-  "0x43d0b380c33cd004a6a69abd61843881a2de4113": "SHOPon",
-  "0x25ffda07f585c39848db6573e533d7585679c52d": "MAon",
-  "0x7048f5227b032326cc8dbc53cf3fddd947a2c757": "NFLXon",
+export const sanitizeAmountInput = (value: string): string => {
+  const stripped = value.replace(/[^0-9.]/g, "");
+  const parts = stripped.split(".");
+  return parts.length > 2 ? parts[0] + "." + parts.slice(1).join("") : stripped;
 };
 
 /**
- * Get token icon/image path based on token code or address
+ * Converts a token (any format) to a stable string identifier.
+ *
+ * @param token - Token in any of the three formats used across the app
+ * @param availableTokens - Stellar token registry (code → { contract })
+ * @param evmTokens - EVM token registry for the active chain (symbol → token info)
+ */
+export const getTokenId = (
+  token: Token | string | EVMToken,
+  availableTokens: Record<string, { contract: string }>,
+  evmTokens: Record<string, unknown> = {}
+): string => {
+  if (isEVMToken(token)) {
+    return token.symbol || "";
+  }
+
+  if (typeof token === "string") {
+    if (evmTokens[token]) return token;
+    for (const [code, info] of Object.entries(availableTokens)) {
+      if (info.contract === token) return code;
+    }
+    return token;
+  }
+
+  if (token.type === "native") return "XLM";
+  if (token.contract) {
+    for (const [code, info] of Object.entries(availableTokens)) {
+      if (info.contract === token.contract) return code;
+    }
+    return token.contract;
+  }
+  if (token.code) return token.code;
+  return "";
+};
+
+/**
+ * Get token icon/image path based on token code or address.
+ * Returns null if no icon is found.
  */
 export const getTokenIcon = (
   token:
@@ -140,7 +156,6 @@ export const getTokenIcon = (
   let tokenCode: string | null = null;
   let isEVM = false;
 
-  // Handle EVM token objects
   if (
     typeof token === "object" &&
     "symbol" in token &&
@@ -151,25 +166,20 @@ export const getTokenIcon = (
     isEVM = true;
   } else if (typeof token === "string") {
     const addressLower = token.toLowerCase();
-    // Check if it's an EVM address
+
     if (EVM_TOKEN_ADDRESS_TO_SYMBOL[addressLower]) {
       tokenCode = EVM_TOKEN_ADDRESS_TO_SYMBOL[addressLower];
       isEVM = true;
-    }
-    // Check if it's an EVM token symbol (exact match first, case-sensitive for Ondo tokens)
-    else if (Object.values(EVM_TOKEN_ADDRESS_TO_SYMBOL).includes(token)) {
+    } else if (Object.values(EVM_TOKEN_ADDRESS_TO_SYMBOL).includes(token)) {
       tokenCode = token;
       isEVM = true;
-    }
-    // Check common EVM token symbols (case-insensitive)
-    else if (["ETH", "BNB", "USDC", "USDT"].includes(token.toUpperCase())) {
+    } else if (["ETH", "BNB", "USDC", "USDT"].includes(token.toUpperCase())) {
       tokenCode = token.toUpperCase();
       isEVM = true;
     } else {
-      // Check if it's a Stellar contract address
+      // Stellar contract address — look up in registry then fallback map
       try {
         const availableTokens = getAvailableTokens();
-        // Find token code by contract address
         for (const [code, info] of Object.entries(availableTokens)) {
           if (info.contract === token) {
             tokenCode = code;
@@ -178,74 +188,22 @@ export const getTokenIcon = (
           }
         }
       } catch {
-        // Fallback to hardcoded addresses if getAvailableTokens fails
-        const hardcodedMap: Record<string, string> = {
-          CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC: "XLM", // testnet XLM
-          CB3TLW74NBIOT3BUWOZ3TUM6RFDF6A4GVIRUQRQZABG5KPOUL4JJOV2F: "USDC", // testnet USDC
-          CDMLFMKMMD7MWZP3FKUBZPVHTUEDLSX4BYGYKH4GCESXYHS3IHQ4EIG4: "XLM", // standalone XLM
-          CAXPYMWLMZRSPNM6NE6DGIZRZABQ6TYQASARRJTOKIIJ3ZJCBFRAPW3F: "USDC", // standalone USDC
-          CBTPNPK5HDORKWSOVM22FCJXDVAMRA6Y2J4COGFWAU7O6VHJ6PV2KSUY: "NVDA", // testnet NVDA
-          CB7ICLBZWLGCULENOTKZAW57WDVM4A5ENFCQ7HRNW4S4SSPGAFY6T26P: "AAPL", // testnet AAPL
-          CBDCAAID46PGO2BXPOCQJVODXGDNWYFUHCMRRHOP56PZZCOVAIOEGA3C: "PLTR", // testnet PLTR
-          CANDL3RC3BWGGQEXIOH76ZFWOGPLCNXEUJG25BAQKCRN7WLXXXHUC35O: "TSLA", // testnet TSLA
-          CAVCEHVJYV4R6LO3YXDOYHZJEPI4B4R4JUX4BLH4OBVNIFDWD77RSJLN: "META", // testnet META
-        };
-        tokenCode = hardcodedMap[token] || null;
+        tokenCode = STELLAR_FALLBACK_CONTRACTS[token] || null;
         isEVM = false;
       }
-      // If still no code found, assume it's a Stellar symbol
+
       if (!tokenCode) {
         tokenCode = token.toUpperCase();
         isEVM = false;
       }
     }
   } else if (typeof token === "object" && "type" in token) {
-    // Stellar token object
-    if (token.type === "native") {
-      tokenCode = "XLM";
-    } else {
-      tokenCode = token.code || null;
-    }
+    tokenCode = token.type === "native" ? "XLM" : token.code || null;
     isEVM = false;
   }
 
-  if (!tokenCode) {
-    return null;
-  }
-
-  if (isEVM) {
-    // EVM tokens icon map
-    const evmIconMap: Record<string, string> = {
-      // Crypto tokens (EVM)
-      ETH: "/crypto/svg/ethereum-eth-logo.svg",
-      BNB: "/crypto/svg/BNB.svg",
-      USDC: "/crypto/svg/USDC.svg",
-      USDT: "/crypto/svg/USDT.svg",
-      // Ondo Tokenized Stocks (EVM)
-      NVDAon: "/stocks/svg/NVDAON.svg",
-      TSLAon: "/stocks/svg/TSLAON.svg",
-      AAPLon: "/stocks/svg/AAPLON.svg",
-      MSFTon: "/stocks/svg/MSFTON.svg",
-      AMZNon: "/stocks/svg/AMZNON.svg",
-      METAon: "/stocks/svg/METAON.svg",
-      SPOTon: "/stocks/svg/SPOTON.svg",
-      SHOPon: "/stocks/svg/SHOPON.svg",
-      MAon: "/stocks/svg/MAON.svg",
-      NFLXon: "/stocks/svg/NFLXON.svg",
-    };
-    return evmIconMap[tokenCode] || null;
-  } else {
-    // Stellar tokens icon map
-    const stellarIconMap: Record<string, string> = {
-      XLM: "/crypto/svg/stellar-xlm-logo.svg",
-      USDC: "/crypto/png/usd-coin-usdc-logo.png",
-      NVDA: "/stocks/nvda.png",
-      AAPL: "/stocks/aapl.png",
-      PLTR: "/stocks/pltr.png",
-      TSLA: "/stocks/tsla.png",
-      META: "/stocks/meta.png",
-      MSFT: "/stocks/msft.png",
-    };
-    return stellarIconMap[tokenCode] || null;
-  }
+  if (!tokenCode) return null;
+  return isEVM
+    ? (EVM_TOKEN_ICON_MAP[tokenCode] ?? null)
+    : (STELLAR_TOKEN_ICON_MAP[tokenCode] ?? null);
 };

--- a/apps/web-app/src/lib/helpers/stellar/swapUtils.ts
+++ b/apps/web-app/src/lib/helpers/stellar/swapUtils.ts
@@ -67,30 +67,6 @@ export const fromSmallestUnit = (
 };
 
 /**
- * Get token display name
- */
-export const getTokenDisplayName = (
-  token:
-    | { type: "native" | "contract"; code?: string; contract?: string }
-    | string
-): string => {
-  if (typeof token === "string") {
-    if (token === "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC") {
-      return "XLM";
-    }
-    if (token === "CBBHRKEP5M3NUDRISGLJKGHDHX3DA2CN2AZBQY6WLVUJ7VNLGSKBDUCM") {
-      return "USDC";
-    }
-    return "Token";
-  }
-
-  if (token.type === "native") {
-    return "XLM";
-  }
-  return token.code || "Token";
-};
-
-/**
  * Get explorer URL for a transaction
  */
 export const getExplorerUrl = (txHash: string, network?: string): string => {

--- a/apps/web-app/src/lib/helpers/stellar/swapUtils.ts
+++ b/apps/web-app/src/lib/helpers/stellar/swapUtils.ts
@@ -75,6 +75,19 @@ export const getExplorerUrl = (txHash: string, network?: string): string => {
 };
 
 /**
+ * Extracts a symbol string from any token variant used in EVM swaps.
+ * Falls back to `fallback` when the token doesn't carry a symbol.
+ */
+export const getEvmTokenSymbol = (
+  token: Token | string | EVMToken,
+  fallback: string = ""
+): string => {
+  if (typeof token === "string") return token;
+  if (isEVMToken(token)) return token.symbol || fallback;
+  return fallback;
+};
+
+/**
  * Strips non-numeric characters and prevents multiple decimal points.
  * Suitable for amount input fields.
  */

--- a/apps/web-app/src/lib/services/cowswap.service.ts
+++ b/apps/web-app/src/lib/services/cowswap.service.ts
@@ -27,6 +27,7 @@ import {
   ETH_FLOW_ABI,
 } from "../constants/cowswapConfig";
 import type { EVMToken } from "../types/evmToken";
+import { isUserRejection } from "../helpers/isUserRejection";
 import type {
   CowSwapQuoteRequest,
   CowSwapQuoteResponse,
@@ -45,6 +46,17 @@ import type {
   CowOrder,
   CowTrade,
 } from "../types/cowswapTypes";
+
+interface CowSdkTradeParameters {
+  kind: OrderKind;
+  sellToken: string;
+  sellTokenDecimals: number;
+  buyToken: string;
+  buyTokenDecimals: number;
+  amount: string;
+  receiver: string;
+  buyAmount?: string;
+}
 
 export class CowSwapService {
   private orderBookApiCache = new Map<SupportedChainId, OrderBookApi>();
@@ -270,27 +282,8 @@ export class CowSwapService {
     }
   }
 
-  /**
-   * Check if error is user rejection
-   */
   private isUserRejectionError(error: unknown): boolean {
-    if (!error) return false;
-
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    const errorString = errorMessage.toLowerCase();
-
-    const rejectionPatterns = [
-      "user denied",
-      "user rejected",
-      "user cancelled",
-      "user canceled",
-      "rejected by user",
-      "denied by user",
-      "action_cancelled",
-      "4001",
-    ];
-
-    return rejectionPatterns.some((pattern) => errorString.includes(pattern));
+    return isUserRejection(error);
   }
 
   /**
@@ -368,7 +361,7 @@ export class CowSwapService {
       walletClient
     );
 
-    const parameters: any = {
+    const parameters: CowSdkTradeParameters = {
       kind: OrderKind.SELL,
       sellToken: this.normalizeTokenAddressForSwap(
         tokenIn.address,
@@ -652,7 +645,7 @@ export class CowSwapService {
     const buyAmountMin =
       (sellAmount * BigInt(Math.floor(limitPrice * 1e6))) / BigInt(1e6);
 
-    const parameters: any = {
+    const parameters: CowSdkTradeParameters = {
       kind: OrderKind.SELL,
       sellToken: this.normalizeTokenAddressForSwap(
         tokenIn.address,

--- a/apps/web-app/src/lib/services/price.service.ts
+++ b/apps/web-app/src/lib/services/price.service.ts
@@ -27,11 +27,10 @@ export class PriceService {
     NFLX: "netflix-ondo-tokenized-stock",
   };
 
-  // Fallback prices for stable coins and common tokens
+  // Fallback prices for stable coins
   private readonly FALLBACK_PRICES: Record<string, number> = {
     USDC: 1.0,
     USDT: 1.0,
-    ETH: 3000, // Rough fallback price
   };
 
   /**

--- a/apps/web-app/src/lib/services/price.service.ts
+++ b/apps/web-app/src/lib/services/price.service.ts
@@ -14,6 +14,7 @@ export class PriceService {
   // CoinGecko ID mapping for tokens
   private readonly COINGECKO_ID_MAP: Record<string, string> = {
     ETH: "ethereum",
+    BNB: "binancecoin",
     USDC: "usd-coin",
     USDT: "tether",
     NVDA: "nvidia-ondo-tokenized-stock",
@@ -23,6 +24,7 @@ export class PriceService {
     AMZN: "amazon-ondo-tokenized-stock",
     META: "meta-platforms-ondo-tokenized-stock",
     SPOT: "spotify-ondo-tokenized-stock",
+    SHOP: "shopify-ondo-tokenized-stock",
     MA: "mastercard-ondo-tokenized-stock",
     NFLX: "netflix-ondo-tokenized-stock",
   };


### PR DESCRIPTION
## Summary

- [x] Closes #85

- **`swapConfig.ts`**: named constants replacing all magic numbers (`DEBOUNCE_MS`, `QUOTE_REFRESH_INTERVAL_MS`, `DEFAULT_SLIPPAGE_BPS`, `MAX_HOPS`, `SUSPICIOUS_VALUE_THRESHOLD_PCT`, `ORDER_HISTORY_LIMIT`)
- **`lib/constants/tokenIcons.ts`**: extracted static token icon/address maps out of `swapUtils.ts`
- **`useSwapQuote` split**: 383-line monolith split into `useEvmQuote` + `useStellarQuote` + thin coordinator; `AbortController` managed inside `useStellarQuote`
- **`swapUtils`**: added `sanitizeAmountInput` and `getTokenId` helpers; simplified `getTokenIcon`
- **`useTokenSelection`**: replaced inline `getTokenId` with `swapUtils` import, replaced `require()` with static import, removed all `console.log` statements
- **`useSwapState`**: removed dead `setTokenInWrapper`/`setTokenOutWrapper` wrappers with `console.log`
- **`useSwapPrices`**: replaced magic `10` with `SUSPICIOUS_VALUE_THRESHOLD_PCT`
- **`TokenInput` / `LimitOrderForm`**: replaced duplicate inline regex with `sanitizeAmountInput`
- **`OrderManagement`**: replaced "coming soon" placeholder with proper empty state, fixed `{} as any` with `useWalletClient`, used `ORDER_HISTORY_LIMIT` constant
- **`price.service.ts`**: removed hardcoded `ETH: 3000` fallback price

## Test plan

- [ ] Swap input only accepts numeric values and a single decimal point
- [ ] Stellar and EVM quotes still load correctly on valid amount input
- [ ] Token selector opens, selects, and swaps tokens as expected
- [ ] Chain switch in EVM mode resets tokens to chain defaults
- [ ] Limit order price input sanitization works
- [ ] Order management tab renders open/history empty states without "coming soon" text
- [ ] USD value warning triggers when output is >10% below expected