### PR TITLE
refactor(stocks): consolidate formatPrice, deduplicate queries, extract sub-components

### DIFF
--- a/apps/web-app/src/app/globals.css
+++ b/apps/web-app/src/app/globals.css
@@ -49,6 +49,8 @@ body {
   --color-neko-teal-light: #68f9f2;
   --color-neko-muted: #bad6eb;
   --color-neko-navy-hover: #12328a;
+  --color-neko-accent-hover: #4a73c4;
+  --color-neko-border-hover: #3d5ac0;
   --color-neko-cream: #fff9f0;
   --color-neko-gray: #f3f4f6;
   /* Wallet UI (pill, modals) */

--- a/apps/web-app/src/components/ui/index.ts
+++ b/apps/web-app/src/components/ui/index.ts
@@ -1,2 +1,3 @@
+export * from "./LoadingSpinner";
 export * from "./WalletButton";
 export * from "./hover-border-gradient";

--- a/apps/web-app/src/features/stocks/components/ui/StatCard.tsx
+++ b/apps/web-app/src/features/stocks/components/ui/StatCard.tsx
@@ -22,7 +22,7 @@ export function StatCard({
   return (
     <div
       className={cn(
-        "rounded-2xl bg-gradient-to-br from-neko-accent to-neko-border p-6 shadow-xl transition-all duration-300 hover:shadow-2xl hover:-translate-y-1 hover:from-[#4A73C4] hover:to-[#3D5AC0]",
+        "rounded-2xl bg-gradient-to-br from-neko-accent to-neko-border p-6 shadow-xl transition-all duration-300 hover:shadow-2xl hover:-translate-y-1 hover:from-neko-accent-hover hover:to-neko-border-hover",
         className
       )}
     >

--- a/packages/config/tailwind.config.ts
+++ b/packages/config/tailwind.config.ts
@@ -21,6 +21,8 @@ const config: Config = {
           "teal-light": "#68f9f2",
           muted: "#bad6eb",
           "navy-hover": "#12328a",
+          "accent-hover": "#4A73C4",
+          "border-hover": "#3D5AC0",
           cream: "#fff9f0",
           gray: "#f3f4f6",
         },


### PR DESCRIPTION
## Summary

Closes #84

All major refactoring items from the issue were implemented directly on `dev` prior to this branch. This PR completes the two remaining acceptance criteria items:

- **Export `LoadingSpinner` from `components/ui/index.ts`** — it existed but was not re-exported from the shared UI barrel
- **Move hardcoded hover colors in `StatCard` to named Tailwind tokens** — `#4A73C4` and `#3D5AC0` are now `neko-accent-hover` and `neko-border-hover`, defined in both `tailwind.config.ts` and `globals.css @theme inline`

Work already merged to `dev` (base for this branch) that satisfies the rest of the acceptance criteria:
- Single `formatPrice()` in `oracleUtils.ts` — duplicate in hook removed
- `calculatePriceChange()` extracted to `oracleUtils.ts`
- `LoadingSpinner` component in `src/components/ui/`
- `StatCard`, `AssetPriceCard`, `PriceChart` extracted to `features/stocks/components/ui/`
- `useOracleAssetPrice` accepts `decimals` param, avoids re-fetching when caller already has the value
- `formatAsset` simplified to `asset.values[0]` (meaningless conditional removed)
- Magic numbers replaced with named constants in `constants/oracle.ts`
- Error states exposed from `useOracle`, `useOracleAssetPrice`, `useOracleRWAMetadata`
- `staleTime` set on all oracle hooks aligned with resolution interval
- Asset grid uses `formatAsset(asset)` as React key (not array index)
- Route paths referenced via `ROUTES` constant
- `useStockInfo` hook reads from oracle RWA metadata with static map fallback

## Test plan

- [ ] Oracle dashboard loads and stat cards display with hover gradient transition
- [ ] `LoadingSpinner` can be imported via `@/components/ui` barrel
- [ ] No TypeScript errors (`npm run build`)