### PR TITLE
refactor(lending): use LendingService in Lend.tsx instead of calling helpers directly

### DIFF
--- a/apps/web-app/src/features/lending/components/pages/Lend.tsx
+++ b/apps/web-app/src/features/lending/components/pages/Lend.tsx
@@ -4,16 +4,10 @@ import React, { useState, useMemo, useCallback } from "react";
 import { Modal, Box, Typography, IconButton, TextField } from "@mui/material";
 import { useLendingPools } from "@/features/lending/hooks/useLendingPools";
 import { useWallet } from "../../../../hooks/useWallet";
-import {
-  approveToken,
-  depositToPool,
-  withdrawFromPool,
-  getBTokenBalance,
-} from "@/lib/helpers/stellar/lending";
+import { lendingService } from "@/lib/services";
 import { getAvailableTokens } from "@/lib/helpers/stellar/soroswap";
-import { TransactionBuilder, Networks } from "@stellar/stellar-sdk";
+import { TransactionBuilder, Networks, rpc } from "@stellar/stellar-sdk";
 import { rpcUrl, stellarNetwork } from "@/lib/config/stellar.config";
-import { rpc } from "@stellar/stellar-sdk";
 import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors";
 
 interface PoolData {
@@ -189,7 +183,10 @@ const Lend: React.FC = () => {
     }
     setIsLoadingBalance(true);
     try {
-      const balance = await getBTokenBalance(selectedPool.assetCode, address);
+      const balance = await lendingService.getBTokenBalance(
+        selectedPool.assetCode,
+        address
+      );
       setBTokenBalance(balance);
     } catch (error) {
       console.error("Error loading bToken balance:", error);
@@ -275,9 +272,6 @@ const Lend: React.FC = () => {
       }
 
       const decimals = token.decimals || 7;
-      // Lending contract ID from the deployed contract
-      const lendingContractId =
-        "CD5WNBT4NEYYLALY776KRRR2WP7BEM4VJPG6QYQE5CRO6C5H4YUQA5KS";
 
       const sorobanServer = new rpc.Server(rpcUrl, {
         allowHttp: stellarNetwork === "LOCAL",
@@ -285,14 +279,20 @@ const Lend: React.FC = () => {
 
       if (isDepositModal) {
         // DEPOSIT FLOW
-        // Step 1: Approve token contract
-        const approveXdr = await approveToken(
+        // Step 1: Build approve + deposit transactions via service
+        const {
+          approveXdr,
+          depositXdr,
+          error: buildError,
+        } = await lendingService.depositWithApprove(
           token.contract,
-          lendingContractId,
+          selectedPool.assetCode,
           amount,
           decimals,
           address
         );
+
+        if (buildError) throw new Error(buildError);
 
         // Step 2: Sign approve transaction
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -312,22 +312,14 @@ const Lend: React.FC = () => {
         // Wait a bit for transaction to be processed
         await new Promise((resolve) => setTimeout(resolve, 2000));
 
-        // Step 4: Build deposit transaction
-        const depositXdr = await depositToPool(
-          selectedPool.assetCode,
-          amount,
-          decimals,
-          address
-        );
-
-        // Step 5: Sign deposit transaction
+        // Step 4: Sign deposit transaction
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const signedDeposit = await signTransaction(depositXdr as any, {
           networkPassphrase: networkPassphrase || Networks.TESTNET,
           address: address,
         });
 
-        // Step 6: Submit deposit transaction
+        // Step 5: Submit deposit transaction
         const depositTx = TransactionBuilder.fromXDR(
           signedDeposit.signedTxXdr,
           networkPassphrase || Networks.TESTNET
@@ -343,13 +335,16 @@ const Lend: React.FC = () => {
 
         const bTokensAmount = bTokensToBurn;
 
-        // Step 1: Build withdraw transaction
-        const withdrawXdr = await withdrawFromPool(
-          selectedPool.assetCode,
-          bTokensAmount, // bTokens to burn (calculated from tokens amount)
-          decimals,
-          address
-        );
+        // Step 1: Build withdraw transaction via service
+        const { xdr: withdrawXdr, error: buildError } =
+          await lendingService.withdrawFromPool(
+            selectedPool.assetCode,
+            bTokensAmount,
+            decimals,
+            address
+          );
+
+        if (buildError) throw new Error(buildError);
 
         // Step 2: Sign withdraw transaction
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/web-app/src/lib/services/index.ts
+++ b/apps/web-app/src/lib/services/index.ts
@@ -28,6 +28,7 @@ export type {
   LendingOperationResult,
   CollateralOperationResult,
   BorrowWithCollateralResult,
+  DepositWithApproveResult,
 } from "../types/lendingTypes";
 
 // Price Service

--- a/apps/web-app/src/lib/services/lending.service.ts
+++ b/apps/web-app/src/lib/services/lending.service.ts
@@ -30,6 +30,7 @@ import type {
   LendingOperationResult,
   CollateralOperationResult,
   BorrowWithCollateralResult,
+  DepositWithApproveResult,
 } from "../types/lendingTypes";
 
 export class LendingService {
@@ -244,6 +245,52 @@ export class LendingService {
         xdr: "",
         error: friendlyError,
       };
+    }
+  }
+
+  /**
+   * Deposit tokens with approve - returns two separate transactions to sign sequentially
+   */
+  async depositWithApprove(
+    tokenContractAddress: string,
+    assetCode: string,
+    amount: string,
+    decimals: number = 7,
+    walletAddress: string
+  ): Promise<DepositWithApproveResult> {
+    try {
+      const approveResult = await this.approveToken(
+        tokenContractAddress,
+        networks.testnet.contractId,
+        amount,
+        decimals,
+        walletAddress
+      );
+
+      if (approveResult.error) {
+        return { approveXdr: "", depositXdr: "", error: approveResult.error };
+      }
+
+      const depositResult = await this.depositToPool(
+        assetCode,
+        amount,
+        decimals,
+        walletAddress
+      );
+
+      if (depositResult.error) {
+        return {
+          approveXdr: approveResult.xdr,
+          depositXdr: "",
+          error: depositResult.error,
+        };
+      }
+
+      return { approveXdr: approveResult.xdr, depositXdr: depositResult.xdr };
+    } catch (error) {
+      console.error("Error building deposit with approve transactions:", error);
+      const friendlyError = extractContractError(error, "rwa-lending");
+      return { approveXdr: "", depositXdr: "", error: friendlyError };
     }
   }
 

--- a/apps/web-app/src/lib/types/lendingTypes.ts
+++ b/apps/web-app/src/lib/types/lendingTypes.ts
@@ -20,3 +20,9 @@ export interface BorrowWithCollateralResult {
   borrowXdr: string;
   error?: string;
 }
+
+export interface DepositWithApproveResult {
+  approveXdr: string;
+  depositXdr: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary

Closes #78

- Add `DepositWithApproveResult` type and `depositWithApprove` method to `LendingService` that orchestrates the approve → deposit flow, following the existing `addCollateralWithApprove` pattern
- Replace direct imports of `approveToken`, `depositToPool`, `withdrawFromPool`, `getBTokenBalance` from the helper layer in `Lend.tsx` with `lendingService` calls
- Export the new `DepositWithApproveResult` type from `services/index.ts`
- Helpers remain as internal implementation details of the service

## Files changed

- `src/features/lending/components/pages/Lend.tsx` — uses `lendingService` instead of raw helpers
- `src/lib/services/lending.service.ts` — adds `depositWithApprove` orchestration method
- `src/lib/types/lendingTypes.ts` — adds `DepositWithApproveResult` type
- `src/lib/services/index.ts` — exports new type

## Test plan

- [ ] Deposit flow: select a pool, enter amount, confirm — approve and deposit transactions should trigger sequentially
- [ ] Withdraw flow: select a pool, enter amount, confirm — withdraw transaction should trigger
- [ ] bToken balance loads correctly on pool selection and after transactions