### PR TITLE
test(web-app): cover fund-moving execution flows (#255)

### DIFF
--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -51,8 +51,11 @@
     "zustand": "^5.0.2"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/lodash": "^4.14.202",
     "@vitest/coverage-v8": "^4.1.9",
+    "jsdom": "^25.0.1",
     "vitest": "^4.1.9"
   }
 }

--- a/apps/web-app/src/features/borrowing/hooks/__tests__/useBorrowExecution.test.ts
+++ b/apps/web-app/src/features/borrowing/hooks/__tests__/useBorrowExecution.test.ts
@@ -1,0 +1,314 @@
+// @vitest-environment jsdom
+/**
+ * Tests for useBorrowExecution — the hook that assembles and submits the
+ * two-step Soroban borrow flow (add collateral, then borrow) (issue #255).
+ *
+ * The wallet, toast, RPC helpers, token registry and contract-error decoder
+ * are all mocked so the test exercises the hook's own control flow: input and
+ * guard validation, the two-step build → sign → send happy path (which signs
+ * and sends twice), and error surfacing.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const { addNotification, signTransaction, walletState, availableTokens } =
+  vi.hoisted(() => {
+    const addNotification = vi.fn();
+    const signTransaction = vi.fn();
+    return {
+      addNotification,
+      signTransaction,
+      walletState: {
+        address: "GTEST_ADDRESS" as string | undefined,
+        signTransaction,
+        networkPassphrase: "Test SDF Network ; September 2015",
+      },
+      availableTokens: {
+        current: {
+          XLM: { contract: "CXLM_CONTRACT", decimals: 7 },
+        } as Record<string, { contract: string; decimals: number }>,
+      },
+    };
+  });
+
+vi.mock("@/hooks/useToast", () => ({
+  useToast: () => ({ addNotification }),
+}));
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => walletState,
+}));
+vi.mock("@/lib/helpers/stellar/lending", () => ({
+  addCollateral: vi.fn(),
+  borrowFromPool: vi.fn(),
+}));
+vi.mock("@/lib/helpers/stellar/transaction", () => ({
+  signAndSendTransaction: vi.fn(),
+}));
+vi.mock("@/lib/helpers/stellar/soroswap", () => ({
+  getAvailableTokens: () => availableTokens.current,
+}));
+vi.mock("@/lib/helpers/stellar/contractErrors", () => ({
+  extractContractErrorOrNull: vi.fn(),
+}));
+
+import { useBorrowExecution } from "../useBorrowExecution";
+import { addCollateral, borrowFromPool } from "@/lib/helpers/stellar/lending";
+import { signAndSendTransaction } from "@/lib/helpers/stellar/transaction";
+import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors";
+import type { BorrowExecutionParams } from "../types/borrowing";
+
+const addCollateralMock = vi.mocked(addCollateral);
+const borrowFromPoolMock = vi.mocked(borrowFromPool);
+const signAndSendMock = vi.mocked(signAndSendTransaction);
+const extractErrorMock = vi.mocked(extractContractErrorOrNull);
+
+const validParams: BorrowExecutionParams = {
+  collateralTokenCode: "XLM",
+  assetCode: "USDC",
+  collateralAmount: "100",
+  borrowAmount: "50",
+  contractId: "CCONTRACT_ID",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  walletState.address = "GTEST_ADDRESS";
+  availableTokens.current = {
+    XLM: { contract: "CXLM_CONTRACT", decimals: 7 },
+  };
+  addCollateralMock.mockResolvedValue("ADD_COLLATERAL_XDR");
+  borrowFromPoolMock.mockResolvedValue("BORROW_XDR");
+  signAndSendMock.mockResolvedValue({ hash: "HASH", status: "SUCCESS" });
+});
+
+describe("useBorrowExecution – guards", () => {
+  it("errors and builds nothing when the wallet is disconnected", async () => {
+    walletState.address = undefined;
+    const { result } = renderHook(() => useBorrowExecution());
+
+    await act(async () => {
+      await result.current.handleBorrow(validParams);
+    });
+
+    expect(addCollateralMock).not.toHaveBeenCalled();
+    expect(borrowFromPoolMock).not.toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({
+        description: "Please connect your wallet first",
+      })
+    );
+  });
+
+  it("errors when the collateral amount is zero or invalid", async () => {
+    const { result } = renderHook(() => useBorrowExecution());
+
+    await act(async () => {
+      await result.current.handleBorrow({
+        ...validParams,
+        collateralAmount: "0",
+      });
+    });
+
+    expect(addCollateralMock).not.toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({
+        description: "Please enter valid collateral and borrow amounts",
+      })
+    );
+  });
+
+  it("errors when the borrow amount is not a finite positive number", async () => {
+    const { result } = renderHook(() => useBorrowExecution());
+
+    await act(async () => {
+      await result.current.handleBorrow({
+        ...validParams,
+        borrowAmount: "abc",
+      });
+    });
+
+    expect(addCollateralMock).not.toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({
+        description: "Please enter valid collateral and borrow amounts",
+      })
+    );
+  });
+
+  it("errors when the collateral token is not in the registry", async () => {
+    availableTokens.current = {};
+    const { result } = renderHook(() => useBorrowExecution());
+
+    await act(async () => {
+      await result.current.handleBorrow(validParams);
+    });
+
+    expect(addCollateralMock).not.toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({
+        description: "Collateral token XLM not found",
+      })
+    );
+  });
+
+  it("exposes wallet-connected state", () => {
+    const { result } = renderHook(() => useBorrowExecution());
+    expect(result.current.isWalletConnected).toBe(true);
+  });
+});
+
+describe("useBorrowExecution – happy path", () => {
+  it("builds both XDRs with the right args and signs/sends twice", async () => {
+    const { result } = renderHook(() => useBorrowExecution());
+
+    let outcome;
+    await act(async () => {
+      outcome = await result.current.handleBorrow(validParams);
+    });
+
+    expect(addCollateralMock).toHaveBeenCalledWith(
+      "CXLM_CONTRACT",
+      "100",
+      7,
+      "GTEST_ADDRESS",
+      "CCONTRACT_ID"
+    );
+    expect(borrowFromPoolMock).toHaveBeenCalledWith(
+      "USDC",
+      "50",
+      7,
+      "GTEST_ADDRESS",
+      "CCONTRACT_ID"
+    );
+
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+    expect(signAndSendMock).toHaveBeenNthCalledWith(
+      1,
+      "ADD_COLLATERAL_XDR",
+      signTransaction,
+      expect.objectContaining({
+        address: "GTEST_ADDRESS",
+        waitForPending: true,
+      })
+    );
+    expect(signAndSendMock).toHaveBeenNthCalledWith(
+      2,
+      "BORROW_XDR",
+      signTransaction,
+      expect.objectContaining({
+        address: "GTEST_ADDRESS",
+        waitForPending: true,
+      })
+    );
+
+    expect(outcome).toEqual({ success: true });
+    expect(addNotification).toHaveBeenCalledWith(
+      "Success",
+      "success",
+      expect.objectContaining({ description: "Successfully borrowed 50 USDC" })
+    );
+  });
+
+  it("honors explicit collateral and borrow decimals from params", async () => {
+    const { result } = renderHook(() => useBorrowExecution());
+
+    await act(async () => {
+      await result.current.handleBorrow({
+        ...validParams,
+        collateralDecimals: 6,
+        borrowDecimals: 18,
+      });
+    });
+
+    expect(addCollateralMock).toHaveBeenCalledWith(
+      "CXLM_CONTRACT",
+      "100",
+      6,
+      "GTEST_ADDRESS",
+      "CCONTRACT_ID"
+    );
+    expect(borrowFromPoolMock).toHaveBeenCalledWith(
+      "USDC",
+      "50",
+      18,
+      "GTEST_ADDRESS",
+      "CCONTRACT_ID"
+    );
+  });
+
+  it("toggles isLoading back to false after completion", async () => {
+    const { result } = renderHook(() => useBorrowExecution());
+    await act(async () => {
+      await result.current.handleBorrow(validParams);
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+});
+
+describe("useBorrowExecution – error handling", () => {
+  it("does not borrow when the collateral submission fails", async () => {
+    signAndSendMock.mockRejectedValueOnce(new Error("boom"));
+    extractErrorMock.mockReturnValue("Insufficient balance");
+
+    const { result } = renderHook(() => useBorrowExecution());
+
+    let outcome;
+    await act(async () => {
+      outcome = await result.current.handleBorrow(validParams);
+    });
+
+    expect(borrowFromPoolMock).not.toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({ description: "Insufficient balance" })
+    );
+    expect(outcome).toMatchObject({ success: false });
+  });
+
+  it("surfaces a decoded contract error when a submission fails", async () => {
+    signAndSendMock.mockRejectedValue(new Error("boom"));
+    extractErrorMock.mockReturnValue("Pool is frozen");
+
+    const { result } = renderHook(() => useBorrowExecution());
+
+    let outcome;
+    await act(async () => {
+      outcome = await result.current.handleBorrow(validParams);
+    });
+
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({ description: "Pool is frozen" })
+    );
+    expect(outcome).toMatchObject({ success: false });
+  });
+
+  it("falls back to a generic message when the error is not decodable", async () => {
+    signAndSendMock.mockRejectedValue(new Error("boom"));
+    extractErrorMock.mockReturnValue(null);
+
+    const { result } = renderHook(() => useBorrowExecution());
+
+    await act(async () => {
+      await result.current.handleBorrow(validParams);
+    });
+
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({
+        description: "An unexpected error occurred. Please try again.",
+      })
+    );
+  });
+});

--- a/apps/web-app/src/features/borrowing/hooks/__tests__/useRepay.test.ts
+++ b/apps/web-app/src/features/borrowing/hooks/__tests__/useRepay.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+/**
+ * Tests for useRepay — the hook that assembles and submits the Soroban
+ * repayment transaction (issue #255).
+ *
+ * The wallet, toast, RPC helpers and contract-error decoder are all mocked so
+ * the test exercises the hook's own control flow: input validation, the
+ * build → sign → send happy path, and error surfacing.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const { addNotification, signTransaction, walletState } = vi.hoisted(() => {
+  const addNotification = vi.fn();
+  const signTransaction = vi.fn();
+  return {
+    addNotification,
+    signTransaction,
+    walletState: {
+      address: "GTEST_ADDRESS" as string | undefined,
+      signTransaction,
+      networkPassphrase: "Test SDF Network ; September 2015",
+    },
+  };
+});
+
+vi.mock("@/hooks/useToast", () => ({
+  useToast: () => ({ addNotification }),
+}));
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => walletState,
+}));
+vi.mock("@/lib/helpers/stellar/lending", () => ({
+  repayPool: vi.fn(),
+}));
+vi.mock("@/lib/helpers/stellar/transaction", () => ({
+  signAndSendTransaction: vi.fn(),
+}));
+vi.mock("@/lib/helpers/stellar/contractErrors", () => ({
+  extractContractErrorOrNull: vi.fn(),
+}));
+
+import { useRepay } from "../useRepay";
+import { repayPool } from "@/lib/helpers/stellar/lending";
+import { signAndSendTransaction } from "@/lib/helpers/stellar/transaction";
+import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors";
+
+const repayPoolMock = vi.mocked(repayPool);
+const signAndSendMock = vi.mocked(signAndSendTransaction);
+const extractErrorMock = vi.mocked(extractContractErrorOrNull);
+
+const validParams = {
+  assetCode: "USDC",
+  dTokens: 1_000_0000n,
+  contractId: "CCONTRACT_ID",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  walletState.address = "GTEST_ADDRESS";
+  repayPoolMock.mockResolvedValue("REPAY_XDR");
+  signAndSendMock.mockResolvedValue({ hash: "HASH", status: "SUCCESS" });
+});
+
+describe("useRepay – guards", () => {
+  it("errors and does not build a tx when the wallet is disconnected", async () => {
+    walletState.address = undefined;
+    const { result } = renderHook(() => useRepay());
+
+    await act(async () => {
+      await result.current.handleRepay(validParams);
+    });
+
+    expect(repayPoolMock).not.toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({
+        description: "Please connect your wallet first",
+      })
+    );
+  });
+
+  it("errors when there is no debt to repay (dTokens <= 0)", async () => {
+    const { result } = renderHook(() => useRepay());
+
+    await act(async () => {
+      await result.current.handleRepay({ ...validParams, dTokens: 0n });
+    });
+
+    expect(repayPoolMock).not.toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({ description: "No debt to repay" })
+    );
+  });
+
+  it("exposes wallet-connected state", () => {
+    const { result } = renderHook(() => useRepay());
+    expect(result.current.isWalletConnected).toBe(true);
+  });
+});
+
+describe("useRepay – happy path", () => {
+  it("builds the repay XDR with the raw dToken amount and submits it", async () => {
+    const { result } = renderHook(() => useRepay());
+
+    let outcome;
+    await act(async () => {
+      outcome = await result.current.handleRepay(validParams);
+    });
+
+    expect(repayPoolMock).toHaveBeenCalledWith(
+      "USDC",
+      1_000_0000n,
+      "GTEST_ADDRESS",
+      "CCONTRACT_ID"
+    );
+    expect(signAndSendMock).toHaveBeenCalledWith(
+      "REPAY_XDR",
+      signTransaction,
+      expect.objectContaining({
+        address: "GTEST_ADDRESS",
+        waitForPending: true,
+      })
+    );
+    expect(outcome).toEqual({ success: true });
+    expect(addNotification).toHaveBeenCalledWith(
+      "Repayment Successful",
+      "success",
+      expect.anything()
+    );
+  });
+
+  it("toggles isLoading back to false after completion", async () => {
+    const { result } = renderHook(() => useRepay());
+    await act(async () => {
+      await result.current.handleRepay(validParams);
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+});
+
+describe("useRepay – error handling", () => {
+  it("surfaces a decoded contract error when the submission fails", async () => {
+    signAndSendMock.mockRejectedValue(new Error("boom"));
+    extractErrorMock.mockReturnValue("Pool is frozen");
+
+    const { result } = renderHook(() => useRepay());
+
+    let outcome;
+    await act(async () => {
+      outcome = await result.current.handleRepay(validParams);
+    });
+
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({ description: "Pool is frozen" })
+    );
+    expect(outcome).toMatchObject({ success: false });
+  });
+
+  it("falls back to a generic message when the error is not decodable", async () => {
+    signAndSendMock.mockRejectedValue(new Error("boom"));
+    extractErrorMock.mockReturnValue(null);
+
+    const { result } = renderHook(() => useRepay());
+
+    await act(async () => {
+      await result.current.handleRepay(validParams);
+    });
+
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({
+        description: "An unexpected error occurred. Please try again.",
+      })
+    );
+  });
+});

--- a/apps/web-app/src/features/lending/hooks/__tests__/useLend.test.ts
+++ b/apps/web-app/src/features/lending/hooks/__tests__/useLend.test.ts
@@ -1,0 +1,323 @@
+// @vitest-environment jsdom
+/**
+ * Tests for useLend — the hook that drives lending-pool deposits and
+ * withdrawals (issue #255).
+ *
+ * The composed react-query hooks (useLendingPools, usePools, usePoolAction),
+ * the wallet/toast context, and all Soroban helpers (deposit/withdraw, token
+ * lookup, RPC send, tx confirmation) are mocked so the test exercises only the
+ * hook's own control flow: the derived `pools` memo, the handleConfirm guards,
+ * and the three fund-moving execution paths (aggregated deposit, Neko deposit,
+ * Neko withdraw).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { PoolData } from "../types/lending";
+
+const {
+  addNotification,
+  signTransaction,
+  walletState,
+  executePoolActionMock,
+  refetchPoolsMock,
+  lendingPoolsFixture,
+} = vi.hoisted(() => {
+  const addNotification = vi.fn();
+  const signTransaction = vi.fn();
+  return {
+    addNotification,
+    signTransaction,
+    executePoolActionMock: vi.fn(),
+    refetchPoolsMock: vi.fn(),
+    lendingPoolsFixture: [
+      {
+        asset: "CASSET",
+        assetCode: "USDC",
+        poolBalance: "1500",
+        poolBalanceUSD: "Calculating...",
+        interestRate: 5.5,
+        bTokenRate: "1.0",
+        isActive: true,
+        contractId: "CPOOL",
+      },
+    ],
+    walletState: {
+      address: "GTEST_ADDRESS" as string | undefined,
+      signTransaction,
+      networkPassphrase: "Test SDF Network ; September 2015",
+    },
+  };
+});
+
+vi.mock("@/hooks/useToast", () => ({
+  useToast: () => ({ addNotification }),
+}));
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => walletState,
+}));
+vi.mock("../useLendingPools", () => ({
+  useLendingPools: () => ({
+    data: lendingPoolsFixture,
+    isLoading: false,
+    error: null,
+    refetch: refetchPoolsMock,
+  }),
+}));
+vi.mock("@/lib/orchestrator", () => ({
+  usePools: () => ({ data: [], isLoading: false, error: null }),
+  usePoolAction: () => ({ mutateAsync: executePoolActionMock }),
+}));
+vi.mock("@/lib/helpers/stellar/lending", () => ({
+  depositToPool: vi.fn(),
+  withdrawFromPool: vi.fn(),
+  getBTokenBalance: vi.fn(),
+}));
+vi.mock("@/lib/helpers/stellar/soroswap", () => ({
+  getAvailableTokens: () => ({ USDC: { contract: "CUSDC", decimals: 7 } }),
+}));
+vi.mock("@/lib/helpers/stellar/waitForTransaction", () => ({
+  waitForTransaction: vi.fn(),
+}));
+vi.mock("@stellar/stellar-sdk", () => ({
+  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+  TransactionBuilder: { fromXDR: vi.fn(() => ({})) },
+  rpc: {
+    Server: class {
+      sendTransaction = vi.fn().mockResolvedValue({ hash: "HASH" });
+    },
+  },
+}));
+
+import { useLend } from "../useLend";
+import {
+  depositToPool,
+  withdrawFromPool,
+  getBTokenBalance,
+} from "@/lib/helpers/stellar/lending";
+import { waitForTransaction } from "@/lib/helpers/stellar/waitForTransaction";
+
+const depositToPoolMock = vi.mocked(depositToPool);
+const withdrawFromPoolMock = vi.mocked(withdrawFromPool);
+const getBTokenBalanceMock = vi.mocked(getBTokenBalance);
+const waitForTransactionMock = vi.mocked(waitForTransaction);
+
+const nekoPool: PoolData = {
+  id: "pool-0",
+  name: "USDC Pool",
+  token1: "USDC",
+  token2: "",
+  fee: "0%",
+  roi: "5.50%",
+  feeApy: "5.50%",
+  liquidity: "$1.50k",
+  isActive: true,
+  assetCode: "USDC",
+  asset: "CASSET",
+  bTokenRate: "1.0",
+  contractId: "CPOOL",
+};
+
+const aggregatedPool: PoolData = {
+  ...nekoPool,
+  id: "agg-orch:1",
+  isAggregated: true,
+  orchestratorId: "orch:1",
+  bTokenRate: undefined,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  walletState.address = "GTEST_ADDRESS";
+  depositToPoolMock.mockResolvedValue("DEPOSIT_XDR");
+  withdrawFromPoolMock.mockResolvedValue("WITHDRAW_XDR");
+  getBTokenBalanceMock.mockResolvedValue("0");
+  waitForTransactionMock.mockResolvedValue(undefined as never);
+  signTransaction.mockResolvedValue({ signedTxXdr: "SIGNED_XDR" });
+  executePoolActionMock.mockResolvedValue(undefined);
+  refetchPoolsMock.mockResolvedValue(undefined);
+});
+
+describe("useLend – derived pools memo", () => {
+  it("maps a lending pool into the PoolData display shape", () => {
+    const { result } = renderHook(() => useLend());
+    expect(result.current.pools).toHaveLength(1);
+    expect(result.current.pools[0]).toMatchObject({
+      id: "pool-0",
+      name: "USDC Pool",
+      token1: "USDC",
+      roi: "5.50%",
+      feeApy: "5.50%",
+      liquidity: "$1.50k",
+      assetCode: "USDC",
+      contractId: "CPOOL",
+      bTokenRate: "1.0",
+    });
+  });
+
+  it("exposes wallet presence via hasWallet", () => {
+    const { result } = renderHook(() => useLend());
+    expect(result.current.hasWallet).toBe(true);
+  });
+});
+
+describe("useLend – handleConfirm guards", () => {
+  it("does nothing when no pool is selected", async () => {
+    const { result } = renderHook(() => useLend());
+    await act(async () => {
+      await result.current.handleConfirm("10");
+    });
+    expect(depositToPoolMock).not.toHaveBeenCalled();
+    expect(executePoolActionMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the wallet is disconnected", async () => {
+    walletState.address = undefined;
+    const { result } = renderHook(() => useLend());
+    act(() => {
+      result.current.openModal(nekoPool, true);
+    });
+    await act(async () => {
+      await result.current.handleConfirm("10");
+    });
+    expect(depositToPoolMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the amount is zero or negative", async () => {
+    const { result } = renderHook(() => useLend());
+    act(() => {
+      result.current.openModal(nekoPool, true);
+    });
+    await act(async () => {
+      await result.current.handleConfirm("0");
+    });
+    expect(depositToPoolMock).not.toHaveBeenCalled();
+    expect(executePoolActionMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useLend – aggregated pool deposit path", () => {
+  it("executes the orchestrator action with the raw bigint amount", async () => {
+    const { result } = renderHook(() => useLend());
+    act(() => {
+      result.current.openModal(aggregatedPool, true);
+    });
+
+    await act(async () => {
+      await result.current.handleConfirm("10");
+    });
+
+    expect(executePoolActionMock).toHaveBeenCalledWith({
+      poolId: "orch:1",
+      action: "deposit",
+      amount: BigInt(Math.floor(parseFloat("10") * 1e7)),
+    });
+    expect(depositToPoolMock).not.toHaveBeenCalled();
+    expect(refetchPoolsMock).toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      "Success",
+      "success",
+      expect.objectContaining({
+        description: "Successfully deposited 10 USDC",
+      })
+    );
+  });
+});
+
+describe("useLend – Neko deposit path", () => {
+  it("builds, signs, submits and confirms the deposit transaction", async () => {
+    const { result } = renderHook(() => useLend());
+    act(() => {
+      result.current.openModal(nekoPool, true);
+    });
+
+    await act(async () => {
+      await result.current.handleConfirm("10");
+    });
+
+    expect(depositToPoolMock).toHaveBeenCalledWith(
+      "USDC",
+      "10",
+      7,
+      "GTEST_ADDRESS",
+      "CPOOL"
+    );
+    expect(signTransaction).toHaveBeenCalledWith(
+      "DEPOSIT_XDR",
+      expect.objectContaining({ address: "GTEST_ADDRESS" })
+    );
+    expect(waitForTransactionMock).toHaveBeenCalledWith(
+      "HASH",
+      expect.anything()
+    );
+    expect(addNotification).toHaveBeenCalledWith(
+      "Success",
+      "success",
+      expect.objectContaining({
+        description: "Successfully deposited 10 USDC",
+      })
+    );
+  });
+});
+
+describe("useLend – Neko withdraw path", () => {
+  it("builds and submits the withdraw transaction", async () => {
+    const { result } = renderHook(() => useLend());
+    act(() => {
+      result.current.openModal(nekoPool, false);
+    });
+
+    await act(async () => {
+      await result.current.handleConfirm("10");
+    });
+
+    expect(withdrawFromPoolMock).toHaveBeenCalledWith(
+      "USDC",
+      expect.any(String),
+      7,
+      "GTEST_ADDRESS",
+      "CPOOL"
+    );
+    expect(waitForTransactionMock).toHaveBeenCalledWith(
+      "HASH",
+      expect.anything()
+    );
+    expect(addNotification).toHaveBeenCalledWith(
+      "Success",
+      "success",
+      expect.objectContaining({
+        description: "Successfully withdrew 10 USDC",
+      })
+    );
+  });
+
+  it("re-throws when bTokenRate is missing on a withdraw", async () => {
+    const poolWithoutRate: PoolData = { ...nekoPool, bTokenRate: undefined };
+    const { result } = renderHook(() => useLend());
+    act(() => {
+      result.current.openModal(poolWithoutRate, false);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.handleConfirm("10");
+      })
+    ).rejects.toThrow("Unable to calculate bTokens. Please try again.");
+    expect(withdrawFromPoolMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useLend – error propagation", () => {
+  it("re-throws when the deposit helper rejects", async () => {
+    depositToPoolMock.mockRejectedValue(new Error("deposit boom"));
+    const { result } = renderHook(() => useLend());
+    act(() => {
+      result.current.openModal(nekoPool, true);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.handleConfirm("10");
+      })
+    ).rejects.toThrow("deposit boom");
+  });
+});

--- a/apps/web-app/src/features/swap/hooks/__tests__/useSwapExecution.test.ts
+++ b/apps/web-app/src/features/swap/hooks/__tests__/useSwapExecution.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+/**
+ * Tests for useSwapExecution — the hook that turns a swap intent into a signed,
+ * submitted Soroswap transaction (issue #255).
+ *
+ * The Soroswap quote/build/send helpers and the wallet (signTransaction +
+ * networkPassphrase) are mocked so the test exercises the hook's own control
+ * flow: input/guard validation, the quote → build → sign → send happy path
+ * (including the exact QuoteRequest shape), and error surfacing — notably the
+ * USER_REJECTED mapping. Note the hook reads networkPassphrase from the wallet,
+ * not from the params.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const { signTransaction, walletState } = vi.hoisted(() => {
+  const signTransaction = vi.fn();
+  return {
+    signTransaction,
+    walletState: {
+      signTransaction,
+      networkPassphrase: "Test SDF Network ; September 2015" as
+        | string
+        | undefined,
+    },
+  };
+});
+
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => walletState,
+}));
+vi.mock("@/lib/helpers/stellar/soroswap", () => ({
+  getQuote: vi.fn(),
+  buildTransaction: vi.fn(),
+  sendTransaction: vi.fn(),
+}));
+
+import { useSwapExecution } from "../useSwapExecution";
+import {
+  getQuote,
+  buildTransaction,
+  sendTransaction,
+} from "@/lib/helpers/stellar/soroswap";
+
+const getQuoteMock = vi.mocked(getQuote);
+const buildTransactionMock = vi.mocked(buildTransaction);
+const sendTransactionMock = vi.mocked(sendTransaction);
+
+const validParams = {
+  amountIn: "100",
+  tokenIn: "CTOKEN_IN",
+  tokenOut: "CTOKEN_OUT",
+  address: "GTEST_ADDRESS",
+  networkPassphrase: "unused-passphrase-from-params",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  walletState.networkPassphrase = "Test SDF Network ; September 2015";
+  getQuoteMock.mockResolvedValue({ some: "quote" } as never);
+  buildTransactionMock.mockResolvedValue({ xdr: "BUILT_XDR" } as never);
+  signTransaction.mockResolvedValue({ signedTxXdr: "SIGNED_XDR" });
+  sendTransactionMock.mockResolvedValue({ txHash: "TX_HASH" } as never);
+});
+
+describe("useSwapExecution – guards", () => {
+  it("throws on a missing / non-positive amount", async () => {
+    const { result } = renderHook(() => useSwapExecution());
+
+    await expect(
+      result.current.executeSwap({ ...validParams, amountIn: "0" })
+    ).rejects.toThrow("Invalid amount or address");
+    expect(getQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when the address is missing", async () => {
+    const { result } = renderHook(() => useSwapExecution());
+
+    await expect(
+      result.current.executeSwap({ ...validParams, address: undefined })
+    ).rejects.toThrow("Invalid amount or address");
+    expect(getQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when the wallet has no networkPassphrase", async () => {
+    walletState.networkPassphrase = undefined;
+    const { result } = renderHook(() => useSwapExecution());
+
+    await expect(result.current.executeSwap(validParams)).rejects.toThrow(
+      "Wallet not connected"
+    );
+    expect(getQuoteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useSwapExecution – happy path", () => {
+  it("requests a quote with the expected EXACT_IN QuoteRequest", async () => {
+    const { result } = renderHook(() => useSwapExecution());
+
+    await result.current.executeSwap(validParams);
+
+    expect(getQuoteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetIn: "CTOKEN_IN",
+        assetOut: "CTOKEN_OUT",
+        amount: "100",
+        tradeType: "EXACT_IN",
+        protocols: ["soroswap", "phoenix", "aqua"],
+        slippageBps: 500,
+        maxHops: 3,
+      })
+    );
+  });
+
+  it("builds, signs and sends, resolving to the tx hash as orderId", async () => {
+    const { result } = renderHook(() => useSwapExecution());
+
+    const outcome = await result.current.executeSwap(validParams);
+
+    expect(buildTransactionMock).toHaveBeenCalledWith({
+      quote: { some: "quote" },
+      from: "GTEST_ADDRESS",
+      to: "GTEST_ADDRESS",
+    });
+    expect(signTransaction).toHaveBeenCalledWith(
+      "BUILT_XDR",
+      expect.objectContaining({
+        networkPassphrase: "Test SDF Network ; September 2015",
+        address: "GTEST_ADDRESS",
+      })
+    );
+    expect(sendTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ xdr: "SIGNED_XDR", launchtube: false })
+    );
+    expect(outcome).toEqual({ orderId: "TX_HASH", txHash: "TX_HASH" });
+  });
+});
+
+describe("useSwapExecution – error handling", () => {
+  it("throws when no quote (no liquidity) is returned", async () => {
+    getQuoteMock.mockResolvedValue(null as never);
+    const { result } = renderHook(() => useSwapExecution());
+
+    await expect(result.current.executeSwap(validParams)).rejects.toThrow(
+      "No liquidity found"
+    );
+    expect(buildTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("throws Transaction failed when send returns no txHash", async () => {
+    sendTransactionMock.mockResolvedValue({} as never);
+    const { result } = renderHook(() => useSwapExecution());
+
+    await expect(result.current.executeSwap(validParams)).rejects.toThrow(
+      "Transaction failed"
+    );
+  });
+
+  it("maps a rejected-signature error to USER_REJECTED", async () => {
+    signTransaction.mockRejectedValue(new Error("User rejected the request"));
+    const { result } = renderHook(() => useSwapExecution());
+
+    await expect(result.current.executeSwap(validParams)).rejects.toThrow(
+      "USER_REJECTED"
+    );
+    expect(sendTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("maps a denied-signature error to USER_REJECTED", async () => {
+    signTransaction.mockRejectedValue(new Error("Request denied by user"));
+    const { result } = renderHook(() => useSwapExecution());
+
+    await expect(result.current.executeSwap(validParams)).rejects.toThrow(
+      "USER_REJECTED"
+    );
+  });
+
+  it("re-throws non-rejection signing errors unchanged", async () => {
+    signTransaction.mockRejectedValue(new Error("network blip"));
+    const { result } = renderHook(() => useSwapExecution());
+
+    await expect(result.current.executeSwap(validParams)).rejects.toThrow(
+      "network blip"
+    );
+    expect(sendTransactionMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-app/src/features/swap/utils/limitOrderMatching.test.ts
+++ b/apps/web-app/src/features/swap/utils/limitOrderMatching.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import { matchLimitOrder, deriveMarketPrice } from "./limitOrderMatching";
 
 // ─── Buy limit ────────────────────────────────────────────────────────────────

--- a/apps/web-app/src/features/vault/hooks/__tests__/useVaultInvest.test.ts
+++ b/apps/web-app/src/features/vault/hooks/__tests__/useVaultInvest.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+/**
+ * Tests for useVaultInvest — the hook that triggers the vault "invest idle
+ * funds" execution flow (issue #255).
+ *
+ * useVaultData (heavy stellar-sdk vault client) is mocked to a no-op refetch,
+ * and `global.fetch` is stubbed so the test drives the hook's own control flow:
+ * the initial invest-status GET, plus the POST-driven `triggerInvest` branches
+ * (partial success, nothing-to-invest, error response, and thrown fetch). The
+ * hook is wrapped in a real QueryClientProvider so `useQuery` behaves normally.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("../useVaultData", () => ({
+  useVaultData: () => ({ refetch: vi.fn() }),
+}));
+
+import { useVaultInvest } from "../useVaultInvest";
+
+const investStatus = {
+  idle: 1000,
+  total: 5000,
+  canInvest: true,
+  cooldownRemaining: 0,
+  allocations: [{ strategy: "s1", amount: 500 }],
+};
+
+/** Fresh QueryClient per render, retries off so failures settle immediately. */
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  Wrapper.displayName = "QueryWrapper";
+  return Wrapper;
+}
+
+/** Builds a fetch mock: GET resolves the status, POST resolves `postResponse`. */
+function mockFetch(postResponse: {
+  ok: boolean;
+  status: number;
+  body: unknown;
+}) {
+  return vi.fn((_url: string, init?: { method?: string }) => {
+    if (init?.method === "POST") {
+      return Promise.resolve({
+        ok: postResponse.ok,
+        status: postResponse.status,
+        json: async () => postResponse.body,
+      } as Response);
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => investStatus,
+    } as Response);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useVaultInvest – status query", () => {
+  it("exposes the fetched invest status once the GET settles", async () => {
+    vi.stubGlobal("fetch", mockFetch({ ok: true, status: 200, body: {} }));
+
+    const { result } = renderHook(() => useVaultInvest(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.idleAmount).toBe(1000));
+    expect(result.current.totalAmount).toBe(5000);
+    expect(result.current.canInvest).toBe(true);
+    expect(result.current.allocations).toEqual(investStatus.allocations);
+  });
+});
+
+describe("useVaultInvest – triggerInvest happy path", () => {
+  it("POSTs to /api/vault/invest and reports the success ratio", async () => {
+    const fetchMock = mockFetch({
+      ok: true,
+      status: 200,
+      body: {
+        invested: true,
+        results: [{ status: "SUCCESS" }, { status: "FAILED" }],
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useVaultInvest(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.triggerInvest();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/vault/invest", {
+      method: "POST",
+    });
+    await waitFor(() =>
+      expect(result.current.lastResult).toBe("Invested across 1/2 strategies")
+    );
+    expect(result.current.isInvesting).toBe(false);
+  });
+});
+
+describe("useVaultInvest – triggerInvest non-happy branches", () => {
+  it("reports the server message when nothing was invested", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        ok: true,
+        status: 200,
+        body: { invested: false, message: "Nothing to invest" },
+      })
+    );
+
+    const { result } = renderHook(() => useVaultInvest(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.triggerInvest();
+    });
+
+    await waitFor(() =>
+      expect(result.current.lastResult).toBe("Nothing to invest")
+    );
+  });
+
+  it("surfaces the error field when the POST fails (non-207)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        ok: false,
+        status: 500,
+        body: { error: "boom" },
+      })
+    );
+
+    const { result } = renderHook(() => useVaultInvest(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.triggerInvest();
+    });
+
+    await waitFor(() => expect(result.current.lastResult).toBe("Error: boom"));
+  });
+
+  it("captures the error message when fetch itself throws", async () => {
+    const fetchMock = vi.fn((_url: string, init?: { method?: string }) => {
+      if (init?.method === "POST") {
+        return Promise.reject(new Error("network down"));
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => investStatus,
+      } as Response);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useVaultInvest(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.triggerInvest();
+    });
+
+    await waitFor(() => expect(result.current.lastResult).toBe("network down"));
+    expect(result.current.isInvesting).toBe(false);
+  });
+});

