### PR TITLE
chore: add zod input validation to api routes

### DIFF
--- a/apps/web-app/src/app/api/anchor/[provider]/assets/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/assets/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, isValidProvider, AnchorError } from "@/lib/anchors";
+import { getAnchorClient, AnchorError } from "@/lib/anchors";
 import { EtherfuseClient } from "@/lib/anchors/etherfuse";
+import { parseParam, parseQuery } from "@/lib/validation/parse";
+import { AssetsQuerySchema, ProviderSchema } from "@/lib/validation/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -13,22 +15,15 @@ export async function GET(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
     const { searchParams } = new URL(request.url);
-    const wallet = searchParams.get("wallet");
-    if (!wallet) {
-      return NextResponse.json(
-        { error: "wallet query parameter is required" },
-        { status: 400 }
-      );
-    }
+    const queryResult = parseQuery(searchParams, AssetsQuerySchema);
+    if ("error" in queryResult) return queryResult.error;
+    const { wallet } = queryResult.data;
 
     const client = getAnchorClient(provider);
     if (!(client instanceof EtherfuseClient)) {

--- a/apps/web-app/src/app/api/anchor/[provider]/customers/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/customers/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, isValidProvider, AnchorError } from "@/lib/anchors";
+import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { parseJsonBody, parseParam, parseQuery } from "@/lib/validation/parse";
+import {
+  CreateCustomerBodySchema,
+  GetCustomerQuerySchema,
+  ProviderSchema,
+} from "@/lib/validation/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -8,16 +14,14 @@ export async function POST(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
-    const body = await request.json();
-    const { email, country = "MX", publicKey } = body;
+    const parsed = await parseJsonBody(request, CreateCustomerBodySchema);
+    if ("error" in parsed) return parsed.error;
+    const { email, country = "MX", publicKey } = parsed.data;
 
     const client = getAnchorClient(provider);
     const customer = await client.createCustomer({ email, country, publicKey });
