### PR TITLE
fix: add missing AmountInput import in BackstopActionPanel

### DIFF
--- a/apps/web-app/src/features/backstop/components/ui/BackstopActionPanel.tsx
+++ b/apps/web-app/src/features/backstop/components/ui/BackstopActionPanel.tsx
@@ -1,3 +1,4 @@
+import { AmountInput } from "@/components/AmountInput";
 "use client";
 
 import { useState } from "react";


### PR DESCRIPTION
## Description
Added missing import for `AmountInput` in BackstopActionPanel.tsx to fix crash in deposit and withdraw tabs.

## Changes
- Added `import { AmountInput } from "@/components/AmountInput";`

## Related Issue
Closes #236

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [x] Uses Lucide icons consistently (N/A)
- [x] Responsive design implemented (N/A)
- [x] Starknet best practices followed (N/A)