### PR TITLE
fix: string/BigInt-safe decimal→integer conversion (issue #257)

### DIFF
--- a/apps/web-app/src/features/admin/components/CollateralFactorForm.tsx
+++ b/apps/web-app/src/features/admin/components/CollateralFactorForm.tsx
@@ -12,6 +12,7 @@ import { POOLS, POOL2_COLLATERAL_ASSETS } from "../constants";
 import { TOAST_CONFIG } from "@/lib/constants/toast.config";
 import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors";
 import { invalidateProtocolQueries } from "@/lib/helpers/invalidateProtocolQueries";
+import { toSmallestUnit } from "@/lib/helpers/tokenUtils";
 import { Networks } from "@stellar/stellar-sdk";
 import type { AssetType } from "@neko/lending";
 
@@ -85,7 +86,7 @@ export default function CollateralFactorForm() {
       });
       return;
     }
-    const factor = Math.round(factorNum * 100_000); // 7 decimals: 75% = 7_500_000
+    const factor = Number(toSmallestUnit(factorPercent, 7) / 100n); // 7 decimals: 75% = 7_500_000
     if (factor > SCALAR_7) {
       addNotification("Error", "error", {
         ...TOAST_CONFIG.defaultOpts,

--- a/apps/web-app/src/features/admin/components/InterestRateParamsForm.tsx
+++ b/apps/web-app/src/features/admin/components/InterestRateParamsForm.tsx
@@ -57,7 +57,7 @@ export default function InterestRateParamsForm() {
       reactivity: Number(toSmallestUnit(reactivity, 7)),
       enabled,
       l_factor: pctTo7(lFactor),
-      supply_cap: BigInt(Number(toSmallestUnit(supplyCap, 7))),
+      supply_cap: toSmallestUnit(supplyCap, 7),
     };
 
     if (params.target_util > 9_500_000) {

--- a/apps/web-app/src/features/admin/components/InterestRateParamsForm.tsx
+++ b/apps/web-app/src/features/admin/components/InterestRateParamsForm.tsx
@@ -10,15 +10,16 @@ import { POOLS } from "../constants";
 import { TOAST_CONFIG } from "@/lib/constants/toast.config";
 import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors";
 import { invalidateProtocolQueries } from "@/lib/helpers/invalidateProtocolQueries";
+import { toSmallestUnit } from "@/lib/helpers/tokenUtils";
 import { Networks } from "@stellar/stellar-sdk";
 import { useQueryClient } from "@tanstack/react-query";
 import type { InterestRateParams } from "@neko/lending";
 
 const SCALAR_7 = 10_000_000;
 
-/** Convert percentage (e.g. 75) to 7 decimals (7_500_000) */
-function pctTo7(pct: number): number {
-  return Math.round((pct / 100) * SCALAR_7);
+/** Convert a percentage string (e.g. "75") to a 7-decimal scalar (7_500_000). */
+function pctTo7(pctStr: string): number {
+  return Number(toSmallestUnit(pctStr, 7) / 100n);
 }
 
 export default function InterestRateParamsForm() {
@@ -47,18 +48,16 @@ export default function InterestRateParamsForm() {
     if (!address) return;
 
     const params: InterestRateParams = {
-      target_util: pctTo7(parseFloat(targetUtil) || 0),
-      max_util: pctTo7(parseFloat(maxUtil) || 0),
-      r_base: pctTo7(parseFloat(rBase) || 0),
-      r_one: pctTo7(parseFloat(rOne) || 0),
-      r_two: pctTo7(parseFloat(rTwo) || 0),
-      r_three: pctTo7(parseFloat(rThree) || 0),
-      reactivity: Math.round(parseFloat(reactivity) * SCALAR_7) || 0,
+      target_util: pctTo7(targetUtil),
+      max_util: pctTo7(maxUtil),
+      r_base: pctTo7(rBase),
+      r_one: pctTo7(rOne),
+      r_two: pctTo7(rTwo),
+      r_three: pctTo7(rThree),
+      reactivity: Number(toSmallestUnit(reactivity, 7)),
       enabled,
-      l_factor: pctTo7(parseFloat(lFactor) || 0),
-      supply_cap: BigInt(
-        Math.round((parseFloat(supplyCap) || 0) * 10 ** 7)
-      ),
+      l_factor: pctTo7(lFactor),
+      supply_cap: BigInt(Number(toSmallestUnit(supplyCap, 7))),
     };
 
     if (params.target_util > 9_500_000) {
@@ -101,7 +100,11 @@ export default function InterestRateParamsForm() {
         ...TOAST_CONFIG.defaultOpts,
         description: `Interest rate params for ${asset} updated`,
       });
-      void invalidateProtocolQueries(queryClient, ["pools", "rates", "positions"]);
+      void invalidateProtocolQueries(queryClient, [
+        "pools",
+        "rates",
+        "positions",
+      ]);
     } catch (err) {
       const msg = extractContractErrorOrNull(err);
       addNotification("Error", "error", {

--- a/apps/web-app/src/features/borrowing/hooks/useBorrow.ts
+++ b/apps/web-app/src/features/borrowing/hooks/useBorrow.ts
@@ -6,7 +6,7 @@ import { useBorrowExecution } from "./useBorrowExecution";
 import { poolsToTableAssets } from "../utils/borrowUtils";
 import { usePools, usePoolAction } from "@/lib/orchestrator";
 import type { PoolInfo } from "@/lib/orchestrator";
-import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
+import { fromSmallestUnit, toSmallestUnit } from "@/lib/helpers/tokenUtils";
 import { formatLiquidity } from "@/lib/helpers/formatUtils";
 import type { BorrowTableAsset } from "../types/borrowing";
 
@@ -104,10 +104,7 @@ export function useBorrow() {
       if (!selectedAsset) return;
 
       if (selectedAsset.isAggregated && selectedAsset.orchestratorId) {
-        const decimals = 7;
-        const rawAmount = BigInt(
-          Math.floor(parseFloat(borrowAmount) * 10 ** decimals)
-        );
+        const rawAmount = toSmallestUnit(borrowAmount, 7);
         await executePoolAction({
           poolId: selectedAsset.orchestratorId,
           action: "borrow",

--- a/apps/web-app/src/features/lending/hooks/useLend.ts
+++ b/apps/web-app/src/features/lending/hooks/useLend.ts
@@ -18,7 +18,7 @@ import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors
 import { waitForTransaction } from "@/lib/helpers/stellar/waitForTransaction";
 import { usePools, usePoolAction } from "@/lib/orchestrator";
 import type { PoolInfo } from "@/lib/orchestrator";
-import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
+import { fromSmallestUnit, toSmallestUnit } from "@/lib/helpers/tokenUtils";
 import { formatLiquidity } from "@/lib/helpers/formatUtils";
 import type { PoolData } from "../types/lending";
 
@@ -186,10 +186,7 @@ export function useLend() {
 
       try {
         if (selectedPool.isAggregated && selectedPool.orchestratorId) {
-          const decimals = 7;
-          const rawAmount = BigInt(
-            Math.floor(parseFloat(amount) * 10 ** decimals)
-          );
+          const rawAmount = toSmallestUnit(amount, 7);
 
           await executePoolAction({
             poolId: selectedPool.orchestratorId,

--- a/apps/web-app/src/features/pools/components/PoolActionModal.tsx
+++ b/apps/web-app/src/features/pools/components/PoolActionModal.tsx
@@ -91,7 +91,7 @@ export function PoolActionModal({
     if (needsAmount) {
       const num = parseFloat(amount);
       if (isNaN(num) || num <= 0) return;
-      const amountBigInt = BigInt(toSmallestUnit(amount, decimals));
+      const amountBigInt = toSmallestUnit(amount, decimals);
       mutate.mutate(
         { poolId, action, amount: amountBigInt, tokenIndex: 0 },
         { onSuccess }

--- a/apps/web-app/src/features/vault/hooks/useVaultAction.ts
+++ b/apps/web-app/src/features/vault/hooks/useVaultAction.ts
@@ -98,10 +98,13 @@ export function useVaultAction() {
           ...(allowHttpForSoroban && { allowHttp: true }),
         });
 
-        const amountBigInt = BigInt(toSmallestUnit(amount, 7));
+        const amountBigInt = toSmallestUnit(amount, 7);
+        // SLIPPAGE is a decimal fraction (0.01 = 1%). Scale it string-safely (7 decimals)
+        // so there is no float multiplication.
+        const SLIPPAGE_SCALE = 10_000_000n;
+        const slippageScaled = toSmallestUnit(String(SLIPPAGE), 7); // 0.01 -> 100000n
         const minAmount =
-          amountBigInt -
-          (amountBigInt * BigInt(Math.floor(SLIPPAGE * 100))) / 100n;
+          amountBigInt - (amountBigInt * slippageScaled) / SLIPPAGE_SCALE;
 
         // Simulate — the resulting XDR already includes Soroban auth entries
         const depositTx = await client.deposit({
@@ -158,7 +161,7 @@ export function useVaultAction() {
           ...(allowHttpForSoroban && { allowHttp: true }),
         });
 
-        const sharesBigInt = BigInt(toSmallestUnit(shares, 7));
+        const sharesBigInt = toSmallestUnit(shares, 7);
 
         const withdrawTx = await client.withdraw({
           withdraw_shares: sharesBigInt,

--- a/apps/web-app/src/lib/helpers/stellar/lending.ts
+++ b/apps/web-app/src/lib/helpers/stellar/lending.ts
@@ -36,7 +36,7 @@ export const depositToPool = async (
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
-    const amountInSmallestUnit = BigInt(toSmallestUnit(amount, decimals));
+    const amountInSmallestUnit = toSmallestUnit(amount, decimals);
 
     const assetSymbol = xdr.ScVal.scvSymbol(assetCode);
 
@@ -105,7 +105,7 @@ export const withdrawFromPool = async (
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
-    const bTokensInSmallestUnit = BigInt(toSmallestUnit(bTokens, decimals));
+    const bTokensInSmallestUnit = toSmallestUnit(bTokens, decimals);
 
     const assetSymbol = xdr.ScVal.scvSymbol(assetCode);
 
@@ -172,7 +172,7 @@ export const addCollateral = async (
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
-    const amountInSmallestUnit = BigInt(toSmallestUnit(amount, decimals));
+    const amountInSmallestUnit = toSmallestUnit(amount, decimals);
 
     const operation = lendingContract.call(
       "add_collateral",
@@ -237,7 +237,7 @@ export const removeCollateral = async (
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
-    const amountInSmallestUnit = BigInt(toSmallestUnit(amount, decimals));
+    const amountInSmallestUnit = toSmallestUnit(amount, decimals);
 
     const operation = lendingContract.call(
       "remove_collateral",
@@ -302,7 +302,7 @@ export const borrowFromPool = async (
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
-    const amountInSmallestUnit = BigInt(toSmallestUnit(amount, decimals));
+    const amountInSmallestUnit = toSmallestUnit(amount, decimals);
 
     const assetSymbol = xdr.ScVal.scvSymbol(assetCode);
 
@@ -666,7 +666,7 @@ export const depositToBackstop = async (
     const horizonServer = new Horizon.Server(horizonUrl);
     const backstopContract = new Contract(backstopContractId);
 
-    const amountInSmallestUnit = BigInt(toSmallestUnit(amount, 7));
+    const amountInSmallestUnit = toSmallestUnit(amount, 7);
 
     const operation = backstopContract.call(
       "deposit",
@@ -728,7 +728,7 @@ export const initiateBackstopWithdrawal = async (
     const horizonServer = new Horizon.Server(horizonUrl);
     const backstopContract = new Contract(backstopContractId);
 
-    const amountInSmallestUnit = BigInt(toSmallestUnit(amount, 7));
+    const amountInSmallestUnit = toSmallestUnit(amount, 7);
 
     const operation = backstopContract.call(
       "queue_withdrawal",
@@ -790,7 +790,7 @@ export const withdrawFromBackstop = async (
     const horizonServer = new Horizon.Server(horizonUrl);
     const backstopContract = new Contract(backstopContractId);
 
-    const amountInSmallestUnit = BigInt(toSmallestUnit(amount, 7));
+    const amountInSmallestUnit = toSmallestUnit(amount, 7);
 
     const operation = backstopContract.call(
       "withdraw",
@@ -1005,7 +1005,7 @@ export const buildFillBadDebtAuctionXdr = async (
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
-    const amountInSmallestUnit = BigInt(toSmallestUnit(amount, decimals));
+    const amountInSmallestUnit = toSmallestUnit(amount, decimals);
 
     const operation = lendingContract.call(
       "fill_bad_debt_auction",

--- a/apps/web-app/src/lib/helpers/stellar/soroswap/quotes.ts
+++ b/apps/web-app/src/lib/helpers/stellar/soroswap/quotes.ts
@@ -11,12 +11,12 @@ import {
 } from "@stellar/stellar-sdk";
 import { rpcUrl, networkPassphrase } from "@/lib/constants/network";
 import { getCurrentNetwork, getAvailableTokens } from "./tokens";
+import { toSmallestUnit } from "@/lib/helpers/tokenUtils";
 import {
   getApiKey,
   getSDKNetwork,
   getSoroswapSDK,
   makeAPIRequest,
-  toSmallestUnit,
   isValidContractAddress,
   formatTokenForAPI,
 } from "./utils";

--- a/apps/web-app/src/lib/helpers/stellar/soroswap/utils.ts
+++ b/apps/web-app/src/lib/helpers/stellar/soroswap/utils.ts
@@ -111,18 +111,6 @@ export const makeAPIRequest = async <T>(
   }
 };
 
-export const toSmallestUnit = (
-  amount: string,
-  decimals: number = 7
-): bigint => {
-  const numAmount = parseFloat(amount);
-  if (isNaN(numAmount)) return BigInt(0);
-
-  const multiplier = BigInt(10 ** decimals);
-  const amountFloat = numAmount * Number(multiplier);
-  return BigInt(Math.floor(amountFloat));
-};
-
 export const isValidContractAddress = (address: string): boolean => {
   return address.startsWith("C") && address.length === 56;
 };

--- a/apps/web-app/src/lib/helpers/tokenUtils.test.ts
+++ b/apps/web-app/src/lib/helpers/tokenUtils.test.ts
@@ -62,4 +62,12 @@ describe("toSmallestUnit", () => {
   it("does not crash on large-magnitude number input", () => {
     expect(toSmallestUnit(1e21, 7)).toBe(10000000000000000000000000000n);
   });
+
+  it("rejects non-decimal strings as 0n (hardening)", () => {
+    expect(toSmallestUnit("0x10", 7)).toBe(0n);
+    expect(toSmallestUnit("Infinity", 7)).toBe(0n);
+    expect(toSmallestUnit("+5", 7)).toBe(0n);
+    expect(toSmallestUnit("-", 7)).toBe(0n);
+    expect(toSmallestUnit(".", 7)).toBe(0n);
+  });
 });

--- a/apps/web-app/src/lib/helpers/tokenUtils.test.ts
+++ b/apps/web-app/src/lib/helpers/tokenUtils.test.ts
@@ -48,4 +48,18 @@ describe("toSmallestUnit", () => {
   it("handles a trailing dot and no fraction", () => {
     expect(toSmallestUnit("7.", 7)).toBe(70000000n);
   });
+
+  it("handles number input in exponential notation", () => {
+    expect(toSmallestUnit(0.0000001, 7)).toBe(1n); // (0.0000001).toString() === "1e-7"
+    expect(toSmallestUnit(1e-7, 7)).toBe(1n);
+  });
+
+  it("handles string input in exponential notation", () => {
+    expect(toSmallestUnit("1e-7", 7)).toBe(1n);
+    expect(toSmallestUnit("1.5e2", 7)).toBe(1500000000n); // 150
+  });
+
+  it("does not crash on large-magnitude number input", () => {
+    expect(toSmallestUnit(1e21, 7)).toBe(10000000000000000000000000000n);
+  });
 });

--- a/apps/web-app/src/lib/helpers/tokenUtils.test.ts
+++ b/apps/web-app/src/lib/helpers/tokenUtils.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { toSmallestUnit } from "./tokenUtils";
+
+describe("toSmallestUnit", () => {
+  it("does not lose precision on 0.41 (regression for #257)", () => {
+    expect(toSmallestUnit("0.41", 7)).toBe(4100000n);
+  });
+
+  it("returns bigint", () => {
+    expect(typeof toSmallestUnit("1", 7)).toBe("bigint");
+  });
+
+  it("handles whole numbers", () => {
+    expect(toSmallestUnit("5", 7)).toBe(50000000n);
+    expect(toSmallestUnit("100", 7)).toBe(1000000000n);
+  });
+
+  it("handles exact decimals", () => {
+    expect(toSmallestUnit("0.0000001", 7)).toBe(1n);
+    expect(toSmallestUnit("1.2345678", 7)).toBe(12345678n);
+  });
+
+  it("truncates (floors) excess fractional digits", () => {
+    expect(toSmallestUnit("0.00000001", 7)).toBe(0n);
+    expect(toSmallestUnit("1.23456789", 7)).toBe(12345678n);
+  });
+
+  it("handles empty and non-numeric input as 0n", () => {
+    expect(toSmallestUnit("", 7)).toBe(0n);
+    expect(toSmallestUnit("abc", 7)).toBe(0n);
+  });
+
+  it("handles zero and leading zeros", () => {
+    expect(toSmallestUnit("0", 7)).toBe(0n);
+    expect(toSmallestUnit("00.50", 7)).toBe(5000000n);
+  });
+
+  it("handles number input", () => {
+    expect(toSmallestUnit(0.41, 7)).toBe(4100000n);
+    expect(toSmallestUnit(5, 7)).toBe(50000000n);
+  });
+
+  it("respects custom decimals", () => {
+    expect(toSmallestUnit("1.5", 2)).toBe(150n);
+    expect(toSmallestUnit("1.999", 2)).toBe(199n);
+  });
+
+  it("handles a trailing dot and no fraction", () => {
+    expect(toSmallestUnit("7.", 7)).toBe(70000000n);
+  });
+});

--- a/apps/web-app/src/lib/helpers/tokenUtils.ts
+++ b/apps/web-app/src/lib/helpers/tokenUtils.ts
@@ -20,16 +20,33 @@ export const formatSwapAmount = (
   return formatter.format(numAmount);
 };
 
+/**
+ * Convert a decimal amount into its smallest on-chain integer unit.
+ *
+ * String/BigInt-safe: parses the decimal string directly with no float
+ * multiplication, so values like "0.41" convert exactly (4100000n, not
+ * 4099999n). Fractional digits beyond `decimals` are truncated (floored).
+ *
+ * For money paths, pass the raw user string rather than a parsed number —
+ * a `number` argument is coerced via toString() and may already carry
+ * float error before it reaches this function.
+ */
 export const toSmallestUnit = (
   amount: string | number,
   decimals: number = 7
-): string => {
-  const numAmount = typeof amount === "string" ? parseFloat(amount) : amount;
-  if (isNaN(numAmount)) return "0";
+): bigint => {
+  const str = typeof amount === "number" ? amount.toString() : amount.trim();
+  if (str === "" || isNaN(Number(str))) return 0n;
 
-  const multiplier = Math.pow(10, decimals);
-  const result = Math.floor(numAmount * multiplier).toString();
-  return result;
+  const negative = str.startsWith("-");
+  const unsigned = negative ? str.slice(1) : str;
+  const [whole = "0", frac = ""] = unsigned.split(".");
+
+  const fracTruncated = frac.slice(0, decimals).padEnd(decimals, "0");
+  const digits = `${whole}${fracTruncated}`.replace(/^0+(?=\d)/, "");
+
+  const result = BigInt(digits || "0");
+  return negative ? -result : result;
 };
 
 export const fromSmallestUnit = (

--- a/apps/web-app/src/lib/helpers/tokenUtils.ts
+++ b/apps/web-app/src/lib/helpers/tokenUtils.ts
@@ -58,7 +58,7 @@ export const toSmallestUnit = (
   decimals: number = 7
 ): bigint => {
   const str = typeof amount === "number" ? amount.toString() : amount.trim();
-  if (str === "" || isNaN(Number(str))) return 0n;
+  if (!/^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(str)) return 0n;
 
   const normalized = expandExponential(str);
   const negative = normalized.startsWith("-");

--- a/apps/web-app/src/lib/helpers/tokenUtils.ts
+++ b/apps/web-app/src/lib/helpers/tokenUtils.ts
@@ -21,6 +21,28 @@ export const formatSwapAmount = (
 };
 
 /**
+ * Expands exponential notation (e.g., "1e-7", "1.5e2") to plain decimal string.
+ * Handles both positive and negative exponents, preserving sign.
+ */
+const expandExponential = (s: string): string => {
+  const match = s.match(/^(-?)(\d+)(?:\.(\d+))?[eE]([+-]?\d+)$/);
+  if (!match) return s;
+  const [, sign, intPart, fracPart = "", expStr] = match;
+  const exp = parseInt(expStr, 10);
+  const digits = intPart + fracPart;
+  const pointPos = intPart.length + exp;
+  let result: string;
+  if (pointPos <= 0) {
+    result = "0." + "0".repeat(-pointPos) + digits;
+  } else if (pointPos >= digits.length) {
+    result = digits + "0".repeat(pointPos - digits.length);
+  } else {
+    result = digits.slice(0, pointPos) + "." + digits.slice(pointPos);
+  }
+  return sign + result;
+};
+
+/**
  * Convert a decimal amount into its smallest on-chain integer unit.
  *
  * String/BigInt-safe: parses the decimal string directly with no float
@@ -38,8 +60,9 @@ export const toSmallestUnit = (
   const str = typeof amount === "number" ? amount.toString() : amount.trim();
   if (str === "" || isNaN(Number(str))) return 0n;
 
-  const negative = str.startsWith("-");
-  const unsigned = negative ? str.slice(1) : str;
+  const normalized = expandExponential(str);
+  const negative = normalized.startsWith("-");
+  const unsigned = negative ? normalized.slice(1) : normalized;
   const [whole = "0", frac = ""] = unsigned.split(".");
 
   const fracTruncated = frac.slice(0, decimals).padEnd(decimals, "0");

--- a/apps/web-app/src/lib/services/lending.service.ts
+++ b/apps/web-app/src/lib/services/lending.service.ts
@@ -88,7 +88,7 @@ export class LendingService {
       const lendingContract = new Contract(networks.testnet.contractId);
 
       // Convert amount to smallest unit (i128)
-      const amountInSmallestUnit = BigInt(toSmallestUnit(amount, decimals));
+      const amountInSmallestUnit = toSmallestUnit(amount, decimals);
 
       // Convert assetCode to Symbol (ScVal)
       const assetSymbol = xdr.ScVal.scvSymbol(assetCode);
@@ -158,7 +158,7 @@ export class LendingService {
       const lendingContract = new Contract(networks.testnet.contractId);
 
       // Convert bTokens to smallest unit (i128)
-      const bTokensInSmallestUnit = BigInt(toSmallestUnit(bTokens, decimals));
+      const bTokensInSmallestUnit = toSmallestUnit(bTokens, decimals);
 
       // Convert assetCode to Symbol (ScVal)
       const assetSymbol = xdr.ScVal.scvSymbol(assetCode);
@@ -228,7 +228,7 @@ export class LendingService {
       const lendingContract = new Contract(networks.testnet.contractId);
 
       // Convert amount to smallest unit (i128)
-      const amountInSmallestUnit = BigInt(toSmallestUnit(amount, decimals));
+      const amountInSmallestUnit = toSmallestUnit(amount, decimals);
 
       // Convert assetCode to Symbol (ScVal)
       const assetSymbol = xdr.ScVal.scvSymbol(assetCode);
@@ -355,7 +355,7 @@ export class LendingService {
       const lendingContract = new Contract(networks.testnet.contractId);
 
       // Convert amount to smallest unit (i128)
-      const amountInSmallestUnit = BigInt(toSmallestUnit(amount, decimals));
+      const amountInSmallestUnit = toSmallestUnit(amount, decimals);
 
       // Build add_collateral transaction
       const operation = lendingContract.call(


### PR DESCRIPTION
## Summary

Financial amounts were losing precision because every money-moving flow converted a user-typed decimal string into the on-chain integer amount (Stellar stroops, 7 decimals) via `parseFloat(...) * 10**decimals` + `Math.floor`, computed in IEEE-754 float space and only cast to `BigInt` afterward. For example, `Math.floor(parseFloat("0.41") * 10**7)` evaluates to `4099999` instead of `4100000` — a systematic 1-stroop undercount on the exact integers submitted as Soroban transaction arguments.

This PR introduces a single canonical, string/BigInt-safe conversion utility and routes every call site through it.

Closes #257

## Changes

- **Canonical `toSmallestUnit(amount: string | number, decimals = 7): bigint`** in `lib/helpers/tokenUtils.ts` — parses the decimal string directly (split, truncate/pad the fractional part, concatenate, single `BigInt(...)`). No float multiplication. Truncates excess fractional digits (never over-counts real value), expands exponential notation before conversion, and rejects non-decimal input via an anchored numeric guard (`""`, `"abc"`, `"0x10"`, `"Infinity"`, `"+5"` → `0n`).
- **Removed the duplicate** `toSmallestUnit` in `soroswap/utils.ts` and the inline float copies in `useBorrow.ts` / `useLend.ts`.
- **Migrated all call sites** to the canonical helper and dropped the now-redundant `BigInt(...)` wraps: `lending.ts` (×9), `lending.service.ts` (×4), `soroswap/quotes.ts` (×3), `vault/useVaultAction.ts` (×2), `pools/PoolActionModal.tsx` (×1).
- **Vault slippage** (`useVaultAction.ts`): replaced the `Math.floor(SLIPPAGE * 100)` float math with float-free bigint math. `SLIPPAGE = 0.01` (a 1% fraction) still yields exactly a 1% deduction.
- **Admin forms** (`admin/InterestRateParamsForm.tsx`, `admin/CollateralFactorForm.tsx`): percentage/rate/amount → 7-decimal scalar now uses the string-safe helper. `supply_cap` (i128) stays a `bigint` with no float round-trip; the `u32` fields coerce to `number`.

## Semantics note

Conversion truncates (floors) fractional digits beyond the supported decimals, matching the dominant behavior across the money paths and guaranteeing no over-counting. This changes the admin forms from round-half-up to truncate, which is equivalent for realistic percentages (≤ 2 fractional digits) and only differs on inputs far outside the admin range.

## Testing

- New `tokenUtils.test.ts` covering the `0.41` regression, whole numbers, exact decimals, truncation of over-precision, empty/non-numeric → `0n`, leading zeros, `number` input, custom decimals, trailing dot, exponential notation, and the non-decimal-input hardening cases.
- Full web-app suite: **128/128 passing**.
- `tsc` and `eslint` on the touched files introduce no new errors (pre-existing, unrelated findings only).