--- a/apps/web-app/src/lib/orchestrator/adapters/__tests__/BlendPoolAdapter.test.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/__tests__/BlendPoolAdapter.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for BlendPoolAdapter — the orchestrator adapter that turns pool actions
+ * into Blend `submit` / `claim` operations and wraps them into a prepared,
+ * signable Stellar transaction (issue #255).
+ *
+ * The Blend SDK and the whole @stellar/stellar-sdk transaction pipeline are
+ * mocked so the suite exercises the adapter's own transformation logic:
+ * raw-id parsing, the action → RequestType mapping, the exact request payload
+ * handed to the tx-builders, reward-claim id selection, and the pure
+ * amount-formatting used when reading a user position. No network runs.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  poolLoadMock,
+  tokenMetaLoadMock,
+  submitMock,
+  claimMock,
+  PoolContractV2Mock,
+  fromXDRMock,
+  loadAccountMock,
+  prepareTransactionMock,
+  builder,
+} = vi.hoisted(() => {
+  const submitMock = vi.fn(() => "OP_XDR");
+  const claimMock = vi.fn(() => "CLAIM_XDR");
+  const builder = {
+    addOperation: vi.fn(() => builder),
+    setTimeout: vi.fn(() => builder),
+    build: vi.fn(() => ({ __tx: true })),
+  };
+  return {
+    poolLoadMock: vi.fn(),
+    tokenMetaLoadMock: vi.fn(),
+    submitMock,
+    claimMock,
+    PoolContractV2Mock: vi.fn(function () {
+      return { submit: submitMock, claim: claimMock };
+    }),
+    fromXDRMock: vi.fn(() => ({ __op: true })),
+    loadAccountMock: vi.fn(async () => ({ __account: true })),
+    prepareTransactionMock: vi.fn(async () => ({
+      toXDR: () => "PREPARED_XDR",
+    })),
+    builder,
+  };
+});
+
+vi.mock("@blend-capital/blend-sdk", () => ({
+  RequestType: {
+    SupplyCollateral: 0,
+    WithdrawCollateral: 1,
+    Supply: 2,
+    Withdraw: 3,
+    Borrow: 4,
+    Repay: 5,
+  },
+  PoolV2: { load: poolLoadMock },
+  PoolContractV2: PoolContractV2Mock,
+  TokenMetadata: { load: tokenMetaLoadMock },
+}));
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  xdr: { Operation: { fromXDR: fromXDRMock } },
+  Horizon: {
+    Server: vi.fn(function () {
+      return { loadAccount: loadAccountMock };
+    }),
+  },
+  TransactionBuilder: vi.fn(function () {
+    return builder;
+  }),
+  rpc: {
+    Server: vi.fn(function () {
+      return { prepareTransaction: prepareTransactionMock };
+    }),
+  },
+}));
+
+import { BlendPoolAdapter } from "../BlendPoolAdapter";
+import { RequestType } from "@blend-capital/blend-sdk";
+import { TransactionBuilder } from "@stellar/stellar-sdk";
+import { networkPassphrase } from "@/lib/constants/network";
+import { AdapterError, UnsupportedActionError } from "../../types/errors";
+
+const POOL = "CPOOL";
+const ASSET = "CASSET";
+const RAW = `${POOL}:${ASSET}`;
+const USER = "GUSER";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  submitMock.mockReturnValue("OP_XDR");
+  claimMock.mockReturnValue("CLAIM_XDR");
+});
+
+describe("BlendPoolAdapter – raw id parsing / guards", () => {
+  it("rejects a raw id without a colon separator", async () => {
+    const adapter = new BlendPoolAdapter(POOL);
+    await expect(adapter.deposit("no-colon", USER, 1n)).rejects.toBeInstanceOf(
+      AdapterError
+    );
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  it("reports supported actions", () => {
+    const adapter = new BlendPoolAdapter(POOL);
+    expect(adapter.supportsAction("deposit")).toBe(true);
+    expect(adapter.supportsAction("flashLoan" as never)).toBe(false);
+  });
+});
+
+describe("BlendPoolAdapter – buildSubmitTx fund-moving flow", () => {
+  it("builds a deposit submit request and returns the prepared xdr", async () => {
+    const adapter = new BlendPoolAdapter(POOL);
+    const result = await adapter.deposit(RAW, USER, 1_000_0000n);
+
+    expect(PoolContractV2Mock).toHaveBeenCalledWith(POOL);
+    expect(submitMock).toHaveBeenCalledWith({
+      from: USER,
+      spender: USER,
+      to: USER,
+      requests: [
+        {
+          request_type: RequestType.Supply,
+          address: ASSET,
+          amount: 1_000_0000n,
+        },
+      ],
+    });
+    // op xdr from submit is decoded and threaded through the tx pipeline
+    expect(fromXDRMock).toHaveBeenCalledWith("OP_XDR", "base64");
+    expect(loadAccountMock).toHaveBeenCalledWith(USER);
+    expect(TransactionBuilder).toHaveBeenCalledWith(
+      { __account: true },
+      { fee: "100", networkPassphrase }
+    );
+    expect(builder.setTimeout).toHaveBeenCalledWith(300);
+    expect(prepareTransactionMock).toHaveBeenCalled();
+    expect(result).toEqual({ xdr: "PREPARED_XDR", networkPassphrase });
+  });
+
+  it("maps each action to the correct RequestType with the raw amount", async () => {
+    const adapter = new BlendPoolAdapter(POOL);
+    const cases: Array<[keyof BlendPoolAdapter, number]> = [
+      ["withdraw", RequestType.Withdraw],
+      ["borrow", RequestType.Borrow],
+      ["repay", RequestType.Repay],
+      ["supplyCollateral", RequestType.SupplyCollateral],
+      ["withdrawCollateral", RequestType.WithdrawCollateral],
+    ];
+
+    for (const [method, requestType] of cases) {
+      submitMock.mockClear();
+      await (
+        adapter[method] as (
+          poolId: string,
+          user: string,
+          amount: bigint
+        ) => Promise<unknown>
+      )(RAW, USER, 42n);
+      expect(submitMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requests: [
+            { request_type: requestType, address: ASSET, amount: 42n },
+          ],
+        })
+      );
+    }
+  });
+
+  it("wraps tx-builder failures in an AdapterError", async () => {
+    submitMock.mockImplementationOnce(() => {
+      throw new Error("submit blew up");
+    });
+    const adapter = new BlendPoolAdapter(POOL);
+    await expect(adapter.borrow(RAW, USER, 5n)).rejects.toBeInstanceOf(
+      AdapterError
+    );
+  });
+});
+
+describe("BlendPoolAdapter – claimRewards", () => {
+  it("claims supply and borrow emission token ids", async () => {
+    const reserve = {
+      supplyEmissions: true,
+      borrowEmissions: true,
+      getBTokenEmissionIndex: () => 0,
+      getDTokenEmissionIndex: () => 1,
+    };
+    poolLoadMock.mockResolvedValue({ reserves: new Map([[ASSET, reserve]]) });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const result = await adapter.claimRewards(RAW, USER);
+
+    expect(claimMock).toHaveBeenCalledWith({
+      from: USER,
+      reserve_token_ids: [0, 1],
+      to: USER,
+    });
+    expect(result).toEqual({ xdr: "PREPARED_XDR", networkPassphrase });
+  });
+
+  it("throws UnsupportedActionError when the reserve has no emissions", async () => {
+    const reserve = { supplyEmissions: false, borrowEmissions: false };
+    poolLoadMock.mockResolvedValue({ reserves: new Map([[ASSET, reserve]]) });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    await expect(adapter.claimRewards(RAW, USER)).rejects.toBeInstanceOf(
+      UnsupportedActionError
+    );
+    expect(claimMock).not.toHaveBeenCalled();
+  });
+
+  it("throws AdapterError when the reserve is missing", async () => {
+    poolLoadMock.mockResolvedValue({ reserves: new Map() });
+    const adapter = new BlendPoolAdapter(POOL);
+    await expect(adapter.claimRewards(RAW, USER)).rejects.toBeInstanceOf(
+      AdapterError
+    );
+  });
+});
+
+describe("BlendPoolAdapter – getUserPosition amount formatting", () => {
+  it("sums supply + collateral and formats by reserve decimals", async () => {
+    const reserve = { config: { decimals: 7 } };
+    const poolUser = {
+      getSupply: () => 5_000_000n,
+      getCollateral: () => 2_000_000n,
+      getLiabilities: () => 0n,
+      estimateEmissions: () => ({ claimedTokens: 3n }),
+    };
+    poolLoadMock.mockResolvedValue({
+      reserves: new Map([[ASSET, reserve]]),
+      loadUser: async () => poolUser,
+    });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos.poolId).toBe(`blend:${POOL}:${ASSET}`);
+    expect(pos.deposited).toBe(7_000_000n);
+    expect(pos.depositedFormatted).toBe("0.7");
+    expect(pos.metadata).toMatchObject({
+      supplied: "5000000",
+      collateral: "2000000",
+      liabilities: "0",
+    });
+  });
+
+  it("returns an empty position when the reserve is not found", async () => {
+    poolLoadMock.mockResolvedValue({ reserves: new Map() });
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos).toEqual({
+      poolId: `blend:${POOL}:${ASSET}`,
+      deposited: 0n,
+      depositedFormatted: "0",
+      rewards: 0n,
+      rewardsFormatted: "0",
+      metadata: {},
+    });
+  });
+});

