### PR TITLE
Closes: #240 a11y Add proper tab semantics (role/aria-selected) to tab components

### DIFF
--- a/apps/web-app/src/features/on-off-ramps/components/pages/OnOffRamps.tsx
+++ b/apps/web-app/src/features/on-off-ramps/components/pages/OnOffRamps.tsx
@@ -286,6 +286,13 @@ const OnOffRamps: React.FC = () => {
           disabled={isLoadingTx || isPollingTx}
         />
 
+        <div
+          id={isOnRamp ? "on-ramp-panel" : "off-ramp-panel"}
+          role="tabpanel"
+          aria-labelledby={isOnRamp ? "on-ramp-tab" : "off-ramp-tab"}
+          tabIndex={0}
+          className="flex flex-col gap-4"
+        >
         {/* KYC Banner */}
         {address && customerId && (
           <KycBanner
@@ -423,6 +430,13 @@ const OnOffRamps: React.FC = () => {
             </button>
           </>
         )}
+        </div>
+        <div
+          id={isOnRamp ? "off-ramp-panel" : "on-ramp-panel"}
+          role="tabpanel"
+          aria-labelledby={isOnRamp ? "off-ramp-tab" : "on-ramp-tab"}
+          hidden
+        />
       </div>
     </PageContainer>
   );

--- a/apps/web-app/src/features/on-off-ramps/components/ui/RampDirectionTabs.tsx
+++ b/apps/web-app/src/features/on-off-ramps/components/ui/RampDirectionTabs.tsx
@@ -5,6 +5,16 @@ import type { RampDirection } from "../../types/ramp";
 import type { AnchorProvider } from "@/lib/anchors/types";
 import { RAMP_PROVIDERS } from "../../constants/ramp.config";
 
+const RAMP_TAB_IDS: Record<RampDirection, string> = {
+  on: "on-ramp-tab",
+  off: "off-ramp-tab",
+};
+
+const RAMP_PANEL_IDS: Record<RampDirection, string> = {
+  on: "on-ramp-panel",
+  off: "off-ramp-panel",
+};
+
 interface RampDirectionTabsProps {
   direction: RampDirection;
   provider: AnchorProvider;
@@ -20,10 +30,51 @@ export const RampDirectionTabs: React.FC<RampDirectionTabsProps> = ({
 }) => {
   const config = RAMP_PROVIDERS[provider];
 
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    tab: RampDirection
+  ) => {
+    if (disabled) return;
+
+    const tabs: RampDirection[] = ["on", "off"];
+    const currentIndex = tabs.indexOf(tab);
+    let nextTab: RampDirection | undefined;
+
+    if (event.key === "ArrowRight") {
+      nextTab = tabs[(currentIndex + 1) % tabs.length];
+    } else if (event.key === "ArrowLeft") {
+      nextTab = tabs[(currentIndex - 1 + tabs.length) % tabs.length];
+    } else if (event.key === "Home") {
+      nextTab = tabs[0];
+    } else if (event.key === "End") {
+      nextTab = tabs[tabs.length - 1];
+    }
+
+    if (!nextTab) return;
+
+    event.preventDefault();
+    onChange(nextTab);
+    requestAnimationFrame(() =>
+      document.getElementById(RAMP_TAB_IDS[nextTab])?.focus()
+    );
+  };
+
   return (
-    <div className="flex bg-[#2A2A2A] rounded-xl p-1 gap-1">
+    <div
+      role="tablist"
+      aria-label="Ramp direction"
+      className="flex bg-[#2A2A2A] rounded-xl p-1 gap-1"
+    >
       <button
+        id={RAMP_TAB_IDS.on}
+        type="button"
+        role="tab"
+        aria-selected={direction === "on"}
+        aria-controls={RAMP_PANEL_IDS.on}
+        aria-disabled={disabled}
+        tabIndex={direction === "on" ? 0 : -1}
         onClick={() => onChange("on")}
+        onKeyDown={(event) => handleKeyDown(event, "on")}
         disabled={disabled}
         className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 ${
           direction === "on"
@@ -37,7 +88,15 @@ export const RampDirectionTabs: React.FC<RampDirectionTabsProps> = ({
         </span>
       </button>
       <button
+        id={RAMP_TAB_IDS.off}
+        type="button"
+        role="tab"
+        aria-selected={direction === "off"}
+        aria-controls={RAMP_PANEL_IDS.off}
+        aria-disabled={disabled}
+        tabIndex={direction === "off" ? 0 : -1}
         onClick={() => onChange("off")}
+        onKeyDown={(event) => handleKeyDown(event, "off")}
         disabled={disabled}
         className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 ${
           direction === "off"

--- a/apps/web-app/src/features/vault/components/pages/Vault.tsx
+++ b/apps/web-app/src/features/vault/components/pages/Vault.tsx
@@ -65,14 +65,44 @@ const Vault: React.FC = () => {
       </div>
 
       {activeTab === "vaults" ? (
-        <VaultGrid
-          vaults={vaults}
-          isLoading={isLoading}
-          onDetailsClick={setSelectedVault}
-          onDepositClick={openDepositModal}
-        />
+        <>
+          <div
+            id="vaults-panel"
+            role="tabpanel"
+            aria-labelledby="vaults-tab"
+            tabIndex={0}
+          >
+            <VaultGrid
+              vaults={vaults}
+              isLoading={isLoading}
+              onDetailsClick={setSelectedVault}
+              onDepositClick={openDepositModal}
+            />
+          </div>
+          <div
+            id="vault-positions-panel"
+            role="tabpanel"
+            aria-labelledby="vault-positions-tab"
+            hidden
+          />
+        </>
       ) : (
-        <MyVaultPositions />
+        <>
+          <div
+            id="vaults-panel"
+            role="tabpanel"
+            aria-labelledby="vaults-tab"
+            hidden
+          />
+          <div
+            id="vault-positions-panel"
+            role="tabpanel"
+            aria-labelledby="vault-positions-tab"
+            tabIndex={0}
+          >
+            <MyVaultPositions />
+          </div>
+        </>
       )}
 
       {selectedVault && (

--- a/apps/web-app/src/features/vault/components/ui/VaultTabs.tsx
+++ b/apps/web-app/src/features/vault/components/ui/VaultTabs.tsx
@@ -4,6 +4,16 @@ import React from "react";
 
 export type VaultTabKey = "vaults" | "positions";
 
+const VAULT_TAB_IDS: Record<VaultTabKey, string> = {
+  vaults: "vaults-tab",
+  positions: "vault-positions-tab",
+};
+
+const VAULT_PANEL_IDS: Record<VaultTabKey, string> = {
+  vaults: "vaults-panel",
+  positions: "vault-positions-panel",
+};
+
 interface VaultTabsProps {
   activeTab: VaultTabKey;
   onChange: (tab: VaultTabKey) => void;
@@ -13,10 +23,48 @@ export const VaultTabs: React.FC<VaultTabsProps> = ({
   activeTab,
   onChange,
 }) => {
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    tab: VaultTabKey
+  ) => {
+    const tabs: VaultTabKey[] = ["vaults", "positions"];
+    const currentIndex = tabs.indexOf(tab);
+    let nextTab: VaultTabKey | undefined;
+
+    if (event.key === "ArrowRight") {
+      nextTab = tabs[(currentIndex + 1) % tabs.length];
+    } else if (event.key === "ArrowLeft") {
+      nextTab = tabs[(currentIndex - 1 + tabs.length) % tabs.length];
+    } else if (event.key === "Home") {
+      nextTab = tabs[0];
+    } else if (event.key === "End") {
+      nextTab = tabs[tabs.length - 1];
+    }
+
+    if (!nextTab) return;
+
+    event.preventDefault();
+    onChange(nextTab);
+    requestAnimationFrame(() =>
+      document.getElementById(VAULT_TAB_IDS[nextTab])?.focus()
+    );
+  };
+
   return (
-    <div className="flex bg-[#2A2A2A] rounded-xl p-1 gap-1 w-fit">
+    <div
+      role="tablist"
+      aria-label="Vault views"
+      className="flex bg-[#2A2A2A] rounded-xl p-1 gap-1 w-fit"
+    >
       <button
+        id={VAULT_TAB_IDS.vaults}
+        type="button"
+        role="tab"
+        aria-selected={activeTab === "vaults"}
+        aria-controls={VAULT_PANEL_IDS.vaults}
+        tabIndex={activeTab === "vaults" ? 0 : -1}
         onClick={() => onChange("vaults")}
+        onKeyDown={(event) => handleKeyDown(event, "vaults")}
         className={`py-2 px-5 rounded-lg text-sm font-medium transition-colors ${
           activeTab === "vaults"
             ? "bg-[#229EDF] text-white"
@@ -26,7 +74,14 @@ export const VaultTabs: React.FC<VaultTabsProps> = ({
         Vaults
       </button>
       <button
+        id={VAULT_TAB_IDS.positions}
+        type="button"
+        role="tab"
+        aria-selected={activeTab === "positions"}
+        aria-controls={VAULT_PANEL_IDS.positions}
+        tabIndex={activeTab === "positions" ? 0 : -1}
         onClick={() => onChange("positions")}
+        onKeyDown={(event) => handleKeyDown(event, "positions")}
         className={`py-2 px-5 rounded-lg text-sm font-medium transition-colors ${
           activeTab === "positions"
             ? "bg-[#229EDF] text-white"


### PR DESCRIPTION
Closes #240 
The staged static check passes, and the ARIA scan shows both the active and hidden inactive panels are present. I’m committing now