### PR TITLE
feat: Add pre-transaction position simulator to borrow flows

### DIFF
--- a/apps/web-app/src/features/borrowing/components/ui/BorrowModal.tsx
+++ b/apps/web-app/src/features/borrowing/components/ui/BorrowModal.tsx
@@ -4,6 +4,8 @@ import { useState, useMemo } from "react";
 import { X } from "lucide-react";
 import { ModalPortal } from "@/components/ui/ModalPortal";
 import { calculateBorrowLimit } from "../../utils/borrowUtils";
+import { usePositionSimulation } from "../../hooks/usePositionSimulation";
+import { PositionPreviewPanel } from "./PositionPreviewPanel";
 import type { BorrowTableAsset } from "../../types/borrowing";
 
 interface BorrowModalProps {
@@ -37,11 +39,27 @@ export function BorrowModal({
 
   const borrowLimitExceeded =
     borrowAmount !== "" && parseFloat(borrowAmount) > borrowLimit;
+
+  // ─── Position simulation ─────────────────────────────────────────────
+  const collateralNum = parseFloat(collateralAmount) || 0;
+  const borrowNum = parseFloat(borrowAmount) || 0;
+
+  const simulation = usePositionSimulation({
+    collateralFactorPct: asset.collateralFactor,
+    action: {
+      type: "borrow",
+      collateralAmount: collateralNum,
+      borrowAmount: borrowNum,
+    },
+    enabled: isWalletConnected && (collateralNum > 0 || borrowNum > 0),
+  });
+
   const canSubmit =
     isWalletConnected &&
     parseFloat(collateralAmount) > 0 &&
     parseFloat(borrowAmount) > 0 &&
-    !borrowLimitExceeded;
+    !borrowLimitExceeded &&
+    simulation.canSubmit;
 
   const handleSubmit = async () => {
     await onSubmit(collateralAmount, borrowAmount);
@@ -96,7 +114,7 @@ export function BorrowModal({
             </p>
           </div>
 
-          <div className="mb-4">
+          <div className="mb-3">
             <label className="text-white/60 text-xs font-medium block mb-1">
               Borrow Amount ({asset.assetCode})
             </label>
@@ -114,6 +132,15 @@ export function BorrowModal({
               </p>
             )}
           </div>
+
+          {/* Position Preview */}
+          {isWalletConnected && (collateralNum > 0 || borrowNum > 0) && (
+            <PositionPreviewPanel
+              simulation={simulation}
+              collateralTokenCode={asset.collateralTokenCode}
+              debtTokenCode={asset.assetCode}
+            />
+          )}
 
           <div className="flex gap-2">
             <button

--- a/apps/web-app/src/features/borrowing/components/ui/HealthFactorBadge.tsx
+++ b/apps/web-app/src/features/borrowing/components/ui/HealthFactorBadge.tsx
@@ -3,7 +3,8 @@
 import {
   getHealthFactorColor,
   getHealthFactorLabel,
-} from "../../hooks/useHealthFactor";
+  getHealthFactorBadgeClasses,
+} from "../../const/riskThresholds";
 
 interface HealthFactorBadgeProps {
   healthFactor: number | null;
@@ -25,22 +26,7 @@ export function HealthFactorBadge({
 
   const color = getHealthFactorColor(healthFactor);
   const label = getHealthFactorLabel(healthFactor);
-
-  let bgBorder = "bg-white/5 border-white/10";
-  let dotColor = "bg-white/20";
-
-  if (healthFactor !== null) {
-    if (healthFactor >= 1.5) {
-      bgBorder = "bg-green-500/10 border-green-500/20";
-      dotColor = "bg-green-400";
-    } else if (healthFactor >= 1.0) {
-      bgBorder = "bg-yellow-500/10 border-yellow-500/20";
-      dotColor = "bg-yellow-400";
-    } else {
-      bgBorder = "bg-red-500/10 border-red-500/20";
-      dotColor = "bg-red-400";
-    }
-  }
+  const { bgBorder, dotColor } = getHealthFactorBadgeClasses(healthFactor);
 
   return (
     <div

--- a/apps/web-app/src/features/borrowing/components/ui/PositionPreviewPanel.tsx
+++ b/apps/web-app/src/features/borrowing/components/ui/PositionPreviewPanel.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import {
+  AlertTriangle,
+  ShieldCheck,
+  TrendingDown,
+  Activity,
+} from "lucide-react";
+import type { PositionSimulationResult } from "../../hooks/usePositionSimulation";
+import {
+  getHealthFactorColor,
+  getHealthFactorLabel,
+  getHealthFactorBadgeClasses,
+} from "../../const/riskThresholds";
+
+interface PositionPreviewPanelProps {
+  simulation: PositionSimulationResult;
+  currentHealthFactor?: number | null;
+  collateralTokenCode: string;
+  debtTokenCode: string;
+}
+
+export function PositionPreviewPanel({
+  simulation,
+  currentHealthFactor = null,
+  collateralTokenCode,
+  debtTokenCode,
+}: PositionPreviewPanelProps) {
+  const { projectedHealthFactor, liquidationPrice, warnings, isStale } =
+    simulation;
+
+  // Don't render if there's nothing to show.
+  if (projectedHealthFactor === null && warnings.length === 0) {
+    return null;
+  }
+
+  const projectedColor = getHealthFactorColor(projectedHealthFactor);
+  const projectedLabel = getHealthFactorLabel(projectedHealthFactor);
+  const { dotColor: projectedDot } = getHealthFactorBadgeClasses(
+    projectedHealthFactor
+  );
+
+  const currentColor = getHealthFactorColor(currentHealthFactor);
+  const currentLabel = getHealthFactorLabel(currentHealthFactor);
+
+  const blockWarnings = warnings.filter((w) => w.severity === "block");
+  const warnWarnings = warnings.filter((w) => w.severity === "warn");
+
+  return (
+    <div
+      className={`mb-3 rounded-xl border p-3 transition-opacity duration-200 ${
+        isStale ? "opacity-50" : "opacity-100"
+      } ${
+        blockWarnings.length > 0
+          ? "bg-red-500/5 border-red-500/20"
+          : warnWarnings.length > 0
+            ? "bg-amber-500/5 border-amber-500/20"
+            : "bg-white/5 border-white/10"
+      }`}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-1.5 mb-2.5">
+        <Activity className="h-3.5 w-3.5 text-white/40" />
+        <span className="text-white/50 text-xs font-medium uppercase tracking-wider">
+          Position Preview
+        </span>
+      </div>
+
+      {/* Metrics grid */}
+      <div className="grid grid-cols-2 gap-2 mb-2">
+        {/* Projected Health Factor */}
+        <div className="rounded-lg bg-black/20 p-2.5">
+          <p className="text-white/40 text-[10px] uppercase tracking-wider mb-1">
+            Projected HF
+          </p>
+          <div className="flex items-center gap-1.5">
+            <div className={`h-1.5 w-1.5 rounded-full ${projectedDot}`} />
+            <span
+              className={`font-bold text-sm tabular-nums ${projectedColor}`}
+            >
+              {projectedHealthFactor !== null
+                ? projectedHealthFactor.toFixed(2)
+                : "—"}
+            </span>
+          </div>
+          <span className={`text-[10px] opacity-70 ${projectedColor}`}>
+            {projectedLabel}
+          </span>
+        </div>
+
+        {/* Liquidation Price */}
+        <div className="rounded-lg bg-black/20 p-2.5">
+          <p className="text-white/40 text-[10px] uppercase tracking-wider mb-1">
+            Liq. Price
+          </p>
+          <div className="flex items-center gap-1.5">
+            <TrendingDown className="h-3 w-3 text-white/30" />
+            <span className="text-white font-bold text-sm tabular-nums">
+              {liquidationPrice !== null ? liquidationPrice.toFixed(4) : "—"}
+            </span>
+          </div>
+          <span className="text-white/30 text-[10px]">
+            {collateralTokenCode}/{debtTokenCode}
+          </span>
+        </div>
+      </div>
+
+      {/* Risk transition */}
+      {currentHealthFactor !== null && projectedHealthFactor !== null && (
+        <div className="flex items-center gap-2 rounded-lg bg-black/20 px-2.5 py-2 mb-2">
+          <ShieldCheck className="h-3.5 w-3.5 text-white/30 shrink-0" />
+          <div className="flex items-center gap-1 text-xs">
+            <span className={currentColor}>
+              {currentHealthFactor.toFixed(2)}{" "}
+              <span className="opacity-70">({currentLabel})</span>
+            </span>
+            <span className="text-white/20">→</span>
+            <span className={projectedColor}>
+              {projectedHealthFactor.toFixed(2)}{" "}
+              <span className="opacity-70">({projectedLabel})</span>
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Block warnings */}
+      {blockWarnings.map((w, i) => (
+        <div
+          key={`block-${i}`}
+          className="flex items-start gap-2 rounded-lg bg-red-500/10 border border-red-500/20 p-2.5 mb-1 last:mb-0"
+        >
+          <AlertTriangle className="h-3.5 w-3.5 text-red-400 shrink-0 mt-0.5" />
+          <p className="text-red-400 text-xs leading-relaxed">{w.message}</p>
+        </div>
+      ))}
+
+      {/* Warn warnings */}
+      {warnWarnings.map((w, i) => (
+        <div
+          key={`warn-${i}`}
+          className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 p-2.5 mb-1 last:mb-0"
+        >
+          <AlertTriangle className="h-3.5 w-3.5 text-amber-400 shrink-0 mt-0.5" />
+          <p className="text-amber-400 text-xs leading-relaxed">{w.message}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web-app/src/features/borrowing/components/ui/RemoveCollateralModal.tsx
+++ b/apps/web-app/src/features/borrowing/components/ui/RemoveCollateralModal.tsx
@@ -1,14 +1,22 @@
 "use client";
 
 import { useState } from "react";
-import { X, AlertTriangle } from "lucide-react";
+import { X } from "lucide-react";
 import { ModalPortal } from "@/components/ui/ModalPortal";
+import { usePositionSimulation } from "../../hooks/usePositionSimulation";
+import { PositionPreviewPanel } from "./PositionPreviewPanel";
 import type { BorrowPosition } from "../../hooks/useUserBorrowPositions";
+
+const STELLAR_DIVISOR = 10_000_000n;
 
 interface RemoveCollateralModalProps {
   position: BorrowPosition;
   isProcessing: boolean;
   isWalletConnected: boolean;
+  /** Collateral factor percentage for the pool (e.g. 75). */
+  collateralFactorPct?: number;
+  /** Current on-chain health factor for comparison display. */
+  currentHealthFactor?: number | null;
   onClose: () => void;
   onSubmit: (amount: string) => Promise<void>;
 }
@@ -17,6 +25,8 @@ export function RemoveCollateralModal({
   position,
   isProcessing,
   isWalletConnected,
+  collateralFactorPct = 75,
+  currentHealthFactor = null,
   onClose,
   onSubmit,
 }: RemoveCollateralModalProps) {
@@ -31,7 +41,23 @@ export function RemoveCollateralModal({
     Number.isFinite(amountNum) &&
     amountNum > parseFloat(position.collateralFormatted);
 
-  const canSubmit = isWalletConnected && isValidAmount && !isProcessing;
+  // ─── Position simulation ─────────────────────────────────────────────
+  const removeNum = parseFloat(amount) || 0;
+  const currentCollateralNum =
+    Number(position.collateralRaw) / Number(STELLAR_DIVISOR);
+  const currentDebtNum = Number(position.debtRaw) / Number(STELLAR_DIVISOR);
+
+  const simulation = usePositionSimulation({
+    collateralFactorPct,
+    action: { type: "remove-collateral", removeAmount: removeNum },
+    currentCollateral: currentCollateralNum,
+    currentDebt: currentDebtNum,
+    currentHealthFactor,
+    enabled: isWalletConnected && removeNum > 0,
+  });
+
+  const canSubmit =
+    isWalletConnected && isValidAmount && !isProcessing && simulation.canSubmit;
 
   const handleMax = () => {
     setAmount(position.collateralFormatted);
@@ -46,7 +72,7 @@ export function RemoveCollateralModal({
   return (
     <ModalPortal>
       <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4 animate__animated animate__fadeIn animate__faster">
-        <div className="bg-[#1C1C1C] border border-white/10 rounded-2xl w-full max-w-md shadow-2xl p-4 sm:p-5 animate__animated animate__fadeInUp animate__faster">
+        <div className="bg-[#1C1C1C] border border-white/10 rounded-2xl w-full max-w-md max-h-[85vh] overflow-y-auto shadow-2xl p-4 sm:p-5 animate__animated animate__fadeInUp animate__faster">
           <div className="flex items-center justify-between mb-3">
             <h3 className="text-white text-lg font-bold">
               Remove {position.collateralTokenCode} Collateral
@@ -70,18 +96,8 @@ export function RemoveCollateralModal({
             </p>
           </div>
 
-          {/* Health factor warning */}
-          <div className="mb-3 flex items-start gap-2 rounded-xl bg-amber-500/10 border border-amber-500/20 p-3">
-            <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
-            <p className="text-amber-400/90 text-xs leading-relaxed">
-              Removing too much collateral may lower your health factor and
-              increase liquidation risk. The contract will reject the
-              transaction if it would drop below the minimum.
-            </p>
-          </div>
-
           {/* Amount input */}
-          <div className="mb-4">
+          <div className="mb-3">
             <div className="flex items-center justify-between mb-1">
               <label className="text-white/60 text-xs font-medium">
                 Amount to Remove ({position.collateralTokenCode})
@@ -108,6 +124,16 @@ export function RemoveCollateralModal({
               </p>
             )}
           </div>
+
+          {/* Position Preview — replaces the old static warning */}
+          {isWalletConnected && removeNum > 0 && (
+            <PositionPreviewPanel
+              simulation={simulation}
+              currentHealthFactor={currentHealthFactor}
+              collateralTokenCode={position.collateralTokenCode}
+              debtTokenCode={position.assetCode}
+            />
+          )}
 
           <div className="flex gap-2">
             <button

--- a/apps/web-app/src/features/borrowing/components/ui/RepayModal.tsx
+++ b/apps/web-app/src/features/borrowing/components/ui/RepayModal.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo } from "react";
 import { X, AlertTriangle } from "lucide-react";
 import { ModalPortal } from "@/components/ui/ModalPortal";
+import { usePositionSimulation } from "../../hooks/usePositionSimulation";
+import { PositionPreviewPanel } from "./PositionPreviewPanel";
 import type { BorrowPosition } from "../../hooks/useUserBorrowPositions";
 
 const SCALAR_12 = 1_000_000_000_000n;
@@ -23,6 +25,10 @@ interface RepayModalProps {
   isBalanceLoading: boolean;
   isProcessing: boolean;
   isWalletConnected: boolean;
+  /** Collateral factor percentage for the pool (e.g. 75). */
+  collateralFactorPct?: number;
+  /** Current on-chain health factor for comparison display. */
+  currentHealthFactor?: number | null;
   onClose: () => void;
   onSubmit: (dTokens: bigint) => Promise<void>;
 }
@@ -33,6 +39,8 @@ export function RepayModal({
   isBalanceLoading,
   isProcessing,
   isWalletConnected,
+  collateralFactorPct = 75,
+  currentHealthFactor = null,
   onClose,
   onSubmit,
 }: RepayModalProps) {
@@ -79,6 +87,22 @@ export function RepayModal({
   const exceedsDebt =
     !isMaxRepay && amountSmallest > position.debtRaw && position.debtRaw > 0n;
 
+  // ─── Position simulation ─────────────────────────────────────────────
+  const repayNum = parseFloat(repayAmount) || 0;
+  const currentCollateralNum =
+    Number(position.collateralRaw) / Number(STELLAR_DIVISOR);
+  const currentDebtNum = Number(position.debtRaw) / Number(STELLAR_DIVISOR);
+
+  const simulation = usePositionSimulation({
+    collateralFactorPct,
+    action: { type: "repay", repayAmount: repayNum },
+    currentCollateral: currentCollateralNum,
+    currentDebt: currentDebtNum,
+    currentHealthFactor,
+    enabled: isWalletConnected && repayNum > 0,
+  });
+
+  // Repay remains submittable even if simulation warns — reducing risk is always safe.
   const canSubmit = isWalletConnected && dTokensToRepay > 0n && !exceedsBalance;
 
   const handleMax = () => {
@@ -106,7 +130,7 @@ export function RepayModal({
   return (
     <ModalPortal>
       <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4 animate__animated animate__fadeIn animate__faster">
-        <div className="bg-[#1C1C1C] border border-white/10 rounded-2xl w-full max-w-md shadow-2xl p-4 sm:p-5 animate__animated animate__fadeInUp animate__faster">
+        <div className="bg-[#1C1C1C] border border-white/10 rounded-2xl w-full max-w-md max-h-[85vh] overflow-y-auto shadow-2xl p-4 sm:p-5 animate__animated animate__fadeInUp animate__faster">
           <div className="flex items-center justify-between mb-3">
             <h3 className="text-white text-lg font-bold">
               Repay {position.assetCode}
@@ -162,7 +186,7 @@ export function RepayModal({
           )}
 
           {/* Amount input */}
-          <div className="mb-4">
+          <div className="mb-3">
             <div className="flex items-center justify-between mb-1">
               <label className="text-white/60 text-xs font-medium">
                 Repay Amount ({position.assetCode})
@@ -197,7 +221,7 @@ export function RepayModal({
 
           {/* Estimated cost */}
           {dTokensToRepay > 0n && (
-            <div className="mb-4 rounded-xl bg-white/5 border border-white/5 px-3 py-2">
+            <div className="mb-3 rounded-xl bg-white/5 border border-white/5 px-3 py-2">
               <p className="text-white/40 text-xs">
                 Estimated cost:{" "}
                 <span className="text-white font-medium tabular-nums">
@@ -205,6 +229,16 @@ export function RepayModal({
                 </span>
               </p>
             </div>
+          )}
+
+          {/* Position Preview */}
+          {isWalletConnected && repayNum > 0 && (
+            <PositionPreviewPanel
+              simulation={simulation}
+              currentHealthFactor={currentHealthFactor}
+              collateralTokenCode={position.collateralTokenCode}
+              debtTokenCode={position.assetCode}
+            />
           )}
 
           <div className="flex gap-2">

--- a/apps/web-app/src/features/borrowing/const/riskThresholds.ts
+++ b/apps/web-app/src/features/borrowing/const/riskThresholds.ts
@@ -1,0 +1,73 @@
+/**
+ * Risk Thresholds — Centralised health-factor constants.
+ *
+ * Every UI component and utility that references health-factor tiers should
+ * import from here instead of using inline magic numbers.
+ */
+
+// ─── Health-Factor tier boundaries ──────────────────────────────────────────
+/** Position is considered safe above this value. */
+export const HF_SAFE = 1.5;
+
+/**
+ * Submit-time warning threshold.  When projected HF is between
+ * HF_WARNING and HF_LIQUIDATION the user sees a non-blocking warning.
+ */
+export const HF_WARNING = 1.2;
+
+/**
+ * At or below this value the position is liquidatable.
+ * Submit is **blocked** when projected HF falls below this value.
+ */
+export const HF_LIQUIDATION = 1.0;
+
+// ─── Risk-tier type ─────────────────────────────────────────────────────────
+export type RiskTier = "safe" | "caution" | "at-risk" | "unknown";
+
+// ─── Warning descriptor ─────────────────────────────────────────────────────
+export interface PositionWarning {
+  /** "block" prevents submission; "warn" is informational. */
+  severity: "block" | "warn";
+  message: string;
+}
+
+// ─── Display helpers (Tailwind classes) ─────────────────────────────────────
+export function getHealthFactorColor(hf: number | null): string {
+  if (hf === null) return "text-white/40";
+  if (hf >= HF_SAFE) return "text-green-400";
+  if (hf >= HF_LIQUIDATION) return "text-yellow-400";
+  return "text-red-400";
+}
+
+export function getHealthFactorLabel(hf: number | null): string {
+  if (hf === null) return "No Position";
+  if (hf >= HF_SAFE) return "Safe";
+  if (hf >= HF_LIQUIDATION) return "Caution";
+  return "At Risk";
+}
+
+/** Badge background + border Tailwind classes. */
+export function getHealthFactorBadgeClasses(hf: number | null): {
+  bgBorder: string;
+  dotColor: string;
+} {
+  if (hf === null) {
+    return { bgBorder: "bg-white/5 border-white/10", dotColor: "bg-white/20" };
+  }
+  if (hf >= HF_SAFE) {
+    return {
+      bgBorder: "bg-green-500/10 border-green-500/20",
+      dotColor: "bg-green-400",
+    };
+  }
+  if (hf >= HF_LIQUIDATION) {
+    return {
+      bgBorder: "bg-yellow-500/10 border-yellow-500/20",
+      dotColor: "bg-yellow-400",
+    };
+  }
+  return {
+    bgBorder: "bg-red-500/10 border-red-500/20",
+    dotColor: "bg-red-400",
+  };
+}

--- a/apps/web-app/src/features/borrowing/hooks/useHealthFactor.ts
+++ b/apps/web-app/src/features/borrowing/hooks/useHealthFactor.ts
@@ -4,19 +4,11 @@ import { useQueries } from "@tanstack/react-query";
 import { networks } from "@neko/lending";
 import { lendingService } from "@/lib/services/lending.service";
 
-export function getHealthFactorColor(hf: number | null): string {
-  if (hf === null) return "text-white/40";
-  if (hf >= 1.5) return "text-green-400";
-  if (hf >= 1.0) return "text-yellow-400";
-  return "text-red-400";
-}
-
-export function getHealthFactorLabel(hf: number | null): string {
-  if (hf === null) return "No Position";
-  if (hf >= 1.5) return "Safe";
-  if (hf >= 1.0) return "Caution";
-  return "At Risk";
-}
+// Re-export from the single source of truth so existing consumers keep working.
+export {
+  getHealthFactorColor,
+  getHealthFactorLabel,
+} from "../const/riskThresholds";
 
 const POOLS = [
   {

--- a/apps/web-app/src/features/borrowing/hooks/usePositionSimulation.ts
+++ b/apps/web-app/src/features/borrowing/hooks/usePositionSimulation.ts
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState, useEffect, useRef, useMemo } from "react";
+import {
+  calculateProjectedHealthFactor,
+  calculateLiquidationPrice,
+  getRiskTier,
+  getPositionWarnings,
+} from "../utils/liquidationPrice";
+import {
+  HF_LIQUIDATION,
+  HF_WARNING,
+  type RiskTier,
+  type PositionWarning,
+} from "../const/riskThresholds";
+
+const DEBOUNCE_MS = 300;
+
+// ─── Action types ────────────────────────────────────────────────────────────
+
+export type SimulationAction =
+  | { type: "borrow"; collateralAmount: number; borrowAmount: number }
+  | { type: "repay"; repayAmount: number }
+  | { type: "remove-collateral"; removeAmount: number };
+
+// ─── Params & Result ─────────────────────────────────────────────────────────
+
+export interface UsePositionSimulationParams {
+  collateralFactorPct: number;
+  action: SimulationAction;
+  /** Existing collateral (for repay / remove-collateral flows). */
+  currentCollateral?: number;
+  /** Existing debt (for repay / remove-collateral flows). */
+  currentDebt?: number;
+  /** Live on-chain health factor for comparison display. */
+  currentHealthFactor?: number | null;
+  /** Set false to disable (e.g. wallet disconnected). */
+  enabled?: boolean;
+}
+
+export interface PositionSimulationResult {
+  projectedHealthFactor: number | null;
+  liquidationPrice: number | null;
+  riskTier: RiskTier;
+  warnings: PositionWarning[];
+  isSimulating: boolean;
+  isStale: boolean;
+  /** False when projected HF < 1.0 (submit should be blocked). */
+  canSubmit: boolean;
+  /** True when projected HF is between 1.0 and 1.2. */
+  hasWarning: boolean;
+}
+
+const EMPTY_RESULT: PositionSimulationResult = {
+  projectedHealthFactor: null,
+  liquidationPrice: null,
+  riskTier: "unknown",
+  warnings: [],
+  isSimulating: false,
+  isStale: false,
+  canSubmit: true,
+  hasWarning: false,
+};
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+export function usePositionSimulation({
+  collateralFactorPct,
+  action,
+  currentCollateral = 0,
+  currentDebt = 0,
+  currentHealthFactor = null,
+  enabled = true,
+}: UsePositionSimulationParams): PositionSimulationResult {
+  const [result, setResult] = useState<PositionSimulationResult>(EMPTY_RESULT);
+  const [isStale, setIsStale] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Derive projected collateral & debt based on the action type.
+  const { projectedCollateral, projectedDebt } = useMemo(() => {
+    switch (action.type) {
+      case "borrow":
+        return {
+          projectedCollateral: action.collateralAmount,
+          projectedDebt: action.borrowAmount,
+        };
+      case "repay":
+        return {
+          projectedCollateral: currentCollateral,
+          projectedDebt: Math.max(0, currentDebt - action.repayAmount),
+        };
+      case "remove-collateral":
+        return {
+          projectedCollateral: Math.max(
+            0,
+            currentCollateral - action.removeAmount
+          ),
+          projectedDebt: currentDebt,
+        };
+    }
+  }, [action, currentCollateral, currentDebt]);
+
+  // Check whether the inputs represent a meaningful position to simulate.
+  const hasInput = useMemo(() => {
+    switch (action.type) {
+      case "borrow":
+        return action.collateralAmount > 0 || action.borrowAmount > 0;
+      case "repay":
+        return action.repayAmount > 0;
+      case "remove-collateral":
+        return action.removeAmount > 0;
+    }
+  }, [action]);
+
+  useEffect(() => {
+    // Guard: nothing to simulate.
+    if (!enabled || !hasInput) {
+      setResult(EMPTY_RESULT);
+      setIsStale(false);
+      return;
+    }
+
+    // Mark stale immediately so the UI can dim previous results.
+    setIsStale(true);
+
+    // Clear any pending timer.
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    timerRef.current = setTimeout(() => {
+      const projectedHF = calculateProjectedHealthFactor(
+        projectedCollateral,
+        projectedDebt,
+        collateralFactorPct
+      );
+
+      const liqPrice = calculateLiquidationPrice(
+        projectedCollateral,
+        projectedDebt,
+        collateralFactorPct
+      );
+
+      const tier = getRiskTier(projectedHF);
+      const warns = getPositionWarnings(projectedHF, currentHealthFactor);
+
+      const canSubmit = projectedHF === null || projectedHF >= HF_LIQUIDATION;
+      const hasWarning =
+        projectedHF !== null &&
+        projectedHF >= HF_LIQUIDATION &&
+        projectedHF < HF_WARNING;
+
+      setResult({
+        projectedHealthFactor: projectedHF,
+        liquidationPrice: liqPrice,
+        riskTier: tier,
+        warnings: warns,
+        isSimulating: false,
+        isStale: false,
+        canSubmit,
+        hasWarning,
+      });
+      setIsStale(false);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [
+    enabled,
+    hasInput,
+    projectedCollateral,
+    projectedDebt,
+    collateralFactorPct,
+    currentHealthFactor,
+  ]);
+
+  // Merge the stale flag (which updates immediately) with the debounced result.
+  return useMemo(
+    () => ({ ...result, isStale: isStale || result.isStale }),
+    [result, isStale]
+  );
+}

--- a/apps/web-app/src/features/borrowing/utils/__tests__/liquidationPrice.test.ts
+++ b/apps/web-app/src/features/borrowing/utils/__tests__/liquidationPrice.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for liquidation-price math utilities.
+ *
+ * Written for Vitest — the test runner is not yet configured in this project
+ * (tracked by issue #241).  Once the harness lands these tests will run as-is.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  calculateProjectedHealthFactor,
+  calculateLiquidationPrice,
+  getRiskTier,
+  getPositionWarnings,
+} from "../liquidationPrice";
+
+// ─── calculateProjectedHealthFactor ──────────────────────────────────────────
+
+describe("calculateProjectedHealthFactor", () => {
+  it("returns null when debt is zero (no risk)", () => {
+    expect(calculateProjectedHealthFactor(100, 0, 75)).toBeNull();
+  });
+
+  it("returns 0 when collateral is zero but debt is positive", () => {
+    expect(calculateProjectedHealthFactor(0, 50, 75)).toBe(0);
+  });
+
+  it("calculates correctly for a normal position", () => {
+    // HF = (100 × 0.75) / 50 = 1.5
+    expect(calculateProjectedHealthFactor(100, 50, 75)).toBeCloseTo(1.5);
+  });
+
+  it("returns under 1 for an under-collateralised position", () => {
+    // HF = (100 × 0.75) / 100 = 0.75
+    expect(calculateProjectedHealthFactor(100, 100, 75)).toBeCloseTo(0.75);
+  });
+
+  it("returns 0 for negative collateral", () => {
+    expect(calculateProjectedHealthFactor(-10, 50, 75)).toBe(0);
+  });
+
+  it("returns null for negative debt", () => {
+    expect(calculateProjectedHealthFactor(100, -50, 75)).toBeNull();
+  });
+
+  it("returns 0 when collateral factor is zero", () => {
+    expect(calculateProjectedHealthFactor(100, 50, 0)).toBe(0);
+  });
+});
+
+// ─── calculateLiquidationPrice ───────────────────────────────────────────────
+
+describe("calculateLiquidationPrice", () => {
+  it("calculates liquidation price correctly", () => {
+    // liqPrice = 50 / (100 × 0.75) = 0.6667
+    const result = calculateLiquidationPrice(100, 50, 75);
+    expect(result).toBeCloseTo(0.6667, 3);
+  });
+
+  it("returns null when debt is zero", () => {
+    expect(calculateLiquidationPrice(100, 0, 75)).toBeNull();
+  });
+
+  it("returns null when collateral is zero", () => {
+    expect(calculateLiquidationPrice(0, 50, 75)).toBeNull();
+  });
+
+  it("returns null for negative collateral amount", () => {
+    expect(calculateLiquidationPrice(-10, 50, 75)).toBeNull();
+  });
+
+  it("higher debt produces a higher liquidation price", () => {
+    const lowDebt = calculateLiquidationPrice(100, 30, 75)!;
+    const highDebt = calculateLiquidationPrice(100, 60, 75)!;
+    expect(highDebt).toBeGreaterThan(lowDebt);
+  });
+});
+
+// ─── getRiskTier ─────────────────────────────────────────────────────────────
+
+describe("getRiskTier", () => {
+  it("returns 'unknown' for null", () => {
+    expect(getRiskTier(null)).toBe("unknown");
+  });
+
+  it("returns 'safe' for HF >= 1.5", () => {
+    expect(getRiskTier(2.0)).toBe("safe");
+    expect(getRiskTier(1.5)).toBe("safe"); // boundary
+  });
+
+  it("returns 'caution' for 1.0 <= HF < 1.5", () => {
+    expect(getRiskTier(1.3)).toBe("caution");
+    expect(getRiskTier(1.0)).toBe("caution"); // boundary
+  });
+
+  it("returns 'at-risk' for HF < 1.0", () => {
+    expect(getRiskTier(0.9)).toBe("at-risk");
+    expect(getRiskTier(0)).toBe("at-risk");
+  });
+});
+
+// ─── getPositionWarnings ─────────────────────────────────────────────────────
+
+describe("getPositionWarnings", () => {
+  it("returns empty array when projectedHF is null", () => {
+    expect(getPositionWarnings(null, 2.0)).toEqual([]);
+  });
+
+  it("returns a 'block' warning when projected HF < 1.0", () => {
+    const warnings = getPositionWarnings(0.8, 2.0);
+    expect(warnings.some((w) => w.severity === "block")).toBe(true);
+  });
+
+  it("returns a 'warn' when projected HF is between 1.0 and 1.2", () => {
+    const warnings = getPositionWarnings(1.1, 2.0);
+    expect(warnings.some((w) => w.severity === "warn")).toBe(true);
+  });
+
+  it("returns no warnings for a safe-to-safe transition", () => {
+    const warnings = getPositionWarnings(2.0, 2.0);
+    expect(warnings).toEqual([]);
+  });
+
+  it("includes tier transition warning when dropping from safe to caution", () => {
+    const warnings = getPositionWarnings(1.3, 2.0);
+    expect(
+      warnings.some((w) => w.severity === "warn" && w.message.includes("Safe"))
+    ).toBe(true);
+  });
+});

--- a/apps/web-app/src/features/borrowing/utils/liquidationPrice.ts
+++ b/apps/web-app/src/features/borrowing/utils/liquidationPrice.ts
@@ -1,0 +1,141 @@
+/**
+ * Liquidation-price & projected-position math.
+ *
+ * All functions are **pure** — no hooks, no network calls.
+ * They mirror the on-chain health-factor formula:
+ *
+ *   Health Factor = (Collateral Value × Collateral Factor%) / Debt Value
+ *
+ * The Neko lending contract stores HF as a u32 with 7-decimal precision
+ * (10_000_000 = 1.0).  We work in plain floats here because the inputs
+ * already arrive as floating-point numbers from the UI layer.
+ *
+ * ---------------------------------------------------------------------------
+ * Liquidation Price (per unit of collateral):
+ *
+ *   Liq Price = Debt Value / (Collateral Amount × Collateral Factor%)
+ *
+ * This is the collateral NAV at which HF = 1.0.  Below this price the
+ * position becomes eligible for liquidation.
+ * ---------------------------------------------------------------------------
+ */
+
+import {
+  HF_SAFE,
+  HF_WARNING,
+  HF_LIQUIDATION,
+  type RiskTier,
+  type PositionWarning,
+} from "../const/riskThresholds";
+
+// ─── Projected Health Factor ─────────────────────────────────────────────────
+
+/**
+ * Calculate projected health factor after a proposed action.
+ *
+ * @param collateralValue     Total collateral value *after* the action.
+ * @param debtValue           Total debt value *after* the action.
+ * @param collateralFactorPct Collateral factor as a percentage (e.g. 75 → 0.75).
+ * @returns Projected health factor, or `null` when debt is zero (no risk).
+ */
+export function calculateProjectedHealthFactor(
+  collateralValue: number,
+  debtValue: number,
+  collateralFactorPct: number
+): number | null {
+  if (!Number.isFinite(debtValue) || debtValue <= 0) return null;
+  if (!Number.isFinite(collateralValue) || collateralValue <= 0) return 0;
+  if (!Number.isFinite(collateralFactorPct) || collateralFactorPct <= 0)
+    return 0;
+
+  return (collateralValue * (collateralFactorPct / 100)) / debtValue;
+}
+
+// ─── Liquidation Price ───────────────────────────────────────────────────────
+
+/**
+ * Estimate the collateral price (NAV) at which HF drops to exactly 1.0.
+ *
+ * @param collateralAmount    Amount of collateral tokens (not value).
+ * @param debtValue           Total outstanding debt value.
+ * @param collateralFactorPct Collateral factor percentage (e.g. 75).
+ * @returns Price per collateral unit at HF = 1.0, or `null` when
+ *          there is no meaningful position (zero debt or collateral).
+ */
+export function calculateLiquidationPrice(
+  collateralAmount: number,
+  debtValue: number,
+  collateralFactorPct: number
+): number | null {
+  if (!Number.isFinite(debtValue) || debtValue <= 0) return null;
+  if (!Number.isFinite(collateralAmount) || collateralAmount <= 0) return null;
+  if (!Number.isFinite(collateralFactorPct) || collateralFactorPct <= 0)
+    return null;
+
+  return debtValue / (collateralAmount * (collateralFactorPct / 100));
+}
+
+// ─── Risk Tier ───────────────────────────────────────────────────────────────
+
+/**
+ * Map a health factor value to a risk tier label.
+ */
+export function getRiskTier(healthFactor: number | null): RiskTier {
+  if (healthFactor === null) return "unknown";
+  if (healthFactor >= HF_SAFE) return "safe";
+  if (healthFactor >= HF_LIQUIDATION) return "caution";
+  return "at-risk";
+}
+
+// ─── Warnings ────────────────────────────────────────────────────────────────
+
+/**
+ * Generate user-facing warnings based on the projected health factor.
+ *
+ * - **block** when projected HF < 1.0 (position would be liquidatable).
+ * - **warn**  when projected HF is between 1.0 and 1.2 (close to danger).
+ * - **warn**  when the action causes a tier downgrade (e.g. Safe → Caution).
+ */
+export function getPositionWarnings(
+  projectedHF: number | null,
+  currentHF: number | null
+): PositionWarning[] {
+  const warnings: PositionWarning[] = [];
+
+  if (projectedHF === null) return warnings;
+
+  if (projectedHF < HF_LIQUIDATION) {
+    warnings.push({
+      severity: "block",
+      message:
+        "This action would drop your health factor below 1.0, making your position liquidatable. Reduce the amount or add more collateral.",
+    });
+  } else if (projectedHF < HF_WARNING) {
+    warnings.push({
+      severity: "warn",
+      message: `Projected health factor (${projectedHF.toFixed(2)}) is close to the liquidation threshold. Proceed with caution.`,
+    });
+  }
+
+  // Tier-transition warning
+  if (currentHF !== null && projectedHF !== null) {
+    const currentTier = getRiskTier(currentHF);
+    const projectedTier = getRiskTier(projectedHF);
+    if (
+      currentTier === "safe" &&
+      (projectedTier === "caution" || projectedTier === "at-risk")
+    ) {
+      warnings.push({
+        severity: "warn",
+        message: `This action moves your position from Safe to ${projectedTier === "caution" ? "Caution" : "At Risk"}.`,
+      });
+    } else if (currentTier === "caution" && projectedTier === "at-risk") {
+      warnings.push({
+        severity: "warn",
+        message: "This action moves your position from Caution to At Risk.",
+      });
+    }
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
Adds a pre-transaction position simulator to BorrowModal, RepayModal, and RemoveCollateralModal so users see projected health factor, liquidation price, and risk tier before signing. Submit is blocked when projected HF < 1.0 and warned between 1.0–1.2. Centralizes health factor thresholds into a single constants file. Includes unit tests for all math utilities.

Closes #247 