--- a/apps/web-app/src/lib/orchestrator/adapters/__tests__/NekoLendingAdapter.test.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/__tests__/NekoLendingAdapter.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for NekoLendingAdapter — the orchestrator adapter that turns pool
+ * actions into Soroban lending transactions (issue #255).
+ *
+ * The @neko/lending contract client, the soroswap token registry and the
+ * deposit/withdraw tx builders are all mocked so the tests exercise the
+ * adapter's own logic: pool-contract selection, smallest-unit → human amount
+ * conversion, PoolInfo/PoolPosition mapping and its guard/error branches.
+ * `fromSmallestUnit` is intentionally left un-mocked so the real numeric
+ * conversion is asserted end to end.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  clientMethods,
+  ClientMock,
+  networksMock,
+  getAvailableTokens,
+  depositToPool,
+  withdrawFromPool,
+} = vi.hoisted(() => {
+  const clientMethods = {
+    get_pool_balance: vi.fn(),
+    get_interest_rate: vi.fn(),
+    get_pool_state: vi.fn(),
+    get_b_token_balance: vi.fn(),
+  };
+  class ClientMock {
+    constructor() {
+      Object.assign(this, clientMethods);
+    }
+  }
+  return {
+    clientMethods,
+    ClientMock,
+    networksMock: {
+      testnet: { pool1ContractId: "CPOOL1", pool2ContractId: "CPOOL2" },
+    },
+    getAvailableTokens: vi.fn(),
+    depositToPool: vi.fn(),
+    withdrawFromPool: vi.fn(),
+  };
+});
+
+vi.mock("@neko/lending", () => ({
+  Client: ClientMock,
+  networks: networksMock,
+}));
+vi.mock("@/lib/helpers/stellar/soroswap", () => ({
+  getAvailableTokens,
+}));
+vi.mock("@/lib/helpers/stellar/lending", () => ({
+  depositToPool,
+  withdrawFromPool,
+}));
+
+import { NekoLendingAdapter } from "../NekoLendingAdapter";
+import { AdapterError, UnsupportedActionError } from "../../types/errors";
+
+const USDC = {
+  contract: "C_USDC",
+  code: "USDC",
+  name: "USD Coin",
+  decimals: 7,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAvailableTokens.mockReturnValue({
+    USDC,
+    CETES: { ...USDC, code: "CETES" },
+  });
+  depositToPool.mockResolvedValue("DEPOSIT_XDR");
+  withdrawFromPool.mockResolvedValue("WITHDRAW_XDR");
+  clientMethods.get_pool_balance.mockResolvedValue({ result: 5000n });
+  clientMethods.get_interest_rate.mockResolvedValue({ result: 250 });
+  clientMethods.get_pool_state.mockResolvedValue({ result: { tag: "Active" } });
+  clientMethods.get_b_token_balance.mockResolvedValue({ result: 15_000_000n });
+});
+
+describe("NekoLendingAdapter – deposit", () => {
+  it("converts the raw amount to a human amount and routes to pool 1", async () => {
+    const adapter = new NekoLendingAdapter();
+    const result = await adapter.deposit("USDC", "GUSER", 10_000_000n);
+
+    // 10_000_000 raw / 10^7 decimals => "1"
+    expect(depositToPool).toHaveBeenCalledWith(
+      "USDC",
+      "1",
+      7,
+      "GUSER",
+      "CPOOL1"
+    );
+    expect(result).toEqual({
+      xdr: "DEPOSIT_XDR",
+      networkPassphrase: expect.any(String),
+    });
+  });
+
+  it("routes pool-2 collateral assets to the pool 2 contract", async () => {
+    const adapter = new NekoLendingAdapter();
+    await adapter.deposit("CETES", "GUSER", 15_000_000n);
+
+    // 15_000_000 raw / 10^7 => "1.5"
+    expect(depositToPool).toHaveBeenCalledWith(
+      "CETES",
+      "1.5",
+      7,
+      "GUSER",
+      "CPOOL2"
+    );
+  });
+
+  it("wraps a builder failure in an AdapterError", async () => {
+    depositToPool.mockRejectedValue(new Error("rpc down"));
+    const adapter = new NekoLendingAdapter();
+
+    await expect(adapter.deposit("USDC", "GUSER", 1n)).rejects.toBeInstanceOf(
+      AdapterError
+    );
+  });
+});
+
+describe("NekoLendingAdapter – withdraw", () => {
+  it("builds the withdraw tx with the converted amount", async () => {
+    const adapter = new NekoLendingAdapter();
+    const result = await adapter.withdraw("USDC", "GUSER", 10_000_000n);
+
+    expect(withdrawFromPool).toHaveBeenCalledWith(
+      "USDC",
+      "1",
+      7,
+      "GUSER",
+      "CPOOL1"
+    );
+    expect(result.xdr).toBe("WITHDRAW_XDR");
+  });
+});
+
+describe("NekoLendingAdapter – getPoolInfo", () => {
+  it("maps balance, interest rate and pool state into a PoolInfo", async () => {
+    const adapter = new NekoLendingAdapter();
+    const info = await adapter.getPoolInfo("USDC");
+
+    expect(info).toMatchObject({
+      id: "neko:USDC",
+      type: "neko",
+      name: "USDC Lending Pool",
+      tvl: 5000n,
+      apy: 2.5, // 250 / 100
+      state: "active",
+      supportedActions: ["deposit", "withdraw"],
+      metadata: { contractId: "CPOOL1", assetCode: "USDC" },
+    });
+    expect(info.tokens[0]).toMatchObject({ address: "C_USDC", code: "USDC" });
+  });
+
+  it("maps a Frozen pool-state tag to the 'frozen' state", async () => {
+    clientMethods.get_pool_state.mockResolvedValue({
+      result: { tag: "Frozen" },
+    });
+    const adapter = new NekoLendingAdapter();
+
+    expect((await adapter.getPoolInfo("USDC")).state).toBe("frozen");
+  });
+
+  it("unwraps a Result<Ok> interest rate into an APY", async () => {
+    clientMethods.get_interest_rate.mockResolvedValue({
+      result: { tag: "Ok", values: ["300"] },
+    });
+    const adapter = new NekoLendingAdapter();
+
+    expect((await adapter.getPoolInfo("USDC")).apy).toBe(3); // 300 / 100
+  });
+
+  it("throws an AdapterError for an unknown asset", async () => {
+    getAvailableTokens.mockReturnValue({});
+    const adapter = new NekoLendingAdapter();
+
+    await expect(adapter.getPoolInfo("NOPE")).rejects.toBeInstanceOf(
+      AdapterError
+    );
+    expect(clientMethods.get_pool_balance).not.toHaveBeenCalled();
+  });
+});
+
+describe("NekoLendingAdapter – getUserPosition", () => {
+  it("returns the b-token balance formatted to human units", async () => {
+    const adapter = new NekoLendingAdapter();
+    const position = await adapter.getUserPosition("USDC", "GUSER");
+
+    expect(position).toMatchObject({
+      poolId: "neko:USDC",
+      deposited: 15_000_000n,
+      depositedFormatted: "1.5",
+      rewards: 0n,
+      metadata: { bTokenBalance: "15000000" },
+    });
+  });
+
+  it("falls back to an empty position when the balance call fails", async () => {
+    clientMethods.get_b_token_balance.mockRejectedValue(new Error("boom"));
+    const adapter = new NekoLendingAdapter();
+    const position = await adapter.getUserPosition("USDC", "GUSER");
+
+    expect(position).toMatchObject({
+      poolId: "neko:USDC",
+      deposited: 0n,
+      depositedFormatted: "0",
+      metadata: {},
+    });
+  });
+});
+
+describe("NekoLendingAdapter – capabilities", () => {
+  it("supports only deposit and withdraw actions", () => {
+    const adapter = new NekoLendingAdapter();
+    expect(adapter.supportsAction("deposit")).toBe(true);
+    expect(adapter.supportsAction("withdraw")).toBe(true);
+    expect(adapter.supportsAction("borrow")).toBe(false);
+  });
+
+  it("rejects claimRewards as unsupported", async () => {
+    const adapter = new NekoLendingAdapter();
+    await expect(adapter.claimRewards()).rejects.toBeInstanceOf(
+      UnsupportedActionError
+    );
+  });
+});

