### PR TITLE
fix(lending): duplicate toast notification for failed lending action

### DIFF
--- a/apps/web-app/src/features/lending/hooks/useLend.ts
+++ b/apps/web-app/src/features/lending/hooks/useLend.ts
@@ -268,10 +268,11 @@ export function useLend() {
         );
         closeModal();
       } catch (err) {
-        const msg = extractContractErrorOrNull(err);
-        showError(
-          typeof msg === "string" ? msg : "An unexpected error occurred."
-        );
+        throw err;
+        // const msg = extractContractErrorOrNull(err);
+        // showError(
+        //   typeof msg === "string" ? msg : "An unexpected error occurred."
+        // );
       } finally {
         setIsLoading(false);
       }
@@ -286,7 +287,7 @@ export function useLend() {
       loadBTokenBalance,
       refetchPools,
       closeModal,
-      showError,
+      // showError,
       showSuccess,
     ]
   );


### PR DESCRIPTION
Closes #238 

## Summary
Remove duplicate toast notification error for failed lending action

## Files Changed
`apps/web-app/src/features/lending/hooks/useLend.ts`

