### PR TITLE
refactor: remove as any casts around signTransaction in Soroban hooks

### DIFF
--- a/apps/web-app/src/features/backstop/hooks/useBackstop.ts
+++ b/apps/web-app/src/features/backstop/hooks/useBackstop.ts
@@ -109,7 +109,7 @@ export function useBackstop(contractId: string) {
         });
 
         const depositXdr = await depositToBackstop(amount, address, contractId);
-        const signedDeposit = await signTransaction(depositXdr as any, {
+        const signedDeposit = await signTransaction(depositXdr, {
           networkPassphrase: passphrase,
           address,
         });
@@ -155,7 +155,7 @@ export function useBackstop(contractId: string) {
           address,
           contractId
         );
-        const signed = await signTransaction(xdr as any, {
+        const signed = await signTransaction(xdr, {
           networkPassphrase: passphrase,
           address,
         });
@@ -199,7 +199,7 @@ export function useBackstop(contractId: string) {
         });
 
         const xdr = await withdrawFromBackstop(amount, address, contractId);
-        const signed = await signTransaction(xdr as any, {
+        const signed = await signTransaction(xdr, {
           networkPassphrase: passphrase,
           address,
         });

--- a/apps/web-app/src/features/lending/hooks/useLend.ts
+++ b/apps/web-app/src/features/lending/hooks/useLend.ts
@@ -229,7 +229,7 @@ export function useLend() {
             lendingContractId
           );
 
-          const signedDeposit = await signTransaction(depositXdr as any, {
+          const signedDeposit = await signTransaction(depositXdr, {
             networkPassphrase: passphrase,
             address,
           });
@@ -249,7 +249,7 @@ export function useLend() {
             lendingContractId
           );
 
-          const signedWithdraw = await signTransaction(withdrawXdr as any, {
+          const signedWithdraw = await signTransaction(withdrawXdr, {
             networkPassphrase: passphrase,
             address,
           });

--- a/apps/web-app/src/features/vault/hooks/useVaultData.ts
+++ b/apps/web-app/src/features/vault/hooks/useVaultData.ts
@@ -24,17 +24,15 @@ function formatTvl(stroops: bigint): string {
 /** Safely extracts the value from a stellar SDK Result<T> or a raw value. */
 function unwrapResult<T>(result: unknown, fallback: T): T {
   if (result === null || result === undefined) return fallback;
-  // Ok/Err objects from @stellar/stellar-sdk/contract
-  if (typeof (result as any).unwrap === "function") {
+  const obj = result as Record<string, unknown>;
+  if (typeof obj.unwrap === "function") {
     try {
-      return (result as any).unwrap() as T;
+      return (obj.unwrap as () => T)();
     } catch {
       return fallback;
     }
   }
-  // Some SDK versions expose .value directly on Ok
-  if ((result as any).tag === "ok") return (result as any).value as T;
-  // Already a raw value (e.g. i128 methods)
+  if (obj.tag === "ok") return obj.value as T;
   return result as T;
 }
 


### PR DESCRIPTION
## Summary

Several Soroban signing hooks cast the unsigned transaction XDR to `any` when calling `signTransaction(...)`, silently disabling type-checking at the exact boundary where a wrong type would cause a runtime failure. These casts are entirely unnecessary — both the XDR-builder helpers and `signTransaction` already agree on `string`.

## Changes

### `apps/web-app/src/features/lending/hooks/useLend.ts`
- **Line 232**: `signTransaction(depositXdr as any, ...)` -> `signTransaction(depositXdr, ...)`
- **Line 252**: `signTransaction(withdrawXdr as any, ...)` -> `signTransaction(withdrawXdr, ...)`

### `apps/web-app/src/features/backstop/hooks/useBackstop.ts`
- **Line 112**: `signTransaction(depositXdr as any, ...)` -> `signTransaction(depositXdr, ...)`
- **Line 158**: `signTransaction(xdr as any, ...)` -> `signTransaction(xdr, ...)`
- **Line 202**: `signTransaction(xdr as any, ...)` -> `signTransaction(xdr, ...)`

### `apps/web-app/src/features/vault/hooks/useVaultData.ts`
- Replaced `as any` casts in `unwrapResult` with `as Record<string, unknown>` and `as () => T` for tighter type safety.

## Why these casts were safe to remove

| Helper | Return type | signTransaction param type |
|---|---|---|
| depositToPool | Promise\<string\> (via preparedTx.toXDR()) | xdr: string |
| withdrawFromPool | Promise\<string\> | xdr: string |
| depositToBackstop | Promise\<string\> | xdr: string |
| initiateBackstopWithdrawal | Promise\<string\> | xdr: string |
| withdrawFromBackstop | Promise\<string\> | xdr: string |

All helpers return `Promise<string>`, which directly satisfies `signTransaction`'s parameter type. The `as any` was redundant.

## Verification
- `tsc --noEmit` — no new errors (pre-existing errors in Swap.tsx unrelated)
- `npm run lint` — only pre-existing warnings in the affected files (unused imports, missing hook deps)
- No `as any` casts remain around any `signTransaction` call in the codebase

# Closes #242