--- a/apps/web-app/src/lib/orchestrator/adapters/__tests__/SoroswapPoolAdapter.test.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/__tests__/SoroswapPoolAdapter.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for SoroswapPoolAdapter — the orchestrator adapter that maps SoroSwap
+ * pools into the unified PoolInfo shape and builds add-liquidity (deposit)
+ * transactions (issue #255).
+ *
+ * The SoroSwap helpers (getPool, addLiquidity, getAvailableTokens) are mocked so
+ * no network / stellar-sdk code runs. The tests characterize the adapter's own
+ * transformation logic: pool-id parsing, token resolution, reserve/TVL/unit
+ * normalization, the deposit build args, and the unsupported-action guards.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { getPool, addLiquidity, getAvailableTokens, tokens } = vi.hoisted(() => {
+  const tokens = {
+    XLM: {
+      contract: "CXLMCONTRACT0000000000000000000000000000000000000000000",
+      code: "XLM",
+      name: "Stellar Lumens",
+      decimals: 7,
+    },
+    USDC: {
+      contract: "CUSDCCONTRACT000000000000000000000000000000000000000000",
+      code: "USDC",
+      name: "USD Coin",
+      decimals: 6,
+    },
+  };
+  return {
+    getPool: vi.fn(),
+    addLiquidity: vi.fn(),
+    getAvailableTokens: vi.fn(() => tokens),
+    tokens,
+  };
+});
+
+vi.mock("@/lib/helpers/stellar/soroswap", () => ({
+  getPool,
+  addLiquidity,
+  getAvailableTokens,
+}));
+
+import { SoroswapPoolAdapter } from "../SoroswapPoolAdapter";
+import { AdapterError, UnsupportedActionError } from "../../types/errors";
+import { networkPassphrase } from "@/lib/constants/network";
+
+let adapter: SoroswapPoolAdapter;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAvailableTokens.mockReturnValue(tokens);
+  adapter = new SoroswapPoolAdapter();
+});
+
+describe("SoroswapPoolAdapter – getPoolInfo", () => {
+  it("maps an existing pool to a normalized PoolInfo with TVL and formatted reserves", async () => {
+    getPool.mockResolvedValue([
+      {
+        address: "CPOOLADDR",
+        protocol: "soroswap",
+        reserveA: "30000000", // 3 XLM (7 decimals)
+        reserveB: "5000000", // 5 USDC (6 decimals)
+        ledger: 42,
+      },
+    ]);
+
+    const info = await adapter.getPoolInfo("XLM-USDC");
+
+    expect(getPool).toHaveBeenCalledWith({
+      tokenA: tokens.XLM.contract,
+      tokenB: tokens.USDC.contract,
+    });
+    expect(info).toMatchObject({
+      id: "soroswap:XLM-USDC",
+      type: "soroswap",
+      name: "XLM / USDC",
+      state: "active",
+      tvl: 35000000n,
+      apy: 0,
+      supportedActions: ["deposit", "withdraw"],
+    });
+    expect(info.tokens.map((t) => t.code)).toEqual(["XLM", "USDC"]);
+    expect(info.metadata).toMatchObject({
+      poolAddress: "CPOOLADDR",
+      reserveAFormatted: "3",
+      reserveBFormatted: "5",
+      ledger: 42,
+    });
+  });
+
+  it("returns an 'unknown' placeholder pool when SoroSwap has no matching pool", async () => {
+    getPool.mockResolvedValue([]);
+
+    const info = await adapter.getPoolInfo("XLM-USDC");
+
+    expect(info).toMatchObject({
+      state: "unknown",
+      tvl: 0n,
+      metadata: { exists: false },
+    });
+  });
+
+  it("throws on a malformed pool id before touching the network", async () => {
+    await expect(adapter.getPoolInfo("XLMONLY")).rejects.toThrow(
+      /Invalid SoroSwap pool id/
+    );
+    expect(getPool).not.toHaveBeenCalled();
+  });
+
+  it("throws on an unknown token code", async () => {
+    await expect(adapter.getPoolInfo("XLM-DOGE")).rejects.toThrow(
+      /Unknown token code: DOGE/
+    );
+  });
+
+  it("wraps downstream failures in an AdapterError", async () => {
+    getPool.mockRejectedValue(new Error("rpc down"));
+
+    await expect(adapter.getPoolInfo("XLM-USDC")).rejects.toBeInstanceOf(
+      AdapterError
+    );
+  });
+});
+
+describe("SoroswapPoolAdapter – deposit", () => {
+  it("converts the raw amount to human units and builds the add-liquidity tx", async () => {
+    addLiquidity.mockResolvedValue({ xdr: "ADD_LIQ_XDR" });
+
+    const result = await adapter.deposit(
+      "XLM-USDC",
+      "GUSER_ADDRESS",
+      12_345_000n // 1.2345 in 7-decimal XLM units
+    );
+
+    expect(addLiquidity).toHaveBeenCalledWith({
+      assetA: tokens.XLM.contract,
+      assetB: tokens.USDC.contract,
+      amountA: "1.2345",
+      amountB: "1.2345",
+      to: "GUSER_ADDRESS",
+    });
+    expect(result).toEqual({ xdr: "ADD_LIQ_XDR", networkPassphrase });
+  });
+
+  it("wraps add-liquidity failures in an AdapterError", async () => {
+    addLiquidity.mockRejectedValue(new Error("insufficient balance"));
+
+    await expect(
+      adapter.deposit("XLM-USDC", "GUSER_ADDRESS", 1n)
+    ).rejects.toBeInstanceOf(AdapterError);
+  });
+});
+
+describe("SoroswapPoolAdapter – unsupported actions & guards", () => {
+  it("rejects withdraw as an unsupported action", async () => {
+    await expect(adapter.withdraw()).rejects.toBeInstanceOf(
+      UnsupportedActionError
+    );
+  });
+
+  it("rejects claimRewards as an unsupported action", async () => {
+    await expect(adapter.claimRewards()).rejects.toBeInstanceOf(
+      UnsupportedActionError
+    );
+  });
+
+  it("reports supportsAction for deposit but not withdraw or claimRewards", () => {
+    expect(adapter.supportsAction("deposit")).toBe(true);
+    expect(adapter.supportsAction("withdraw")).toBe(false);
+    expect(adapter.supportsAction("claimRewards")).toBe(false);
+  });
+
+  it("returns an empty zeroed position for getUserPosition", async () => {
+    const position = await adapter.getUserPosition("XLM-USDC", "GUSER_ADDRESS");
+    expect(position).toMatchObject({
+      poolId: "soroswap:XLM-USDC",
+      deposited: 0n,
+      depositedFormatted: "0",
+      rewards: 0n,
+    });
+  });
+});