@@ -45,25 +49,15 @@ export async function GET(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
     const { searchParams } = new URL(request.url);
-    const email = searchParams.get("email");
-    const customerId = searchParams.get("customerId");
-    const country = searchParams.get("country") || "MX";
-
-    if (!email && !customerId) {
-      return NextResponse.json(
-        { error: "email or customerId query parameter is required" },
-        { status: 400 }
-      );
-    }
+    const queryResult = parseQuery(searchParams, GetCustomerQuerySchema);
+    if ("error" in queryResult) return queryResult.error;
+    const { email, customerId, country = "MX" } = queryResult.data;
 
     const client = getAnchorClient(provider);
     const customer = await client.getCustomer({

--- a/apps/web-app/src/app/api/anchor/[provider]/fiat-accounts/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/fiat-accounts/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, isValidProvider, AnchorError } from "@/lib/anchors";
+import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { parseJsonBody, parseParam, parseQuery } from "@/lib/validation/parse";
+import {
+  CustomerIdQuerySchema,
+  FiatAccountBodySchema,
+  ProviderSchema,
+} from "@/lib/validation/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -8,23 +14,14 @@ export async function POST(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
-    const body = await request.json();
-    const { customerId, publicKey, bankName, clabe, beneficiary } = body;
-
-    if (!customerId || !clabe || !beneficiary) {
-      return NextResponse.json(
-        { error: "customerId, clabe, and beneficiary are required" },
-        { status: 400 }
-      );
-    }
+    const parsed = await parseJsonBody(request, FiatAccountBodySchema);
+    if ("error" in parsed) return parsed.error;
+    const { customerId, publicKey, bankName, clabe, beneficiary } = parsed.data;
 
     const client = getAnchorClient(provider);
     const result = await client.registerFiatAccount({
@@ -61,23 +58,15 @@ export async function GET(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
     const { searchParams } = new URL(request.url);
-    const customerId = searchParams.get("customerId");
-
-    if (!customerId) {
-      return NextResponse.json(
-        { error: "customerId query parameter is required" },
-        { status: 400 }
-      );
-    }
+    const queryResult = parseQuery(searchParams, CustomerIdQuerySchema);
+    if ("error" in queryResult) return queryResult.error;
+    const { customerId } = queryResult.data;
 
     const client = getAnchorClient(provider);
     const accounts = await client.getFiatAccounts(customerId);

--- a/apps/web-app/src/app/api/anchor/[provider]/kyc/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/kyc/route.ts
@@ -1,7 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, isValidProvider, AnchorError } from "@/lib/anchors";
+import { getAnchorClient, AnchorError } from "@/lib/anchors";
 import { AlfredPayClient } from "@/lib/anchors/alfredpay";
-import type { AlfredPayKycFileType } from "@/lib/anchors/alfredpay/types";
+import {
+  parseJsonBody,
+  parseParam,
+  parseQuery,
+  zodErrorResponse,
+} from "@/lib/validation/parse";
+import {
+  KycFileUploadSchema,
+  KycGetQuerySchema,
+  KycPostTypeSchema,
+  KycSubmitFormFieldsSchema,
+  KycSubmitJsonBodySchema,
+  ProviderSchema,
+} from "@/lib/validation/schemas";
+import { ZodError } from "zod";
 
 export const dynamic = "force-dynamic";
 
@@ -10,19 +24,21 @@ export async function GET(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
     const { searchParams } = new URL(request.url);
-    const customerId = searchParams.get("customerId") || undefined;
-    const type = searchParams.get("type") || "status";
-    const country = searchParams.get("country") || "MX";
-    const publicKey = searchParams.get("publicKey") || undefined;
+    const queryResult = parseQuery(searchParams, KycGetQuerySchema);
+    if ("error" in queryResult) return queryResult.error;
+    const {
+      customerId,
+      type = "status",
+      country = "MX",
+      publicKey,
+      bankAccountId,
+    } = queryResult.data;
 
     const client = getAnchorClient(provider);
 
@@ -44,15 +60,8 @@ export async function GET(
           { status: 501 }
         );
       }
-      if (!customerId) {
-        return NextResponse.json(
-          { error: "customerId query parameter is required" },
-          { status: 400 }
-        );
-      }
-      const bankAccountId = searchParams.get("bankAccountId") || undefined;
       const kycUrl = await client.getKycUrl(
-        customerId,
+        customerId!,
         publicKey,
         bankAccountId
       );
@@ -60,24 +69,11 @@ export async function GET(
     }
 
     if (type === "submission" && client instanceof AlfredPayClient) {
-      if (!customerId) {
-        return NextResponse.json(
-          { error: "customerId query parameter is required" },
-          { status: 400 }
-        );
-      }
-      const submission = await client.getKycSubmission(customerId);
+      const submission = await client.getKycSubmission(customerId!);
       return NextResponse.json({ submission });
     }
 
-    // Default: return status
-    if (!customerId) {
-      return NextResponse.json(
-        { error: "customerId query parameter is required" },
-        { status: 400 }
-      );
-    }
-    const status = await client.getKycStatus(customerId, publicKey);
+    const status = await client.getKycStatus(customerId!, publicKey);
     return NextResponse.json({ status });
   } catch (error) {
     if (error instanceof AnchorError) {
@@ -101,16 +97,22 @@ export async function POST(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
+
+    const { searchParams } = new URL(request.url);
+    const typeParam = searchParams.get("type");
+    const typeResult = parseParam(typeParam ?? "", KycPostTypeSchema);
+    if ("error" in typeResult) {
       return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
+        { error: 'type query parameter must be "submit-kyc" or "file"' },
         { status: 400 }
       );
     }
+    const type = typeResult.data;
 
-    const { searchParams } = new URL(request.url);
-    const type = searchParams.get("type");
     const client = getAnchorClient(provider);
 
     if (type === "submit-kyc") {
@@ -125,11 +127,32 @@ export async function POST(
 
       if (contentType.includes("multipart/form-data")) {
         const formData = await request.formData();
-        const customerId = formData.get("customerId") as string;
-        const fields = JSON.parse(formData.get("fields") as string);
-        const metadata = formData.has("metadata")
-          ? JSON.parse(formData.get("metadata") as string)
-          : undefined;
+
+        let fields: Record<string, string>;
+        let metadata: Record<string, string> | undefined;
+        try {
+          fields = JSON.parse(formData.get("fields") as string);
+          metadata = formData.has("metadata")
+            ? JSON.parse(formData.get("metadata") as string)
+            : undefined;
+        } catch {
+          return NextResponse.json(
+            {
+              error: "Invalid request",
+              issues: [{ message: "Invalid JSON in form fields" }],
+            },
+            { status: 400 }
+          );
+        }
+
+        const formParsed = KycSubmitFormFieldsSchema.safeParse({
+          customerId: formData.get("customerId"),
+          fields,
+          metadata,
+        });
+        if (!formParsed.success) {
+          return zodErrorResponse(formParsed.error);
+        }
 
         const documents: Record<string, File | string> = {};
         for (const [key, value] of formData.entries()) {
@@ -138,37 +161,48 @@ export async function POST(
           }
         }
 
-        const result = await client.submitKyc(customerId, {
-          fields,
+        const result = await client.submitKyc(formParsed.data.customerId, {
+          fields: formParsed.data.fields,
           documents,
-          metadata,
+          metadata: formParsed.data.metadata,
         });
         return NextResponse.json(result);
-      } else {
-        const body = await request.json();
-        const { customerId, data } = body;
-        const result = await client.submitKyc(customerId, data);
-        return NextResponse.json(result);
       }
+
+      const parsed = await parseJsonBody(request, KycSubmitJsonBodySchema);
+      if ("error" in parsed) return parsed.error;
+      const { customerId, data } = parsed.data;
+      const result = await client.submitKyc(customerId, {
+        fields: data.fields,
+        documents: data.documents ?? {},
+        metadata: data.metadata,
+      });
+      return NextResponse.json(result);
     }
 
-    // AlfredPay-specific: file upload
     if (type === "file" && client instanceof AlfredPayClient) {
       const formData = await request.formData();
-      const customerId = formData.get("customerId") as string;
-      const submissionId = formData.get("submissionId") as string;
-      const fileType = formData.get("fileType") as AlfredPayKycFileType;
-      const file = formData.get("file") as File;
+      const file = formData.get("file");
 
-      if (!customerId || !submissionId || !fileType || !file) {
+      const fileParsed = KycFileUploadSchema.safeParse({
+        customerId: formData.get("customerId"),
+        submissionId: formData.get("submissionId"),
+        fileType: formData.get("fileType"),
+      });
+      if (!fileParsed.success) {
+        return zodErrorResponse(fileParsed.error);
+      }
+      if (!(file instanceof File)) {
         return NextResponse.json(
           {
-            error: "customerId, submissionId, fileType, and file are required",
+            error: "Invalid request",
+            issues: [{ message: "file is required", path: ["file"] }],
           },
           { status: 400 }
         );
       }
 
+      const { customerId, submissionId, fileType } = fileParsed.data;
       const result = await client.submitKycFile(
         customerId,
         submissionId,
@@ -184,6 +218,9 @@ export async function POST(
       { status: 400 }
     );
   } catch (error) {
+    if (error instanceof ZodError) {
+      return zodErrorResponse(error);
+    }
     if (error instanceof AnchorError) {
       return NextResponse.json(
         { error: error.message, code: error.code },

--- a/apps/web-app/src/app/api/anchor/[provider]/offramp/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/offramp/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, isValidProvider, AnchorError } from "@/lib/anchors";
+import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { parseJsonBody, parseParam, parseQuery } from "@/lib/validation/parse";
+import {
+  OffRampBodySchema,
+  ProviderSchema,
+  TransactionIdQuerySchema,
+} from "@/lib/validation/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -8,15 +14,13 @@ export async function POST(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
-    const body = await request.json();
+    const parsed = await parseJsonBody(request, OffRampBodySchema);
+    if ("error" in parsed) return parsed.error;
     const {
       customerId,
       quoteId,
@@ -27,31 +31,7 @@ export async function POST(
       fiatAccountId: existingFiatAccountId,
       bankAccount,
       memo,
-    } = body;
-
-    if (
-      !customerId ||
-      !quoteId ||
-      !stellarAddress ||
-      !fromCurrency ||
-      !toCurrency ||
-      !amount
-    ) {
-      return NextResponse.json(
-        {
-          error:
-            "customerId, quoteId, stellarAddress, fromCurrency, toCurrency, and amount are required",
-        },
-        { status: 400 }
-      );
-    }
-
-    if (!existingFiatAccountId && !bankAccount) {
-      return NextResponse.json(
-        { error: "Either fiatAccountId or bankAccount is required" },
-        { status: 400 }
-      );
-    }
+    } = parsed.data;
 
     const client = getAnchorClient(provider);
     let fiatAccountId: string;
@@ -59,13 +39,7 @@ export async function POST(
     if (existingFiatAccountId) {
       fiatAccountId = existingFiatAccountId;
     } else {
-      const { bankName, clabe, beneficiary } = bankAccount;
-      if (!clabe || !beneficiary) {
-        return NextResponse.json(
-          { error: "bankAccount must include clabe and beneficiary" },
-          { status: 400 }
-        );
-      }
+      const { bankName, clabe, beneficiary } = bankAccount!;
       const fiatAccount = await client.registerFiatAccount({
         customerId,
         account: {
@@ -112,23 +86,15 @@ export async function GET(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
     const { searchParams } = new URL(request.url);
-    const transactionId = searchParams.get("transactionId");
-
-    if (!transactionId) {
-      return NextResponse.json(
-        { error: "transactionId query parameter is required" },
-        { status: 400 }
-      );
-    }
+    const queryResult = parseQuery(searchParams, TransactionIdQuerySchema);
+    if ("error" in queryResult) return queryResult.error;
+    const { transactionId } = queryResult.data;
 
     const client = getAnchorClient(provider);
     const transaction = await client.getOffRampTransaction(transactionId);

--- a/apps/web-app/src/app/api/anchor/[provider]/offramp/sign/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/offramp/sign/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, isValidProvider, AnchorError } from "@/lib/anchors";
-import { EtherfuseClient } from "@/lib/anchors/etherfuse";
+import { AnchorError } from "@/lib/anchors";
+import { parseJsonBody, parseParam } from "@/lib/validation/parse";
+import {
+  OffRampSignBodySchema,
+  ProviderSchema,
+} from "@/lib/validation/schemas";
 import { rpc, Horizon, TransactionBuilder } from "@stellar/stellar-sdk";
 
 export const dynamic = "force-dynamic";
@@ -15,23 +19,13 @@ export async function POST(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
 
-    const body = await request.json();
-    const { signedXdr, transactionId } = body;
-
-    if (!signedXdr) {
-      return NextResponse.json(
-        { error: "signedXdr is required" },
-        { status: 400 }
-      );
-    }
+    const parsed = await parseJsonBody(request, OffRampSignBodySchema);
+    if ("error" in parsed) return parsed.error;
+    const { signedXdr, transactionId } = parsed.data;
 
     const rpcUrl =
       process.env.NEXT_PUBLIC_STELLAR_RPC_URL ||
@@ -43,12 +37,10 @@ export async function POST(
       process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL ||
       "https://horizon-testnet.stellar.org";
 
-    // Submit the signed XDR directly to Stellar network
     const sorobanServer = new rpc.Server(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
 
     try {
-      // Try Soroban RPC first
       const tx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
       const response = await sorobanServer.sendTransaction(
         tx as Parameters<typeof sorobanServer.sendTransaction>[0]
@@ -60,7 +52,6 @@ export async function POST(
         transactionId,
       });
     } catch {
-      // Fall back to Horizon for classic transactions
       try {
         const response = await horizonServer.submitTransaction(
           TransactionBuilder.fromXDR(

--- a/apps/web-app/src/app/api/anchor/[provider]/onramp/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/onramp/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, isValidProvider, AnchorError } from "@/lib/anchors";
+import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { parseJsonBody, parseParam, parseQuery } from "@/lib/validation/parse";
+import {
+  OnRampBodySchema,
+  ProviderSchema,
+  TransactionIdQuerySchema,
+} from "@/lib/validation/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -8,15 +14,13 @@ export async function POST(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
-    const body = await request.json();
+    const parsed = await parseJsonBody(request, OnRampBodySchema);
+    if ("error" in parsed) return parsed.error;
     const {
       customerId,
       quoteId,
@@ -26,24 +30,7 @@ export async function POST(
       amount,
       memo,
       bankAccountId,
-    } = body;
-
-    if (
-      !customerId ||
-      !quoteId ||
-      !stellarAddress ||
-      !fromCurrency ||
-      !toCurrency ||
-      !amount
-    ) {
-      return NextResponse.json(
-        {
-          error:
-            "customerId, quoteId, stellarAddress, fromCurrency, toCurrency, and amount are required",
-        },
-        { status: 400 }
-      );
-    }
+    } = parsed.data;
 
     const client = getAnchorClient(provider);
     const transaction = await client.createOnRamp({
@@ -80,23 +67,15 @@ export async function GET(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
     const { searchParams } = new URL(request.url);
-    const transactionId = searchParams.get("transactionId");
-
-    if (!transactionId) {
-      return NextResponse.json(
-        { error: "transactionId query parameter is required" },
-        { status: 400 }
-      );
-    }
+    const queryResult = parseQuery(searchParams, TransactionIdQuerySchema);
+    if ("error" in queryResult) return queryResult.error;
+    const { transactionId } = queryResult.data;
 
     const client = getAnchorClient(provider);
     const transaction = await client.getOnRampTransaction(transactionId);

--- a/apps/web-app/src/app/api/anchor/[provider]/quotes/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/quotes/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, isValidProvider, AnchorError } from "@/lib/anchors";
+import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { parseJsonBody, parseParam } from "@/lib/validation/parse";
+import { ProviderSchema, QuoteBodySchema } from "@/lib/validation/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -8,15 +10,13 @@ export async function POST(
   { params }: { params: Promise<{ provider: string }> }
 ) {
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
-    const body = await request.json();
+    const parsed = await parseJsonBody(request, QuoteBodySchema);
+    if ("error" in parsed) return parsed.error;
     const {
       fromCurrency,
       toCurrency,
@@ -25,20 +25,7 @@ export async function POST(
       customerId,
       stellarAddress,
       resourceId,
-    } = body;
-
-    if (!fromCurrency || !toCurrency) {
-      return NextResponse.json(
-        { error: "fromCurrency and toCurrency are required" },
-        { status: 400 }
-      );
-    }
-    if (!fromAmount && !toAmount) {
-      return NextResponse.json(
-        { error: "Either fromAmount or toAmount is required" },
-        { status: 400 }
-      );
-    }
+    } = parsed.data;
 
     const client = getAnchorClient(provider);
     const quote = await client.getQuote({

--- a/apps/web-app/src/app/api/anchor/[provider]/sandbox/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/sandbox/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, isValidProvider, AnchorError } from "@/lib/anchors";
+import { getAnchorClient, AnchorError } from "@/lib/anchors";
 import { EtherfuseClient } from "@/lib/anchors/etherfuse";
 import { AlfredPayClient } from "@/lib/anchors/alfredpay";
+import { parseJsonBody, parseParam } from "@/lib/validation/parse";
+import { ProviderSchema, SandboxBodySchema } from "@/lib/validation/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -21,27 +23,18 @@ export async function POST(
   }
 
   try {
-    const { provider } = await params;
-    if (!isValidProvider(provider)) {
-      return NextResponse.json(
-        { error: `Invalid provider: ${provider}` },
-        { status: 400 }
-      );
-    }
+    const { provider: providerParam } = await params;
+    const providerResult = parseParam(providerParam, ProviderSchema);
+    if ("error" in providerResult) return providerResult.error;
+    const provider = providerResult.data;
 
-    const body = await request.json();
-    const { action } = body;
-
-    if (!action) {
-      return NextResponse.json(
-        { error: "action is required" },
-        { status: 400 }
-      );
-    }
+    const parsed = await parseJsonBody(request, SandboxBodySchema);
+    if ("error" in parsed) return parsed.error;
+    const body = parsed.data;
 
     const client = getAnchorClient(provider);
 
-    switch (action) {
+    switch (body.action) {
       case "simulateFiatReceived": {
         if (!(client instanceof EtherfuseClient)) {
           return NextResponse.json(
@@ -49,14 +42,7 @@ export async function POST(
             { status: 400 }
           );
         }
-        const { orderId } = body;
-        if (!orderId) {
-          return NextResponse.json(
-            { error: "orderId is required for simulateFiatReceived" },
-            { status: 400 }
-          );
-        }
-        const statusCode = await client.simulateFiatReceived(orderId);
+        const statusCode = await client.simulateFiatReceived(body.orderId);
         return NextResponse.json({ success: statusCode === 200, statusCode });
       }
 
@@ -67,25 +53,12 @@ export async function POST(
             { status: 400 }
           );
         }
-        const { submissionId } = body;
-        if (!submissionId) {
-          return NextResponse.json(
-            { error: "submissionId is required for completeKyc" },
-            { status: 400 }
-          );
-        }
-        await client.completeKycSandbox(submissionId);
+        await client.completeKycSandbox(body.submissionId);
         return NextResponse.json({
           success: true,
           message: "KYC marked as completed",
         });
       }
-
-      default:
-        return NextResponse.json(
-          { error: `Unknown action: ${action}` },
-          { status: 400 }
-        );
     }
   } catch (error) {
     if (error instanceof AnchorError) {

--- a/apps/web-app/src/app/api/faucet/route.ts
+++ b/apps/web-app/src/app/api/faucet/route.ts
@@ -13,6 +13,8 @@ import {
   buildMintRequestsScVal,
   FAUCET_COOLDOWN_MS,
 } from "@/lib/constants/faucet";
+import { parseJsonBody } from "@/lib/validation/parse";
+import { FaucetBodySchema } from "@/lib/validation/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -152,15 +154,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { address } = body as { address?: string };
-
-    if (!address || typeof address !== "string") {
-      return NextResponse.json(
-        { error: "Missing or invalid address" },
-        { status: 400 }
-      );
-    }
+    const parsed = await parseJsonBody(request, FaucetBodySchema);
+    if ("error" in parsed) return parsed.error;
+    const { address } = parsed.data;
 
     if (!checkRateLimit(address)) {
       const remaining = Math.ceil(

--- a/apps/web-app/src/lib/validation/parse.ts
+++ b/apps/web-app/src/lib/validation/parse.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ZodError, type ZodSchema } from "zod";
+
+export function zodErrorResponse(error: ZodError): NextResponse {
+  return NextResponse.json(
+    { error: "Invalid request", issues: error.issues },
+    { status: 400 }
+  );
+}
+
+export async function parseJsonBody<T>(
+  req: NextRequest,
+  schema: ZodSchema<T>
+): Promise<{ data: T } | { error: NextResponse }> {
+  try {
+    const body = await req.json();
+    return { data: schema.parse(body) };
+  } catch (e) {
+    if (e instanceof ZodError) {
+      return { error: zodErrorResponse(e) };
+    }
+    throw e;
+  }
+}
+
+export function searchParamsToObject(
+  searchParams: URLSearchParams
+): Record<string, string | undefined> {
+  const obj: Record<string, string | undefined> = {};
+  searchParams.forEach((value, key) => {
+    obj[key] = value;
+  });
+  return obj;
+}
+
+export function parseQuery<T>(
+  searchParams: URLSearchParams,
+  schema: ZodSchema<T>
+): { data: T } | { error: NextResponse } {
+  try {
+    return { data: schema.parse(searchParamsToObject(searchParams)) };
+  } catch (e) {
+    if (e instanceof ZodError) {
+      return { error: zodErrorResponse(e) };
+    }
+    throw e;
+  }
+}
+
+export function parseParam<T>(
+  value: string,
+  schema: ZodSchema<T>
+): { data: T } | { error: NextResponse } {
+  try {
+    return { data: schema.parse(value) };
+  } catch (e) {
+    if (e instanceof ZodError) {
+      return { error: zodErrorResponse(e) };
+    }
+    throw e;
+  }
+}

--- a/apps/web-app/src/lib/validation/schemas.ts
+++ b/apps/web-app/src/lib/validation/schemas.ts
@@ -1,0 +1,192 @@
+import { z } from "zod";
+
+export const StellarAddressSchema = z
+  .string()
+  .regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar public key");
+
+export const ProviderSchema = z.enum(["etherfuse", "alfredpay"]);
+
+export const CurrencyCodeSchema = z.string().min(1).max(12);
+
+export const AmountSchema = z
+  .string()
+  .regex(/^\d+(\.\d+)?$/, "Amount must be a decimal string");
+
+export const CountrySchema = z.string().length(2).default("MX");
+
+export const EmailSchema = z.string().email();
+
+export const ClabeSchema = z
+  .string()
+  .regex(/^\d{18}$/, "CLABE must be 18 digits");
+
+export const CustomerIdSchema = z.string().min(1);
+
+export const QuoteIdSchema = z.string().min(1);
+
+export const TransactionIdSchema = z.string().min(1);
+
+export const NonEmptyStringSchema = z.string().min(1);
+
+export const FaucetBodySchema = z.object({
+  address: StellarAddressSchema,
+});
+
+export const CreateCustomerBodySchema = z.object({
+  email: EmailSchema.optional(),
+  country: CountrySchema.optional(),
+  publicKey: StellarAddressSchema.optional(),
+});
+
+export const GetCustomerQuerySchema = z
+  .object({
+    email: EmailSchema.optional(),
+    customerId: CustomerIdSchema.optional(),
+    country: CountrySchema.optional(),
+  })
+  .refine((data) => data.email || data.customerId, {
+    message: "email or customerId query parameter is required",
+  });
+
+export const QuoteBodySchema = z
+  .object({
+    fromCurrency: CurrencyCodeSchema,
+    toCurrency: CurrencyCodeSchema,
+    fromAmount: AmountSchema.optional(),
+    toAmount: AmountSchema.optional(),
+    customerId: CustomerIdSchema.optional(),
+    stellarAddress: StellarAddressSchema.optional(),
+    resourceId: NonEmptyStringSchema.optional(),
+  })
+  .refine((data) => data.fromAmount || data.toAmount, {
+    message: "Either fromAmount or toAmount is required",
+  });
+
+export const OnRampBodySchema = z.object({
+  customerId: CustomerIdSchema,
+  quoteId: QuoteIdSchema,
+  stellarAddress: StellarAddressSchema,
+  fromCurrency: CurrencyCodeSchema,
+  toCurrency: CurrencyCodeSchema,
+  amount: AmountSchema,
+  memo: z.string().optional(),
+  bankAccountId: NonEmptyStringSchema.optional(),
+});
+
+export const TransactionIdQuerySchema = z.object({
+  transactionId: TransactionIdSchema,
+});
+
+export const BankAccountSchema = z.object({
+  bankName: z.string().optional(),
+  clabe: ClabeSchema,
+  beneficiary: z.string().min(1),
+});
+
+export const OffRampBodySchema = z
+  .object({
+    customerId: CustomerIdSchema,
+    quoteId: QuoteIdSchema,
+    stellarAddress: StellarAddressSchema,
+    fromCurrency: CurrencyCodeSchema,
+    toCurrency: CurrencyCodeSchema,
+    amount: AmountSchema,
+    fiatAccountId: NonEmptyStringSchema.optional(),
+    bankAccount: BankAccountSchema.optional(),
+    memo: z.string().optional(),
+  })
+  .refine((data) => data.fiatAccountId || data.bankAccount, {
+    message: "Either fiatAccountId or bankAccount is required",
+  });
+
+export const OffRampSignBodySchema = z.object({
+  signedXdr: NonEmptyStringSchema,
+  transactionId: TransactionIdSchema.optional(),
+});
+
+export const FiatAccountBodySchema = z.object({
+  customerId: CustomerIdSchema,
+  publicKey: StellarAddressSchema.optional(),
+  bankName: z.string().optional(),
+  clabe: ClabeSchema,
+  beneficiary: z.string().min(1),
+});
+
+export const CustomerIdQuerySchema = z.object({
+  customerId: CustomerIdSchema,
+});
+
+export const AssetsQuerySchema = z.object({
+  wallet: StellarAddressSchema,
+});
+
+export const SandboxSimulateFiatSchema = z.object({
+  action: z.literal("simulateFiatReceived"),
+  orderId: NonEmptyStringSchema,
+});
+
+export const SandboxCompleteKycSchema = z.object({
+  action: z.literal("completeKyc"),
+  submissionId: NonEmptyStringSchema,
+});
+
+export const SandboxBodySchema = z.discriminatedUnion("action", [
+  SandboxSimulateFiatSchema,
+  SandboxCompleteKycSchema,
+]);
+
+export const KycGetQuerySchema = z
+  .object({
+    customerId: CustomerIdSchema.optional(),
+    type: z
+      .enum(["status", "requirements", "iframe", "url", "submission"])
+      .default("status"),
+    country: CountrySchema.optional(),
+    publicKey: StellarAddressSchema.optional(),
+    bankAccountId: NonEmptyStringSchema.optional(),
+  })
+  .superRefine((data, ctx) => {
+    const needsCustomerId = ["status", "iframe", "url", "submission"].includes(
+      data.type
+    );
+    if (needsCustomerId && !data.customerId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "customerId query parameter is required",
+        path: ["customerId"],
+      });
+    }
+  });
+
+export const KycSubmissionDataSchema = z.object({
+  fields: z.record(z.string()),
+  documents: z.record(z.string()).default({}),
+  metadata: z.record(z.string()).optional(),
+});
+
+export const KycSubmitJsonBodySchema = z.object({
+  customerId: CustomerIdSchema,
+  data: KycSubmissionDataSchema,
+});
+
+export const KycSubmitFormFieldsSchema = z.object({
+  customerId: CustomerIdSchema,
+  fields: z.record(z.string()),
+  metadata: z.record(z.string()).optional(),
+});
+
+export const AlfredPayKycFileTypeSchema = z.enum([
+  "National ID Front",
+  "National ID Back",
+  "Driver Licence Front",
+  "Driver Licence Back",
+  "Selfie",
+]);
+
+export const KycFileUploadSchema = z.object({
+  customerId: CustomerIdSchema,
+  submissionId: NonEmptyStringSchema,
+  fileType: AlfredPayKycFileTypeSchema,
+});
+
+export const KycPostTypeSchema = z.enum(["submit-kyc", "file"]);


### PR DESCRIPTION
## Problem

API routes validated input manually (or not at all). Examples like the faucet route only checked that `address` was a string — not that it is a valid Stellar `G...` public key. Anchor routes forwarded unvalidated payloads to third-party APIs (Etherfuse, AlfredPay).

- [x] closes #224 

## Fix

- Added shared Zod schemas in `apps/web-app/src/lib/validation/schemas.ts`
- Added parse helpers in `apps/web-app/src/lib/validation/parse.ts` (`parseJsonBody`, `parseQuery`, `parseParam`)
- Updated all `app/api/**/route.ts` handlers to validate body, query, and path params
- Invalid input returns `400` with `{ error: "Invalid request", issues: [...] }`

## Acceptance criteria

- [x] All `app/api/**/route.ts` handlers validate body + query + path params with Zod
- [x] Invalid input returns `400` with a structured `issues` array
- [x] Shared schemas live in one module
- [x] No regression in happy-path responses (validation runs before existing logic)

## Notes

- `vault/invest` and `vault/apy` have no user-supplied body/query params — no validation changes needed.