--- a/apps/web-app/vitest.config.ts
+++ b/apps/web-app/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+/**
+ * Vitest configuration for the web-app.
+ *
+ * The only responsibility here is resolving the `@/*` path alias (mirrors the
+ * `paths` entry in tsconfig.json) so that tests can import and mock modules the
+ * same way the application code does — e.g. `vi.mock("@/hooks/useWallet")`.
+ *
+ * `globals` is intentionally left disabled: every test imports `describe` /
+ * `it` / `expect` / `vi` explicitly. React-hook tests opt into the jsdom
+ * environment per-file with a `// @vitest-environment jsdom` docblock, so the
+ * default (node) stays fast for the pure-logic and adapter suites.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,8 +78,11 @@
         "zustand": "^5.0.2"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/lodash": "^4.14.202",
         "@vitest/coverage-v8": "^4.1.9",
+        "jsdom": "^25.0.1",
         "vitest": "^4.1.9"
       }
     },
@@ -143,6 +146,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -621,6 +645,121 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -6218,6 +6357,64 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@trezor/analytics": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@trezor/analytics/-/analytics-1.5.0.tgz",
@@ -8158,6 +8355,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -11146,6 +11350,27 @@
         "node": "*"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -11280,6 +11505,57 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -11365,6 +11641,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -11452,6 +11735,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/des.js": {
@@ -11542,6 +11835,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -11628,6 +11928,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -13039,12 +13352,53 @@
       "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
@@ -13069,6 +13423,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/idb-keyval": {
@@ -13477,6 +13844,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -13849,6 +14223,84 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -14367,6 +14819,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -14820,6 +15282,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -15133,6 +15602,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -15328,6 +15810,41 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -15912,6 +16429,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -16027,6 +16551,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -16742,6 +17286,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
@@ -16873,6 +17424,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -16911,6 +17482,19 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -18144,6 +18728,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-app": {
       "resolved": "apps/web-app",
       "link": true
@@ -18153,6 +18750,30 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -18344,6 +18965,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xrpl": {
       "version": "4.4.3",


### PR DESCRIPTION
## What

Closes #255.

Adds unit tests (with mocked wallet / RPC / helper dependencies) for every
execution hook and orchestrator adapter that builds and submits Soroban
transactions moving user funds — the paths that previously had **zero**
automated coverage.

## Coverage added

| Target | Tests |
| --- | --- |
| `features/borrowing/hooks/useBorrowExecution.ts` | 11 |
| `features/borrowing/hooks/useRepay.ts` | 7 |
| `features/swap/hooks/useSwapExecution.ts` | 10 |
| `features/lending/hooks/useLend.ts` | 10 |
| `features/vault/hooks/useVaultInvest.ts` | 5 |
| `lib/orchestrator/adapters/BlendPoolAdapter.ts` | 10 |
| `lib/orchestrator/adapters/NekoLendingAdapter.ts` | 12 |
| `lib/orchestrator/adapters/SoroswapPoolAdapter.ts` | 11 |

Each suite characterizes existing behaviour across three axes:

- **Guards / input validation** — disconnected wallet, non-positive or
  invalid amounts, missing tokens/pools, missing bToken rate, etc.
- **Happy path** — asserts the *exact* arguments handed to the tx-builders
  (`addCollateral`, `borrowFromPool`, `repayPool`, `depositToPool`,
  `withdrawFromPool`, Blend `submit`/`claim`, Soroswap `addLiquidity`),
  including amount/decimal/raw-unit conversions, then the sign → send →
  confirm flow.
- **Error handling** — decoded contract-error surfacing, generic fallbacks,
  re-throws, and the swap `USER_REJECTED` mapping.

## Test infrastructure

Building on the Vitest harness from #241, this PR adds what hook testing
needs:

- `@testing-library/react`, `@testing-library/dom`, `jsdom` dev dependencies.
- `apps/web-app/vitest.config.ts` resolving the `@/*` path alias so tests can
  mock modules exactly as the app imports them. `globals` stays off — every
  test imports its Vitest helpers explicitly; React-hook suites opt into jsdom
  per-file via a `// @vitest-environment jsdom` docblock.

Also fixes the pre-existing `limitOrderMatching.test.ts`, which referenced
`describe`/`it` without importing them, so the whole suite runs green.

## Notes

- **No production code was modified** — coverage is achieved entirely through
  mocking, so none of the fund-moving code paths were touched.
- Full suite: **11 files / 114 tests passing**. Lint clean on all new files.

## How to run

```bash
cd apps/web-app
npm test
```