### PR TITLE
Feature/strategy module

### DIFF
--- a/apps/web-app/src/app/(app)/strategies/loading.tsx
+++ b/apps/web-app/src/app/(app)/strategies/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+export default function StrategiesLoading() {
+  return <PageSkeleton variant="cards" maxWidth="6xl" />;
+}

--- a/apps/web-app/src/app/(app)/strategies/page.tsx
+++ b/apps/web-app/src/app/(app)/strategies/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import Strategies from "@/features/strategies/components/Strategies";
+
+export const metadata: Metadata = {
+  title: "Strategies | Neko Protocol",
+  description:
+    "Compose, simulate, and execute reusable multi-step DeFi strategies across SoroSwap, RWA Lending, Blend, DeFindex, and Liquidity Pools on Stellar.",
+};
+
+export default function StrategiesPage() {
+  return <Strategies />;
+}

--- a/apps/web-app/src/components/navigation/sidebarConfig.ts
+++ b/apps/web-app/src/components/navigation/sidebarConfig.ts
@@ -10,6 +10,7 @@ import {
   TrendingUp,
   PieChart,
   Zap,
+  Workflow,
 } from "lucide-react";
 
 export const NAV_ITEMS = [
@@ -20,6 +21,7 @@ export const NAV_ITEMS = [
   { label: "Borrow", href: "/borrowing", icon: Landmark },
   { label: "Lend", href: "/lending", icon: TrendingUp },
   { label: "Vault", href: "/vaults", icon: Vault },
+  { label: "Strategies", href: "/strategies", icon: Workflow },
   { label: "Analytics", href: "/analytics", icon: PieChart },
   { label: "Automation", href: "/automation", icon: Zap },
   { label: "Ramps", href: "/ramps", icon: Banknote },

--- a/apps/web-app/src/features/strategies/__tests__/ExecutionUI.test.tsx
+++ b/apps/web-app/src/features/strategies/__tests__/ExecutionUI.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ExecutionProgress } from "../components/ExecutionUI";
+import type { ExecutionRecord, Strategy } from "@/lib/strategy/types";
+
+afterEach(cleanup);
+
+const strategy: Strategy = {
+  id: "s1",
+  version: 1,
+  name: "Test",
+  isTemplate: false,
+  createdAt: 0,
+  updatedAt: 0,
+  steps: [
+    {
+      id: "a",
+      type: "swap",
+      protocol: "soroswap",
+      label: "Swap Step",
+      params: {},
+      dependsOn: [],
+    },
+    {
+      id: "b",
+      type: "vaultDeposit",
+      protocol: "defindex",
+      label: "Deposit Step",
+      dependsOn: ["a"],
+      params: {},
+    },
+  ],
+};
+
+function execution(steps: ExecutionRecord["steps"]): ExecutionRecord {
+  return {
+    id: "e1",
+    strategyId: "s1",
+    strategySnapshot: strategy,
+    status: "in_progress",
+    startedAt: 0,
+    updatedAt: 0,
+    projectedOutcome: {},
+    steps,
+  };
+}
+
+describe("ExecutionProgress", () => {
+  it("renders every strategy step, defaulting to pending when no record exists yet", () => {
+    render(<ExecutionProgress strategy={strategy} execution={execution([])} />);
+    expect(screen.getByText("Swap Step")).toBeTruthy();
+    expect(screen.getByText("Deposit Step")).toBeTruthy();
+    expect(screen.getAllByText("Pending")).toHaveLength(2);
+  });
+
+  it("reflects each step's actual recorded status and shows a truncated tx hash when recorded", () => {
+    render(
+      <ExecutionProgress
+        strategy={strategy}
+        execution={execution([
+          { stepId: "a", status: "completed", txHash: "abcdef1234567890" },
+          { stepId: "b", status: "confirming" },
+        ])}
+      />
+    );
+    expect(screen.getByText(/^Completed/)).toBeTruthy();
+    expect(screen.getByText("Confirming on-chain")).toBeTruthy();
+    expect(screen.getByText(/abcdef12…/)).toBeTruthy();
+  });
+
+  it("renders as an ordered list for assistive tech", () => {
+    render(<ExecutionProgress strategy={strategy} execution={execution([])} />);
+    expect(
+      screen.getByRole("list", { name: /execution progress/i })
+    ).toBeTruthy();
+  });
+});

--- a/apps/web-app/src/features/strategies/__tests__/Strategies.test.tsx
+++ b/apps/web-app/src/features/strategies/__tests__/Strategies.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import {
+  TemplatePicker,
+  ResumeExecutionBanner,
+} from "../components/Strategies";
+import { STRATEGY_TEMPLATES } from "@/lib/strategy/templates";
+import type { ExecutionRecord } from "@/lib/strategy/types";
+
+afterEach(cleanup);
+
+describe("TemplatePicker", () => {
+  it("renders one card per built-in template", () => {
+    render(<TemplatePicker onUseTemplate={vi.fn()} />);
+    for (const template of STRATEGY_TEMPLATES) {
+      expect(screen.getByText(template.name)).toBeTruthy();
+    }
+  });
+
+  it("clicking 'Use template' calls onUseTemplate with that exact template", () => {
+    const onUseTemplate = vi.fn();
+    render(<TemplatePicker onUseTemplate={onUseTemplate} />);
+    const firstTemplate = STRATEGY_TEMPLATES[0];
+    const buttons = screen.getAllByRole("button", { name: /use template/i });
+    fireEvent.click(buttons[0]);
+    expect(onUseTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: firstTemplate.id, isTemplate: true })
+    );
+  });
+
+  it("every template card exposes an accessible button (keyboard reachable)", () => {
+    render(<TemplatePicker onUseTemplate={vi.fn()} />);
+    const buttons = screen.getAllByRole("button", { name: /use template/i });
+    expect(buttons).toHaveLength(STRATEGY_TEMPLATES.length);
+    buttons.forEach((btn) => expect(btn.tagName).toBe("BUTTON"));
+  });
+});
+
+function execution(overrides: Partial<ExecutionRecord> = {}): ExecutionRecord {
+  return {
+    id: "e1",
+    strategyId: "s1",
+    strategySnapshot: {},
+    status: "in_progress",
+    startedAt: 0,
+    updatedAt: 0,
+    projectedOutcome: {},
+    steps: [
+      { stepId: "a", status: "completed" },
+      { stepId: "b", status: "pending" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("ResumeExecutionBanner", () => {
+  it("renders nothing when there are no unfinished executions", () => {
+    const { container } = render(
+      <ResumeExecutionBanner
+        executions={[]}
+        onResume={vi.fn()}
+        onAbandon={vi.fn()}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows progress and mentions the deviation pause explicitly for a paused-deviation execution", () => {
+    render(
+      <ResumeExecutionBanner
+        executions={[execution()]}
+        onResume={vi.fn()}
+        onAbandon={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/1\/2 steps completed/)).toBeTruthy();
+
+    render(
+      <ResumeExecutionBanner
+        executions={[execution({ status: "paused-deviation" })]}
+        onResume={vi.fn()}
+        onAbandon={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/paused on a deviation/)).toBeTruthy();
+  });
+
+  it("Continue calls onResume and Abandon calls onAbandon with that execution", () => {
+    const onResume = vi.fn();
+    const onAbandon = vi.fn();
+    const exec = execution();
+    render(
+      <ResumeExecutionBanner
+        executions={[exec]}
+        onResume={onResume}
+        onAbandon={onAbandon}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onResume).toHaveBeenCalledWith(exec);
+    fireEvent.click(screen.getByRole("button", { name: /abandon execution/i }));
+    expect(onAbandon).toHaveBeenCalledWith(exec);
+  });
+});

--- a/apps/web-app/src/features/strategies/__tests__/StrategyComposer.test.tsx
+++ b/apps/web-app/src/features/strategies/__tests__/StrategyComposer.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { StepCard } from "../components/StrategyComposer";
+import type { Strategy, StrategyStep } from "@/lib/strategy/types";
+
+afterEach(cleanup);
+
+const step: StrategyStep = {
+  id: "a",
+  type: "swap",
+  protocol: "soroswap",
+  label: "Swap XLM to USDC",
+  params: { tokenIn: { source: "literal", value: "XLM" } },
+  dependsOn: [],
+};
+
+const strategy: Strategy = {
+  id: "s1",
+  version: 1,
+  name: "Test",
+  isTemplate: false,
+  steps: [step],
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+describe("StepCard — keyboard-operable reordering and accessibility", () => {
+  it("exposes labeled Move Up / Move Down / Remove buttons reachable by role+name (keyboard/screen-reader path)", () => {
+    render(
+      <StepCard
+        strategy={strategy}
+        step={step}
+        index={0}
+        total={2}
+        onMove={vi.fn()}
+        onRemove={vi.fn()}
+        onParamsChange={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /move swap xlm to usdc up/i })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /move swap xlm to usdc down/i })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /remove swap xlm to usdc/i })
+    ).toBeTruthy();
+  });
+
+  it("disables Move Up for the first step and Move Down for the last step", () => {
+    render(
+      <StepCard
+        strategy={strategy}
+        step={step}
+        index={0}
+        total={1}
+        onMove={vi.fn()}
+        onRemove={vi.fn()}
+        onParamsChange={vi.fn()}
+      />
+    );
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /move swap xlm to usdc up/i,
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(true);
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /move swap xlm to usdc down/i,
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(true);
+  });
+
+  it("clicking Move Down calls onMove('down'), Remove calls onRemove", () => {
+    const onMove = vi.fn();
+    const onRemove = vi.fn();
+    render(
+      <StepCard
+        strategy={strategy}
+        step={step}
+        index={0}
+        total={2}
+        onMove={onMove}
+        onRemove={onRemove}
+        onParamsChange={vi.fn()}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /move swap xlm to usdc down/i })
+    );
+    expect(onMove).toHaveBeenCalledWith("down");
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove swap xlm to usdc/i })
+    );
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it("expanding the card reveals the params form with the existing param visible", () => {
+    render(
+      <StepCard
+        strategy={strategy}
+        step={step}
+        index={0}
+        total={2}
+        onMove={vi.fn()}
+        onRemove={vi.fn()}
+        onParamsChange={vi.fn()}
+      />
+    );
+    const toggle = screen.getByRole("button", {
+      name: /edit swap xlm to usdc parameters/i,
+    });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("tokenIn")).toBeTruthy();
+  });
+});

--- a/apps/web-app/src/features/strategies/__tests__/hooks.test.ts
+++ b/apps/web-app/src/features/strategies/__tests__/hooks.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  useStrategyComposerState,
+  createEmptyStrategy,
+  cloneAsEditable,
+} from "../hooks";
+import type { Strategy } from "@/lib/strategy/types";
+
+describe("createEmptyStrategy / cloneAsEditable", () => {
+  it("creates an empty, non-template strategy with a fresh id each time", () => {
+    const s1 = createEmptyStrategy();
+    const s2 = createEmptyStrategy();
+    expect(s1.isTemplate).toBe(false);
+    expect(s1.steps).toEqual([]);
+    expect(s1.id).not.toBe(s2.id);
+  });
+
+  it("clones a template into an editable draft with a new id and isTemplate:false, preserving steps", () => {
+    const template: Strategy = {
+      id: "template-x",
+      version: 1,
+      name: "Template X",
+      isTemplate: true,
+      steps: [
+        {
+          id: "a",
+          type: "swap",
+          protocol: "soroswap",
+          label: "Swap",
+          params: {},
+          dependsOn: [],
+        },
+      ],
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const draft = cloneAsEditable(template);
+    expect(draft.id).not.toBe(template.id);
+    expect(draft.isTemplate).toBe(false);
+    expect(draft.steps).toEqual(template.steps);
+  });
+});
+
+describe("useStrategyComposerState", () => {
+  it("addStep appends a new step with a generated id", () => {
+    const { result } = renderHook(() =>
+      useStrategyComposerState(createEmptyStrategy())
+    );
+    act(() =>
+      result.current.addStep({
+        type: "swap",
+        protocol: "soroswap",
+        label: "Swap",
+        params: {},
+        dependsOn: [],
+      })
+    );
+    expect(result.current.strategy.steps).toHaveLength(1);
+    expect(result.current.strategy.steps[0].id).toBeTruthy();
+  });
+
+  it("moveStep swaps with the neighbor and is a no-op at the boundary", () => {
+    const initial = createEmptyStrategy();
+    initial.steps = [
+      {
+        id: "a",
+        type: "swap",
+        protocol: "soroswap",
+        label: "A",
+        params: {},
+        dependsOn: [],
+      },
+      {
+        id: "b",
+        type: "swap",
+        protocol: "soroswap",
+        label: "B",
+        params: {},
+        dependsOn: [],
+      },
+    ];
+    const { result } = renderHook(() => useStrategyComposerState(initial));
+    act(() => result.current.moveStep("b", "up"));
+    expect(result.current.strategy.steps.map((s) => s.id)).toEqual(["b", "a"]);
+    act(() => result.current.moveStep("b", "up")); // "b" is now first — no-op
+    expect(result.current.strategy.steps.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+
+  it("removeStep drops the step and prunes dependent dependsOn/bindings referencing it", () => {
+    const initial = createEmptyStrategy();
+    initial.steps = [
+      {
+        id: "a",
+        type: "swap",
+        protocol: "soroswap",
+        label: "A",
+        params: {},
+        dependsOn: [],
+      },
+      {
+        id: "b",
+        type: "vaultDeposit",
+        protocol: "defindex",
+        label: "B",
+        dependsOn: ["a"],
+        params: {
+          amount: { source: "stepOutput", stepId: "a", portId: "out.amount" },
+        },
+      },
+    ];
+    const { result } = renderHook(() => useStrategyComposerState(initial));
+    act(() => result.current.removeStep("a"));
+    expect(result.current.strategy.steps).toHaveLength(1);
+    expect(result.current.strategy.steps[0].dependsOn).toEqual([]);
+    expect(result.current.strategy.steps[0].params.amount).toBeUndefined();
+  });
+
+  it("updateStepParams replaces a step's params by id, and rename updates the strategy name", () => {
+    const initial = createEmptyStrategy("Old");
+    initial.steps = [
+      {
+        id: "a",
+        type: "swap",
+        protocol: "soroswap",
+        label: "A",
+        params: {},
+        dependsOn: [],
+      },
+    ];
+    const { result } = renderHook(() => useStrategyComposerState(initial));
+    act(() =>
+      result.current.updateStepParams("a", {
+        tokenIn: { source: "literal", value: "XLM" },
+      })
+    );
+    expect(result.current.strategy.steps[0].params).toEqual({
+      tokenIn: { source: "literal", value: "XLM" },
+    });
+    act(() => result.current.rename("New name"));
+    expect(result.current.strategy.name).toBe("New name");
+  });
+});

--- a/apps/web-app/src/features/strategies/components/ExecutionUI.tsx
+++ b/apps/web-app/src/features/strategies/components/ExecutionUI.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CircleDashed,
+  Loader2,
+  PauseCircle,
+  XCircle,
+} from "lucide-react";
+import { ModalPortal } from "@/components/ui/ModalPortal";
+import { computeSensitivity } from "@/lib/strategy/engine";
+import { getHealthFactorColor } from "@/features/borrowing/const/riskThresholds";
+import type {
+  ExecutionRecord,
+  ExecutionStepRecord,
+  RiskAssessment,
+  Strategy,
+  StrategyProjection,
+} from "@/lib/strategy/types";
+import { formatBps, formatMultiplier, formatNumber } from "../utils";
+
+// ─── Simulation summary ──────────────────────────────────────────────────────
+
+export interface SimulationSummaryProps {
+  projection: StrategyProjection;
+}
+
+/** Cumulative fees/slippage/APY/leverage/health factor/liquidation price, plus the per-step breakdown. */
+export function SimulationSummary({ projection }: SimulationSummaryProps) {
+  if (!projection.success) {
+    return (
+      <div className="rounded-xl border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-300">
+        <p className="font-medium">
+          Simulation failed at step &quot;{projection.failedStepId}&quot;
+        </p>
+        <p className="mt-1 text-red-300/80">{projection.failureReason}</p>
+      </div>
+    );
+  }
+
+  const stats: { label: string; value: string; className?: string }[] = [
+    { label: "Cumulative fee", value: `${projection.cumulativeFee} XLM` },
+    {
+      label: "Cumulative slippage",
+      value: formatBps(projection.cumulativeSlippageBps),
+    },
+    {
+      label: "Projected APY",
+      value:
+        projection.projectedApy != null
+          ? `${formatNumber(projection.projectedApy)}%`
+          : "—",
+    },
+    {
+      label: "Effective leverage",
+      value: formatMultiplier(projection.effectiveLeverage),
+    },
+    {
+      label: "Projected health factor",
+      value: formatNumber(projection.projectedHealthFactor),
+      className: getHealthFactorColor(projection.projectedHealthFactor),
+    },
+    {
+      label: "Liquidation price",
+      value: formatNumber(projection.projectedLiquidationPrice),
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        {stats.map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-xl border border-white/10 bg-white/[0.03] p-3"
+          >
+            <p className="text-[11px] uppercase tracking-wide text-white/40">
+              {stat.label}
+            </p>
+            <p
+              className={`mt-1 text-lg font-semibold ${stat.className ?? "text-white"}`}
+            >
+              {stat.value}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h4 className="text-xs font-semibold uppercase tracking-widest text-white/40">
+          Per-step projection
+        </h4>
+        {Object.entries(projection.steps).map(([stepId, step]) => (
+          <div
+            key={stepId}
+            className="flex items-center justify-between rounded-lg border border-white/5 bg-white/[0.02] px-3 py-2 text-sm"
+          >
+            <span className="text-white/70">{stepId}</span>
+            <span className="text-white/50">
+              fee {step.estimatedFee}
+              {step.slippageBps != null
+                ? ` · ${formatBps(step.slippageBps)} slippage`
+                : ""}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Sensitivity panel ───────────────────────────────────────────────────────
+
+export interface SensitivityPanelProps {
+  baseline: StrategyProjection;
+}
+
+/** Slippage/market-movement scenario table, computed analytically from a single baseline simulation. */
+export function SensitivityPanel({ baseline }: SensitivityPanelProps) {
+  const scenarios = useMemo(() => computeSensitivity(baseline), [baseline]);
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-white/10">
+      <table className="w-full min-w-[480px] text-left text-sm">
+        <thead>
+          <tr className="border-b border-white/10 text-xs uppercase tracking-wide text-white/40">
+            <th className="px-3 py-2">Scenario</th>
+            <th className="px-3 py-2">Slippage</th>
+            <th className="px-3 py-2">Health factor</th>
+            <th className="px-3 py-2">Liquidation price</th>
+          </tr>
+        </thead>
+        <tbody>
+          {scenarios.map((scenario) => (
+            <tr
+              key={scenario.label}
+              className="border-b border-white/5 last:border-0"
+            >
+              <td className="px-3 py-2 text-white/80">{scenario.label}</td>
+              <td className="px-3 py-2 text-white/60">
+                {formatBps(scenario.projection.cumulativeSlippageBps)}
+              </td>
+              <td className="px-3 py-2 text-white/60">
+                {formatNumber(scenario.projection.projectedHealthFactor)}
+              </td>
+              <td className="px-3 py-2 text-white/60">
+                {formatNumber(scenario.projection.projectedLiquidationPrice)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─── Risk acknowledgement modal ──────────────────────────────────────────────
+
+export interface RiskAcknowledgementModalProps {
+  assessment: RiskAssessment;
+  onAcknowledge: () => void;
+  onCancel: () => void;
+}
+
+/** Blocks execution start until the user explicitly acknowledges an over-threshold risk assessment. */
+export function RiskAcknowledgementModal({
+  assessment,
+  onAcknowledge,
+  onCancel,
+}: RiskAcknowledgementModalProps) {
+  return (
+    <ModalPortal>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="risk-ack-title"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      >
+        <div className="w-full max-w-md rounded-2xl border border-yellow-500/30 bg-[#1C1C1C] p-6">
+          <div className="flex items-center gap-2 text-yellow-300">
+            <AlertTriangle size={20} />
+            <h2 id="risk-ack-title" className="text-base font-semibold">
+              This strategy exceeds your safety thresholds
+            </h2>
+          </div>
+
+          <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <dt className="text-white/40">Effective leverage</dt>
+              <dd className="text-white">
+                {formatMultiplier(assessment.effectiveLeverage)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-white/40">Health factor</dt>
+              <dd className="text-white">
+                {formatNumber(assessment.projectedHealthFactor)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-white/40">Cumulative slippage</dt>
+              <dd className="text-white">
+                {formatBps(assessment.cumulativeSlippageBps)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-white/40">Risk tier</dt>
+              <dd className="text-white capitalize">{assessment.riskTier}</dd>
+            </div>
+          </dl>
+
+          <p className="mt-4 text-sm text-white/60">
+            Proceeding executes real on-chain transactions at this risk level.
+            Confirm you understand the risk before continuing.
+          </p>
+
+          <div className="mt-6 flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-full px-4 py-2 text-sm text-white/60 hover:text-white"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={onAcknowledge}
+              className="rounded-full bg-yellow-500 px-4 py-2 text-sm font-semibold text-black hover:bg-yellow-400"
+            >
+              I understand the risk, proceed
+            </button>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}
+
+// ─── Execution progress ──────────────────────────────────────────────────────
+
+export interface ExecutionProgressProps {
+  strategy: Strategy;
+  execution: ExecutionRecord;
+}
+
+const STATUS_ICON: Record<string, React.ReactNode> = {
+  pending: <CircleDashed size={16} className="text-white/30" />,
+  preparing: <Loader2 size={16} className="animate-spin text-[#229EDF]" />,
+  awaiting_signature: (
+    <Loader2 size={16} className="animate-spin text-[#229EDF]" />
+  ),
+  submitting: <Loader2 size={16} className="animate-spin text-[#229EDF]" />,
+  confirming: <Loader2 size={16} className="animate-spin text-[#229EDF]" />,
+  completed: <CheckCircle2 size={16} className="text-green-400" />,
+  failed: <XCircle size={16} className="text-red-400" />,
+  paused_deviation: <PauseCircle size={16} className="text-yellow-400" />,
+  cancelled: <XCircle size={16} className="text-white/30" />,
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  pending: "Pending",
+  preparing: "Preparing transaction",
+  awaiting_signature: "Awaiting your signature",
+  submitting: "Submitting",
+  confirming: "Confirming on-chain",
+  completed: "Completed",
+  failed: "Failed",
+  paused_deviation: "Paused — result deviated from projection",
+  cancelled: "Cancelled",
+};
+
+/** Step-by-step guided execution status: prepare / sign / submit / confirm per step. */
+export function ExecutionProgress({
+  strategy,
+  execution,
+}: ExecutionProgressProps) {
+  return (
+    <ol className="flex flex-col gap-2" aria-label="Execution progress">
+      {strategy.steps.map((step, i) => {
+        const record = execution.steps.find((s) => s.stepId === step.id);
+        const status = record?.status ?? "pending";
+        return (
+          <li
+            key={step.id}
+            className="flex items-center gap-3 rounded-xl border border-white/10 bg-[#1C1C1C] p-3"
+          >
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white/5 text-xs text-white/50">
+              {i + 1}
+            </span>
+            {STATUS_ICON[status]}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm text-white">{step.label}</p>
+              <p className="truncate text-xs text-white/40">
+                {STATUS_LABEL[status]}
+                {record?.txHash ? ` · ${record.txHash.slice(0, 8)}…` : ""}
+              </p>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+// ─── Deviation pause modal ────────────────────────────────────────────────────
+
+export interface DeviationPauseModalProps {
+  step: ExecutionStepRecord;
+  stepLabel: string;
+  onResume: () => void;
+  onAbandon: () => void;
+}
+
+/** Shown when a step's confirmed on-chain result deviates beyond threshold from its projection. */
+export function DeviationPauseModal({
+  step,
+  stepLabel,
+  onResume,
+  onAbandon,
+}: DeviationPauseModalProps) {
+  const deviation = step.deviation;
+
+  return (
+    <ModalPortal>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="deviation-title"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      >
+        <div className="w-full max-w-md rounded-2xl border border-yellow-500/30 bg-[#1C1C1C] p-6">
+          <div className="flex items-center gap-2 text-yellow-300">
+            <PauseCircle size={20} />
+            <h2 id="deviation-title" className="text-base font-semibold">
+              Execution paused: &quot;{stepLabel}&quot; deviated from projection
+            </h2>
+          </div>
+
+          <p className="mt-3 text-sm text-white/70">
+            {deviation?.message ??
+              "This step's on-chain result differs significantly from what was simulated."}
+          </p>
+
+          {deviation && (
+            <p className="mt-2 text-xs text-white/40">
+              Deviation: {((deviation.relativeDeviation ?? 0) * 100).toFixed(1)}
+              % (threshold {(deviation.threshold * 100).toFixed(1)}%)
+            </p>
+          )}
+
+          <p className="mt-4 text-sm text-white/60">
+            The remaining steps have not run. Resume to continue with the actual
+            result, or abandon this execution (the transactions already
+            submitted stay on-chain and in your history either way).
+          </p>
+
+          <div className="mt-6 flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onAbandon}
+              className="rounded-full px-4 py-2 text-sm text-white/60 hover:text-white"
+            >
+              Abandon
+            </button>
+            <button
+              type="button"
+              onClick={onResume}
+              className="rounded-full bg-[#229EDF] px-4 py-2 text-sm font-semibold text-white hover:bg-[#1c8bc4]"
+            >
+              Resume anyway
+            </button>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/apps/web-app/src/features/strategies/components/Strategies.tsx
+++ b/apps/web-app/src/features/strategies/components/Strategies.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Layers,
+  Pencil,
+  Play,
+  RotateCcw,
+  Trash2,
+  Workflow,
+  X,
+} from "lucide-react";
+import { BannerPage } from "@/components/ui/BannerPage";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { useWallet } from "@/hooks/useWallet";
+import {
+  useStrategyPersistence,
+  useExecutionRecovery,
+} from "@/lib/strategy/hooks";
+import { listExecutions, upsertExecution } from "@/lib/strategy/persistence";
+import { STRATEGY_TEMPLATES } from "@/lib/strategy/templates";
+import type { ExecutionRecord, Strategy } from "@/lib/strategy/types";
+import { STRATEGIES_TABS, type StrategiesTab } from "../utils";
+import { createEmptyStrategy, cloneAsEditable } from "../hooks";
+import { StrategyComposer } from "./StrategyComposer";
+
+// ─── Strategy list ───────────────────────────────────────────────────────────
+
+export interface StrategyListProps {
+  strategies: Strategy[];
+  isLoading: boolean;
+  onCreate: () => void;
+  onEdit: (strategy: Strategy) => void;
+  onDelete: (strategyId: string) => void;
+  onOpen: (strategy: Strategy) => void;
+}
+
+export function StrategyList({
+  strategies,
+  isLoading,
+  onCreate,
+  onEdit,
+  onDelete,
+  onOpen,
+}: StrategyListProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-white/80">Your strategies</h3>
+        <button
+          type="button"
+          onClick={onCreate}
+          className="rounded-full bg-[#229EDF] px-4 py-2 text-sm font-semibold text-white hover:bg-[#1c8bc4]"
+        >
+          Create strategy
+        </button>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-white/40">Loading…</p>
+      ) : strategies.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-white/10 py-16 text-center">
+          <Layers size={28} className="text-white/20" />
+          <p className="text-sm text-white/40">
+            No strategies yet — start from a template or create one from
+            scratch.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {strategies.map((strategy) => (
+            <div
+              key={strategy.id}
+              className="flex flex-col justify-between rounded-2xl border border-white/10 bg-[#1C1C1C] p-4"
+            >
+              <button
+                type="button"
+                onClick={() => onOpen(strategy)}
+                className="text-left"
+              >
+                <h4 className="text-sm font-semibold text-white">
+                  {strategy.name}
+                </h4>
+                <p className="mt-1 text-xs text-white/40">
+                  {strategy.steps.length} steps
+                </p>
+              </button>
+              <div className="mt-3 flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => onOpen(strategy)}
+                  aria-label={`Run ${strategy.name}`}
+                  className="flex items-center gap-1 rounded-full border border-white/10 px-2.5 py-1 text-xs text-white/70 hover:bg-white/5"
+                >
+                  <Play size={12} /> Open
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onEdit(strategy)}
+                  aria-label={`Edit ${strategy.name}`}
+                  className="rounded-full p-1.5 text-white/40 hover:bg-white/5 hover:text-white"
+                >
+                  <Pencil size={13} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDelete(strategy.id)}
+                  aria-label={`Delete ${strategy.name}`}
+                  className="rounded-full p-1.5 text-white/40 hover:bg-white/5 hover:text-red-400"
+                >
+                  <Trash2 size={13} />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Template picker ─────────────────────────────────────────────────────────
+
+export interface TemplatePickerProps {
+  onUseTemplate: (template: Strategy) => void;
+}
+
+/** The 4 built-in templates, presented as selectable cards. "Use Template" clones the data, no separate code path. */
+export function TemplatePicker({ onUseTemplate }: TemplatePickerProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {STRATEGY_TEMPLATES.map((template) => (
+        <div
+          key={template.id}
+          className="flex flex-col justify-between rounded-2xl border border-white/10 bg-[#1C1C1C] p-5"
+        >
+          <div>
+            <h3 className="text-sm font-semibold text-white">
+              {template.name}
+            </h3>
+            <p className="mt-1 text-xs text-white/50">{template.description}</p>
+            <p className="mt-3 text-xs text-white/30">
+              {template.steps.length} steps
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onUseTemplate(template)}
+            className="mt-4 self-start rounded-full bg-[#229EDF] px-4 py-2 text-sm font-semibold text-white hover:bg-[#1c8bc4] focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+          >
+            Use template
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Execution history table ─────────────────────────────────────────────────
+
+const STATUS_CLASS: Record<string, string> = {
+  completed: "text-green-400",
+  in_progress: "text-[#229EDF]",
+  failed: "text-red-400",
+  "paused-deviation": "text-yellow-400",
+  abandoned: "text-white/40",
+};
+
+/** Persisted execution history: projected and actual outcomes, status, and tx references. */
+export function ExecutionHistoryTable({
+  executions,
+}: {
+  executions: ExecutionRecord[];
+}) {
+  if (executions.length === 0) {
+    return (
+      <p className="rounded-xl border border-dashed border-white/10 p-6 text-center text-sm text-white/40">
+        No executions yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-white/10">
+      <table className="w-full min-w-[560px] text-left text-sm">
+        <thead>
+          <tr className="border-b border-white/10 text-xs uppercase tracking-wide text-white/40">
+            <th className="px-3 py-2">Started</th>
+            <th className="px-3 py-2">Strategy</th>
+            <th className="px-3 py-2">Status</th>
+            <th className="px-3 py-2">Steps completed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {executions
+            .slice()
+            .sort((a, b) => b.startedAt - a.startedAt)
+            .map((execution) => {
+              const completed = execution.steps.filter(
+                (s) => s.status === "completed"
+              ).length;
+              return (
+                <tr
+                  key={execution.id}
+                  className="border-b border-white/5 last:border-0"
+                >
+                  <td className="px-3 py-2 text-white/60">
+                    {new Date(execution.startedAt).toLocaleString()}
+                  </td>
+                  <td className="px-3 py-2 text-white/80">
+                    {execution.strategyId}
+                  </td>
+                  <td
+                    className={`px-3 py-2 font-medium ${STATUS_CLASS[execution.status] ?? "text-white/60"}`}
+                  >
+                    {execution.status}
+                  </td>
+                  <td className="px-3 py-2 text-white/60">
+                    {completed}/{execution.steps.length}
+                  </td>
+                </tr>
+              );
+            })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─── Resume execution banner ─────────────────────────────────────────────────
+
+export interface ResumeExecutionBannerProps {
+  executions: ExecutionRecord[];
+  onResume: (execution: ExecutionRecord) => void;
+  onAbandon: (execution: ExecutionRecord) => void;
+}
+
+/** Surfaces unfinished executions detected on reopen — continue or abandon without losing history. */
+export function ResumeExecutionBanner({
+  executions,
+  onResume,
+  onAbandon,
+}: ResumeExecutionBannerProps) {
+  if (executions.length === 0) return null;
+
+  return (
+    <div className="mb-6 flex flex-col gap-2 rounded-xl border border-[#229EDF]/30 bg-[#229EDF]/10 p-4">
+      {executions.map((execution) => {
+        const completed = execution.steps.filter(
+          (s) => s.status === "completed"
+        ).length;
+        return (
+          <div
+            key={execution.id}
+            className="flex items-center justify-between gap-3"
+          >
+            <p className="text-sm text-white/80">
+              An unfinished strategy execution is waiting to resume ({completed}
+              /{execution.steps.length} steps completed
+              {execution.status === "paused-deviation"
+                ? ", paused on a deviation"
+                : ""}
+              ).
+            </p>
+            <div className="flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                onClick={() => onResume(execution)}
+                className="flex items-center gap-1.5 rounded-full bg-[#229EDF] px-3 py-1.5 text-xs font-semibold text-white hover:bg-[#1c8bc4]"
+              >
+                <RotateCcw size={14} />
+                Continue
+              </button>
+              <button
+                type="button"
+                onClick={() => onAbandon(execution)}
+                aria-label="Abandon execution"
+                className="rounded-full p-1.5 text-white/50 hover:bg-white/10 hover:text-white"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+export function Strategies() {
+  const { address } = useWallet();
+  const [tab, setTab] = useState<StrategiesTab>("my-strategies");
+  const [composing, setComposing] = useState<Strategy | null>(null);
+
+  const { strategies, isLoading, saveStrategy, deleteStrategy } =
+    useStrategyPersistence();
+  const { resumable, refresh } = useExecutionRecovery();
+
+  const executions: ExecutionRecord[] = address ? listExecutions(address) : [];
+
+  if (!address) {
+    return (
+      <PageContainer maxWidth="6xl">
+        <BannerPage
+          title="Strategies"
+          subtitle="Compose, simulate, and execute reusable multi-step DeFi strategies across every protocol Neko integrates."
+        />
+        <div className="mt-6 flex flex-col items-center gap-4 rounded-2xl border border-dashed border-white/10 py-20 text-center">
+          <Workflow size={36} className="text-white/20" />
+          <p className="text-white/50">
+            Connect your wallet to build and run strategies.
+          </p>
+        </div>
+      </PageContainer>
+    );
+  }
+
+  if (composing) {
+    return (
+      <PageContainer maxWidth="6xl">
+        <StrategyComposer
+          initial={composing}
+          onClose={() => setComposing(null)}
+        />
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer maxWidth="6xl">
+      <BannerPage
+        title="Strategies"
+        subtitle="Compose, simulate, and execute reusable multi-step DeFi strategies across every protocol Neko integrates."
+      />
+
+      <div className="mt-6">
+        <ResumeExecutionBanner
+          executions={resumable}
+          onResume={(execution) =>
+            setComposing(execution.strategySnapshot as Strategy)
+          }
+          onAbandon={(execution) => {
+            if (!address) return;
+            upsertExecution(address, { ...execution, status: "abandoned" });
+            void refresh();
+          }}
+        />
+      </div>
+
+      <div
+        className="mb-6 flex gap-1 rounded-xl border border-white/10 bg-white/5 p-1 w-fit"
+        role="tablist"
+        aria-label="Strategies sections"
+      >
+        {STRATEGIES_TABS.map((t) => (
+          <button
+            key={t.key}
+            role="tab"
+            aria-selected={tab === t.key}
+            onClick={() => setTab(t.key)}
+            className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#229EDF] ${
+              tab === t.key
+                ? "bg-white/10 text-white"
+                : "text-white/50 hover:text-white"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "my-strategies" && (
+        <StrategyList
+          strategies={strategies}
+          isLoading={isLoading}
+          onCreate={() => setComposing(createEmptyStrategy())}
+          onEdit={(strategy) => setComposing(strategy)}
+          onOpen={(strategy) => setComposing(strategy)}
+          onDelete={(id) => deleteStrategy(id)}
+        />
+      )}
+
+      {tab === "templates" && (
+        <TemplatePicker
+          onUseTemplate={(template) => {
+            const draft = cloneAsEditable(template);
+            saveStrategy(draft);
+            setComposing(draft);
+          }}
+        />
+      )}
+
+      {tab === "history" && <ExecutionHistoryTable executions={executions} />}
+    </PageContainer>
+  );
+}
+
+export default Strategies;

--- a/apps/web-app/src/features/strategies/components/StrategyComposer.tsx
+++ b/apps/web-app/src/features/strategies/components/StrategyComposer.tsx
@@ -1,0 +1,658 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { nanoid } from "nanoid";
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  CheckCircle2,
+  ChevronDown,
+  ChevronLeft,
+  ChevronUp,
+  Trash2,
+} from "lucide-react";
+import { useWallet } from "@/hooks/useWallet";
+import { useToast } from "@/hooks/useToast";
+import {
+  useStrategyPersistence,
+  useStrategyValidation,
+  useStrategySimulation,
+  useStrategyExecution,
+} from "@/lib/strategy/hooks";
+import { exceedsThresholds } from "@/lib/strategy/engine";
+import { strategyStepRegistry } from "@/lib/strategy/registry";
+import { getRiskTier } from "@/features/borrowing/utils/liquidationPrice";
+import type {
+  ExecutionRecord,
+  ParamBinding,
+  RiskAssessment,
+  StepPort,
+  Strategy,
+  StrategyStep,
+  StrategyStepDefinition,
+  ValidationResult,
+} from "@/lib/strategy/types";
+import { useStrategyComposerState } from "../hooks";
+import {
+  SimulationSummary,
+  SensitivityPanel,
+  RiskAcknowledgementModal,
+  ExecutionProgress,
+  DeviationPauseModal,
+} from "./ExecutionUI";
+
+// ─── Step palette ────────────────────────────────────────────────────────────
+
+export interface StepPaletteProps {
+  onAdd: (definition: StrategyStepDefinition) => void;
+}
+
+/** "Add step" picker, grouped by step type, backed by the registered step definitions. */
+export function StepPalette({ onAdd }: StepPaletteProps) {
+  const definitions = useMemo(() => strategyStepRegistry.listRegistered(), []);
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+      <h4 className="mb-3 text-xs font-semibold uppercase tracking-widest text-white/40">
+        Add a step
+      </h4>
+      <div
+        className="flex flex-wrap gap-2"
+        role="list"
+        aria-label="Available step types"
+      >
+        {definitions.map((definition) => (
+          <button
+            key={`${definition.stepType}:${definition.protocol}`}
+            type="button"
+            role="listitem"
+            onClick={() => onAdd(definition)}
+            className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/80 transition-colors hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#229EDF]"
+          >
+            {definition.stepType}
+            <span className="ml-1.5 text-white/40">
+              ({definition.protocol})
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Port binding editor ─────────────────────────────────────────────────────
+
+export interface UpstreamPortOption {
+  stepId: string;
+  stepLabel: string;
+  port: StepPort;
+}
+
+interface PortBindingEditorProps {
+  paramKey: string;
+  binding: ParamBinding;
+  upstreamOptions: UpstreamPortOption[];
+  onChange: (binding: ParamBinding) => void;
+}
+
+/**
+ * Lets a step's param be bound either to a literal value or to an upstream
+ * step's output port. Uses native <select>/<input> — screen-reader
+ * friendly and keyboard operable by default, no custom widget needed.
+ */
+function PortBindingEditor({
+  paramKey,
+  binding,
+  upstreamOptions,
+  onChange,
+}: PortBindingEditorProps) {
+  const inputId = `param-${paramKey}`;
+  const sourceId = `param-source-${paramKey}`;
+
+  return (
+    <div className="flex flex-1 items-center gap-2">
+      <label htmlFor={sourceId} className="sr-only">
+        {paramKey} source
+      </label>
+      <select
+        id={sourceId}
+        value={binding.source}
+        onChange={(e) => {
+          if (e.target.value === "literal")
+            onChange({ source: "literal", value: "" });
+          else if (upstreamOptions[0])
+            onChange({
+              source: "stepOutput",
+              stepId: upstreamOptions[0].stepId,
+              portId: upstreamOptions[0].port.id,
+            });
+        }}
+        className="rounded-lg border border-white/10 bg-[#121212] px-2 py-1.5 text-xs text-white/70"
+      >
+        <option value="literal">Fixed value</option>
+        <option value="stepOutput" disabled={upstreamOptions.length === 0}>
+          From previous step
+        </option>
+      </select>
+
+      {binding.source === "literal" ? (
+        <>
+          <label htmlFor={inputId} className="sr-only">
+            {paramKey} value
+          </label>
+          <input
+            id={inputId}
+            type="text"
+            value={
+              typeof binding.value === "string"
+                ? binding.value
+                : String(binding.value ?? "")
+            }
+            onChange={(e) =>
+              onChange({ source: "literal", value: e.target.value })
+            }
+            className="min-w-0 flex-1 rounded-lg border border-white/10 bg-[#121212] px-2 py-1.5 text-sm text-white"
+          />
+        </>
+      ) : (
+        <>
+          <label htmlFor={inputId} className="sr-only">
+            {paramKey} source port
+          </label>
+          <select
+            id={inputId}
+            value={`${binding.stepId}::${binding.portId}`}
+            onChange={(e) => {
+              const [stepId, portId] = e.target.value.split("::");
+              onChange({ source: "stepOutput", stepId, portId });
+            }}
+            className="min-w-0 flex-1 rounded-lg border border-white/10 bg-[#121212] px-2 py-1.5 text-sm text-white"
+          >
+            {upstreamOptions.map(({ stepId, stepLabel, port }) => (
+              <option
+                key={`${stepId}::${port.id}`}
+                value={`${stepId}::${port.id}`}
+              >
+                {stepLabel} → {port.id}
+              </option>
+            ))}
+          </select>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Step params form ────────────────────────────────────────────────────────
+
+interface StepParamsFormProps {
+  params: Record<string, ParamBinding>;
+  upstreamOptions: UpstreamPortOption[];
+  onChange: (params: Record<string, ParamBinding>) => void;
+}
+
+/**
+ * A generic key/value parameter editor — each step definition declares its
+ * own paramsSchema, so rather than hand-building a bespoke form per step
+ * type, this lets the user add/edit/remove named params directly, with a
+ * literal-vs-bound-to-upstream-output toggle per param (PortBindingEditor).
+ */
+function StepParamsForm({
+  params,
+  upstreamOptions,
+  onChange,
+}: StepParamsFormProps) {
+  const [newKey, setNewKey] = useState("");
+
+  const setParam = (key: string, binding: ParamBinding) =>
+    onChange({ ...params, [key]: binding });
+  const removeParam = (key: string) => {
+    const next = { ...params };
+    delete next[key];
+    onChange(next);
+  };
+  const addParam = () => {
+    const key = newKey.trim();
+    if (!key || params[key]) return;
+    onChange({ ...params, [key]: { source: "literal", value: "" } });
+    setNewKey("");
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {Object.entries(params).map(([key, binding]) => (
+        <div key={key} className="flex items-center gap-2">
+          <span
+            className="w-28 shrink-0 truncate text-xs text-white/50"
+            title={key}
+          >
+            {key}
+          </span>
+          <PortBindingEditor
+            paramKey={key}
+            binding={binding}
+            upstreamOptions={upstreamOptions}
+            onChange={(next) => setParam(key, next)}
+          />
+          <button
+            type="button"
+            onClick={() => removeParam(key)}
+            aria-label={`Remove parameter ${key}`}
+            className="shrink-0 rounded-md p-1.5 text-white/30 hover:bg-white/5 hover:text-red-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#229EDF]"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      ))}
+
+      <form
+        className="flex items-center gap-2 pt-1"
+        onSubmit={(e) => {
+          e.preventDefault();
+          addParam();
+        }}
+      >
+        <label htmlFor="new-param-key" className="sr-only">
+          New parameter name
+        </label>
+        <input
+          id="new-param-key"
+          type="text"
+          value={newKey}
+          onChange={(e) => setNewKey(e.target.value)}
+          placeholder="parameter name"
+          className="w-28 shrink-0 rounded-lg border border-dashed border-white/15 bg-transparent px-2 py-1.5 text-xs text-white placeholder:text-white/30"
+        />
+        <button
+          type="submit"
+          disabled={!newKey.trim()}
+          className="rounded-lg border border-white/10 px-2.5 py-1.5 text-xs text-white/60 hover:bg-white/5 disabled:opacity-40"
+        >
+          + Add parameter
+        </button>
+      </form>
+    </div>
+  );
+}
+
+// ─── Step card ───────────────────────────────────────────────────────────────
+
+export interface StepCardProps {
+  strategy: Strategy;
+  step: StrategyStep;
+  index: number;
+  total: number;
+  onMove: (direction: "up" | "down") => void;
+  onRemove: () => void;
+  onParamsChange: (params: Record<string, ParamBinding>) => void;
+}
+
+/** One step in the composer: keyboard-operable Move Up/Down + Remove, and an expandable param editor. */
+export function StepCard({
+  strategy,
+  step,
+  index,
+  total,
+  onMove,
+  onRemove,
+  onParamsChange,
+}: StepCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const upstreamOptions = useMemo<UpstreamPortOption[]>(() => {
+    const options: UpstreamPortOption[] = [];
+    for (const upstream of strategy.steps.slice(0, index)) {
+      const definition = strategyStepRegistry.tryResolve(
+        upstream.type,
+        upstream.protocol
+      );
+      if (!definition) continue;
+      try {
+        const literalParams: Record<string, unknown> = {};
+        for (const [key, binding] of Object.entries(upstream.params))
+          literalParams[key] =
+            binding.source === "literal" ? binding.value : "1";
+        for (const port of definition.describeOutputs(literalParams as never))
+          options.push({
+            stepId: upstream.id,
+            stepLabel: upstream.label,
+            port,
+          });
+      } catch {
+        // definition couldn't describe outputs from partial params yet — skip
+      }
+    }
+    return options;
+  }, [strategy.steps, index]);
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-[#1C1C1C]">
+      <div className="flex items-center gap-2 p-3">
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white/5 text-xs text-white/50">
+          {index + 1}
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-white">
+            {step.label}
+          </p>
+          <p className="truncate text-xs text-white/40">
+            {step.type} · {step.protocol}
+          </p>
+        </div>
+
+        <div
+          className="flex items-center gap-1"
+          role="group"
+          aria-label={`Reorder ${step.label}`}
+        >
+          <button
+            type="button"
+            onClick={() => onMove("up")}
+            disabled={index === 0}
+            aria-label={`Move ${step.label} up`}
+            className="rounded-md p-1.5 text-white/50 hover:bg-white/5 hover:text-white disabled:opacity-30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#229EDF]"
+          >
+            <ArrowUp size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={() => onMove("down")}
+            disabled={index === total - 1}
+            aria-label={`Move ${step.label} down`}
+            className="rounded-md p-1.5 text-white/50 hover:bg-white/5 hover:text-white disabled:opacity-30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#229EDF]"
+          >
+            <ArrowDown size={14} />
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove ${step.label}`}
+          className="rounded-md p-1.5 text-white/40 hover:bg-white/5 hover:text-red-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#229EDF]"
+        >
+          <Trash2 size={14} />
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          aria-label={
+            expanded
+              ? `Collapse ${step.label} parameters`
+              : `Edit ${step.label} parameters`
+          }
+          className="rounded-md p-1.5 text-white/50 hover:bg-white/5 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#229EDF]"
+        >
+          {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-white/5 p-3">
+          <StepParamsForm
+            params={step.params}
+            upstreamOptions={upstreamOptions}
+            onChange={onParamsChange}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Validation panel ────────────────────────────────────────────────────────
+
+export interface ValidationPanelProps {
+  strategy: Strategy;
+  result: ValidationResult;
+}
+
+/** Renders validation issues, each pointing at the exact failing step. */
+export function ValidationPanel({ strategy, result }: ValidationPanelProps) {
+  if (result.issues.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-xl border border-green-500/20 bg-green-500/10 p-3 text-sm text-green-300">
+        <CheckCircle2 size={16} />
+        Strategy is valid.
+      </div>
+    );
+  }
+
+  const labelFor = (stepId: string | null) =>
+    stepId
+      ? (strategy.steps.find((s) => s.id === stepId)?.label ?? stepId)
+      : null;
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-xl border border-white/10 bg-white/[0.03] p-3"
+      role="alert"
+    >
+      {result.issues.map((issue, i) => {
+        const stepLabel = labelFor(issue.stepId);
+        const isWarning = issue.severity === "warning";
+        return (
+          <div
+            key={`${issue.code}-${i}`}
+            className={`flex items-start gap-2 text-sm ${isWarning ? "text-yellow-300" : "text-red-300"}`}
+          >
+            <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+            <span>
+              {stepLabel && (
+                <strong className="font-medium">{stepLabel}: </strong>
+              )}
+              {issue.message}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Strategy composer ───────────────────────────────────────────────────────
+
+export interface StrategyComposerProps {
+  initial: Strategy;
+  onClose: () => void;
+}
+
+export function StrategyComposer({ initial, onClose }: StrategyComposerProps) {
+  const { address } = useWallet();
+  const { addNotification } = useToast();
+  const { saveStrategy } = useStrategyPersistence();
+  const { execute, isExecuting } = useStrategyExecution();
+
+  const { strategy, addStep, removeStep, moveStep, updateStepParams, rename } =
+    useStrategyComposerState(initial);
+
+  const validation = useStrategyValidation(strategy);
+  const simulationQuery = useStrategySimulation(strategy, validation.valid);
+
+  const [showRiskAck, setShowRiskAck] = useState(false);
+  const [execution, setExecution] = useState<ExecutionRecord | null>(null);
+
+  const riskAssessment = useMemo<RiskAssessment | null>(() => {
+    const projection = simulationQuery.data;
+    if (!projection?.success) return null;
+    return {
+      effectiveLeverage: projection.effectiveLeverage,
+      projectedHealthFactor: projection.projectedHealthFactor,
+      projectedLiquidationPrice: projection.projectedLiquidationPrice,
+      cumulativeSlippageBps: projection.cumulativeSlippageBps,
+      riskTier: getRiskTier(projection.projectedHealthFactor),
+      protocolExposure: {},
+    };
+  }, [simulationQuery.data]);
+
+  const pausedStep = execution?.steps.find(
+    (s) => s.status === "paused_deviation"
+  );
+
+  const runExecution = async (acknowledgedDeviationStepIds?: string[]) => {
+    if (!address) return;
+    const record: ExecutionRecord = execution ?? {
+      id: nanoid(),
+      strategyId: strategy.id,
+      strategySnapshot: strategy,
+      status: "in_progress",
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+      projectedOutcome: simulationQuery.data ?? {},
+      steps: [],
+    };
+
+    const result = await execute(strategy, record, {
+      acknowledgedDeviationStepIds,
+    });
+    if (!result) return;
+    setExecution(result.record);
+
+    if (result.status === "completed") {
+      addNotification("Strategy executed", "success", {
+        description: `${strategy.name} completed successfully.`,
+      });
+    } else if (result.status === "failed") {
+      addNotification("Strategy execution failed", "error", {
+        description:
+          result.record.steps.find((s) => s.status === "failed")
+            ?.errorMessage ?? "An unexpected error occurred.",
+      });
+    }
+  };
+
+  const handleExecuteClick = () => {
+    if (riskAssessment && exceedsThresholds(riskAssessment)) {
+      setShowRiskAck(true);
+      return;
+    }
+    void runExecution();
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Back to strategies"
+          className="rounded-full p-2 text-white/50 hover:bg-white/5 hover:text-white"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <label htmlFor="strategy-name" className="sr-only">
+          Strategy name
+        </label>
+        <input
+          id="strategy-name"
+          value={strategy.name}
+          onChange={(e) => rename(e.target.value)}
+          className="min-w-0 flex-1 bg-transparent text-lg font-semibold text-white outline-none"
+        />
+        <button
+          type="button"
+          onClick={() => {
+            saveStrategy(strategy);
+            addNotification("Strategy saved", "success", {});
+          }}
+          className="rounded-full border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/5"
+        >
+          Save
+        </button>
+      </div>
+
+      <StepPalette
+        onAdd={(definition) =>
+          addStep({
+            type: definition.stepType,
+            protocol: definition.protocol,
+            label: `${definition.stepType} (${definition.protocol})`,
+            params: {},
+            dependsOn: [],
+          })
+        }
+      />
+
+      {strategy.steps.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-white/10 p-8 text-center text-sm text-white/40">
+          Add a step above to start composing this strategy.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {strategy.steps.map((step, index) => (
+            <StepCard
+              key={step.id}
+              strategy={strategy}
+              step={step}
+              index={index}
+              total={strategy.steps.length}
+              onMove={(direction) => moveStep(step.id, direction)}
+              onRemove={() => removeStep(step.id)}
+              onParamsChange={(params) => updateStepParams(step.id, params)}
+            />
+          ))}
+        </div>
+      )}
+
+      <ValidationPanel strategy={strategy} result={validation} />
+
+      {simulationQuery.data && (
+        <div className="flex flex-col gap-4">
+          <SimulationSummary projection={simulationQuery.data} />
+          {simulationQuery.data.success && (
+            <SensitivityPanel baseline={simulationQuery.data} />
+          )}
+        </div>
+      )}
+
+      {execution && (
+        <ExecutionProgress strategy={strategy} execution={execution} />
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={handleExecuteClick}
+          disabled={
+            !validation.valid ||
+            !simulationQuery.data?.success ||
+            isExecuting ||
+            !address
+          }
+          className="rounded-full bg-[#229EDF] px-6 py-2.5 text-sm font-semibold text-white hover:bg-[#1c8bc4] disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {isExecuting ? "Executing…" : "Execute strategy"}
+        </button>
+      </div>
+
+      {showRiskAck && riskAssessment && (
+        <RiskAcknowledgementModal
+          assessment={riskAssessment}
+          onCancel={() => setShowRiskAck(false)}
+          onAcknowledge={() => {
+            setShowRiskAck(false);
+            void runExecution();
+          }}
+        />
+      )}
+
+      {pausedStep && (
+        <DeviationPauseModal
+          step={pausedStep}
+          stepLabel={
+            strategy.steps.find((s) => s.id === pausedStep.stepId)?.label ??
+            pausedStep.stepId
+          }
+          onResume={() => void runExecution([pausedStep.stepId])}
+          onAbandon={() =>
+            setExecution((prev) =>
+              prev ? { ...prev, status: "abandoned" } : prev
+            )
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web-app/src/features/strategies/hooks.ts
+++ b/apps/web-app/src/features/strategies/hooks.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { nanoid } from "nanoid";
+import type {
+  ParamBinding,
+  Strategy,
+  StrategyStep,
+} from "@/lib/strategy/types";
+
+export function createEmptyStrategy(name = "Untitled strategy"): Strategy {
+  const now = Date.now();
+  return {
+    id: nanoid(),
+    version: 1,
+    name,
+    isTemplate: false,
+    steps: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function cloneAsEditable(template: Strategy): Strategy {
+  const now = Date.now();
+  return {
+    ...template,
+    id: nanoid(),
+    isTemplate: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function pruneBindingsTo(
+  params: Record<string, ParamBinding>,
+  removedStepId: string
+): Record<string, ParamBinding> {
+  const next: Record<string, ParamBinding> = {};
+  for (const [key, binding] of Object.entries(params)) {
+    if (binding.source === "stepOutput" && binding.stepId === removedStepId)
+      continue;
+    next[key] = binding;
+  }
+  return next;
+}
+
+/**
+ * Local, in-memory draft-editing state for the Strategy Composer: add,
+ * remove, reorder (via keyboard-operable move up/down, no drag-and-drop
+ * dependency), and configure steps. Persisting the draft is a separate
+ * concern (useStrategyPersistence.saveStrategy).
+ */
+export function useStrategyComposerState(initial: Strategy) {
+  const [strategy, setStrategy] = useState<Strategy>(initial);
+
+  const touch = useCallback((updater: (s: Strategy) => Strategy) => {
+    setStrategy((prev) => ({ ...updater(prev), updatedAt: Date.now() }));
+  }, []);
+
+  const addStep = useCallback(
+    (step: Omit<StrategyStep, "id">) => {
+      touch((s) => ({ ...s, steps: [...s.steps, { ...step, id: nanoid() }] }));
+    },
+    [touch]
+  );
+
+  const removeStep = useCallback(
+    (stepId: string) => {
+      touch((s) => ({
+        ...s,
+        steps: s.steps
+          .filter((step) => step.id !== stepId)
+          .map((step) => ({
+            ...step,
+            dependsOn: step.dependsOn.filter((id) => id !== stepId),
+            params: pruneBindingsTo(step.params, stepId),
+          })),
+      }));
+    },
+    [touch]
+  );
+
+  const moveStep = useCallback(
+    (stepId: string, direction: "up" | "down") => {
+      touch((s) => {
+        const idx = s.steps.findIndex((step) => step.id === stepId);
+        if (idx === -1) return s;
+        const swapWith = direction === "up" ? idx - 1 : idx + 1;
+        if (swapWith < 0 || swapWith >= s.steps.length) return s;
+        const steps = [...s.steps];
+        [steps[idx], steps[swapWith]] = [steps[swapWith], steps[idx]];
+        return { ...s, steps };
+      });
+    },
+    [touch]
+  );
+
+  const updateStepParams = useCallback(
+    (stepId: string, params: Record<string, ParamBinding>) => {
+      touch((s) => ({
+        ...s,
+        steps: s.steps.map((step) =>
+          step.id === stepId ? { ...step, params } : step
+        ),
+      }));
+    },
+    [touch]
+  );
+
+  const updateStepDependsOn = useCallback(
+    (stepId: string, dependsOn: string[]) => {
+      touch((s) => ({
+        ...s,
+        steps: s.steps.map((step) =>
+          step.id === stepId ? { ...step, dependsOn } : step
+        ),
+      }));
+    },
+    [touch]
+  );
+
+  const rename = useCallback(
+    (name: string) => {
+      touch((s) => ({ ...s, name }));
+    },
+    [touch]
+  );
+
+  return {
+    strategy,
+    setStrategy,
+    addStep,
+    removeStep,
+    moveStep,
+    updateStepParams,
+    updateStepDependsOn,
+    rename,
+  };
+}

--- a/apps/web-app/src/features/strategies/utils.ts
+++ b/apps/web-app/src/features/strategies/utils.ts
@@ -1,0 +1,26 @@
+export type StrategiesTab = "my-strategies" | "templates" | "history";
+
+export const STRATEGIES_TABS: { key: StrategiesTab; label: string }[] = [
+  { key: "my-strategies", label: "My Strategies" },
+  { key: "templates", label: "Templates" },
+  { key: "history", label: "Execution History" },
+];
+
+export function formatPercent(value: number | null, digits = 1): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return `${value.toFixed(digits)}%`;
+}
+
+export function formatBps(bps: number): string {
+  return `${(bps / 100).toFixed(2)}%`;
+}
+
+export function formatNumber(value: number | null, digits = 2): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return value.toFixed(digits);
+}
+
+export function formatMultiplier(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return `${value.toFixed(2)}x`;
+}

--- a/apps/web-app/src/lib/orchestrator/adapters/NekoLendingAdapter.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/NekoLendingAdapter.ts
@@ -6,7 +6,14 @@ import {
 } from "@/lib/constants/network";
 import { getAvailableTokens } from "@/lib/helpers/stellar/soroswap";
 import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
-import { depositToPool, withdrawFromPool } from "@/lib/helpers/stellar/lending";
+import {
+  depositToPool,
+  withdrawFromPool,
+  borrowFromPool,
+  repayPool,
+  addCollateral,
+  removeCollateral,
+} from "@/lib/helpers/stellar/lending";
 
 import type { BasePoolAdapter } from "../types/adapter.types";
 import type {
@@ -18,7 +25,35 @@ import type {
 } from "../types/pool.types";
 import { AdapterError, UnsupportedActionError } from "../types/errors";
 
-const SUPPORTED_ACTIONS: PoolAction[] = ["deposit", "withdraw"];
+const SUPPORTED_ACTIONS: PoolAction[] = [
+  "deposit",
+  "withdraw",
+  "borrow",
+  "repay",
+  "supplyCollateral",
+  "withdrawCollateral",
+];
+
+const D_TOKEN_SCALAR_12 = 1_000_000_000_000n;
+
+/** Collateral is keyed by (pool contract, RWA token), not a single asset code — mirrors Blend's <poolContractId>:<assetAddress> raw-id convention. */
+function parseCollateralRawId(rawId: string): {
+  contractId: string;
+  tokenAddress: string;
+} {
+  const idx = rawId.indexOf(":");
+  if (idx === -1) {
+    throw new AdapterError(
+      "neko",
+      "parseCollateralRawId",
+      `Invalid raw id "${rawId}" — expected <poolContractId>:<rwaTokenAddress>`
+    );
+  }
+  return {
+    contractId: rawId.slice(0, idx),
+    tokenAddress: rawId.slice(idx + 1),
+  };
+}
 
 /** Assets that belong to Pool 1 (RWA collateral → borrow USDC/XLM) */
 const POOL1_ASSETS = new Set(["USDC", "XLM"]);
@@ -270,6 +305,110 @@ export class NekoLendingAdapter implements BasePoolAdapter {
 
   async claimRewards(): Promise<TransactionResult> {
     throw new UnsupportedActionError("neko", "claimRewards");
+  }
+
+  async borrow(
+    poolId: string,
+    userAddress: string,
+    amount: bigint
+  ): Promise<TransactionResult> {
+    const assetCode = poolId;
+    const tokens = getAvailableTokens();
+    const decimals = tokens[assetCode]?.decimals ?? 7;
+    const humanAmount = fromSmallestUnit(amount.toString(), decimals);
+    const contractId = getPoolContractId(assetCode);
+
+    try {
+      const xdr = await borrowFromPool(
+        assetCode,
+        humanAmount,
+        decimals,
+        userAddress,
+        contractId
+      );
+      return { xdr, networkPassphrase };
+    } catch (error) {
+      throw new AdapterError("neko", "borrow", error);
+    }
+  }
+
+  /**
+   * `amount` is underlying-asset units (matching Blend's repay contract), not
+   * dTokens — the on-chain repay() call takes dTokens, so it's derived here
+   * via the pool's own d_token rate rather than the pool-unaware
+   * `getDTokenRate` helper in lending.ts.
+   */
+  async repay(
+    poolId: string,
+    userAddress: string,
+    amount: bigint
+  ): Promise<TransactionResult> {
+    const assetCode = poolId;
+    const contractId = getPoolContractId(assetCode);
+    const client = this.clientFor(assetCode);
+
+    try {
+      const rateTx = await client.get_d_token_rate(
+        { asset: assetCode },
+        { simulate: true }
+      );
+      const dRate = unwrapResult(rateTx.result);
+      if (dRate <= 0n) {
+        throw new Error(`No active debt / d-token rate for ${assetCode}`);
+      }
+      const dTokens = (amount * D_TOKEN_SCALAR_12) / dRate;
+      const xdr = await repayPool(assetCode, dTokens, userAddress, contractId);
+      return { xdr, networkPassphrase };
+    } catch (error) {
+      throw new AdapterError("neko", "repay", error);
+    }
+  }
+
+  /** poolId here is "<poolContractId>:<rwaTokenAddress>" — see parseCollateralRawId. */
+  async supplyCollateral(
+    poolId: string,
+    userAddress: string,
+    amount: bigint
+  ): Promise<TransactionResult> {
+    const { contractId, tokenAddress } = parseCollateralRawId(poolId);
+    const decimals = 7;
+    const humanAmount = fromSmallestUnit(amount.toString(), decimals);
+
+    try {
+      const xdr = await addCollateral(
+        tokenAddress,
+        humanAmount,
+        decimals,
+        userAddress,
+        contractId
+      );
+      return { xdr, networkPassphrase };
+    } catch (error) {
+      throw new AdapterError("neko", "supplyCollateral", error);
+    }
+  }
+
+  async withdrawCollateral(
+    poolId: string,
+    userAddress: string,
+    amount: bigint
+  ): Promise<TransactionResult> {
+    const { contractId, tokenAddress } = parseCollateralRawId(poolId);
+    const decimals = 7;
+    const humanAmount = fromSmallestUnit(amount.toString(), decimals);
+
+    try {
+      const xdr = await removeCollateral(
+        tokenAddress,
+        humanAmount,
+        decimals,
+        userAddress,
+        contractId
+      );
+      return { xdr, networkPassphrase };
+    } catch (error) {
+      throw new AdapterError("neko", "withdrawCollateral", error);
+    }
   }
 
   supportsAction(action: PoolAction): boolean {

--- a/apps/web-app/src/lib/orchestrator/adapters/__tests__/NekoLendingAdapter.test.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/__tests__/NekoLendingAdapter.test.ts
@@ -18,12 +18,17 @@ const {
   getAvailableTokens,
   depositToPool,
   withdrawFromPool,
+  borrowFromPool,
+  repayPool,
+  addCollateral,
+  removeCollateral,
 } = vi.hoisted(() => {
   const clientMethods = {
     get_pool_balance: vi.fn(),
     get_interest_rate: vi.fn(),
     get_pool_state: vi.fn(),
     get_b_token_balance: vi.fn(),
+    get_d_token_rate: vi.fn(),
   };
   class ClientMock {
     constructor() {
@@ -39,6 +44,10 @@ const {
     getAvailableTokens: vi.fn(),
     depositToPool: vi.fn(),
     withdrawFromPool: vi.fn(),
+    borrowFromPool: vi.fn(),
+    repayPool: vi.fn(),
+    addCollateral: vi.fn(),
+    removeCollateral: vi.fn(),
   };
 });
 
@@ -52,6 +61,10 @@ vi.mock("@/lib/helpers/stellar/soroswap", () => ({
 vi.mock("@/lib/helpers/stellar/lending", () => ({
   depositToPool,
   withdrawFromPool,
+  borrowFromPool,
+  repayPool,
+  addCollateral,
+  removeCollateral,
 }));
 
 import { NekoLendingAdapter } from "../NekoLendingAdapter";
@@ -72,10 +85,18 @@ beforeEach(() => {
   });
   depositToPool.mockResolvedValue("DEPOSIT_XDR");
   withdrawFromPool.mockResolvedValue("WITHDRAW_XDR");
+  borrowFromPool.mockResolvedValue("BORROW_XDR");
+  repayPool.mockResolvedValue("REPAY_XDR");
+  addCollateral.mockResolvedValue("ADD_COLLATERAL_XDR");
+  removeCollateral.mockResolvedValue("REMOVE_COLLATERAL_XDR");
   clientMethods.get_pool_balance.mockResolvedValue({ result: 5000n });
   clientMethods.get_interest_rate.mockResolvedValue({ result: 250 });
   clientMethods.get_pool_state.mockResolvedValue({ result: { tag: "Active" } });
   clientMethods.get_b_token_balance.mockResolvedValue({ result: 15_000_000n });
+  // SCALAR_12 (1e12) => underlying == dTokens 1:1 by default in tests.
+  clientMethods.get_d_token_rate.mockResolvedValue({
+    result: 1_000_000_000_000n,
+  });
 });
 
 describe("NekoLendingAdapter – deposit", () => {
@@ -149,7 +170,14 @@ describe("NekoLendingAdapter – getPoolInfo", () => {
       tvl: 5000n,
       apy: 2.5, // 250 / 100
       state: "active",
-      supportedActions: ["deposit", "withdraw"],
+      supportedActions: [
+        "deposit",
+        "withdraw",
+        "borrow",
+        "repay",
+        "supplyCollateral",
+        "withdrawCollateral",
+      ],
       metadata: { contractId: "CPOOL1", assetCode: "USDC" },
     });
     expect(info.tokens[0]).toMatchObject({ address: "C_USDC", code: "USDC" });
@@ -213,11 +241,15 @@ describe("NekoLendingAdapter – getUserPosition", () => {
 });
 
 describe("NekoLendingAdapter – capabilities", () => {
-  it("supports only deposit and withdraw actions", () => {
+  it("supports deposit, withdraw, borrow, repay, and collateral actions", () => {
     const adapter = new NekoLendingAdapter();
     expect(adapter.supportsAction("deposit")).toBe(true);
     expect(adapter.supportsAction("withdraw")).toBe(true);
-    expect(adapter.supportsAction("borrow")).toBe(false);
+    expect(adapter.supportsAction("borrow")).toBe(true);
+    expect(adapter.supportsAction("repay")).toBe(true);
+    expect(adapter.supportsAction("supplyCollateral")).toBe(true);
+    expect(adapter.supportsAction("withdrawCollateral")).toBe(true);
+    expect(adapter.supportsAction("claimRewards")).toBe(false);
   });
 
   it("rejects claimRewards as unsupported", async () => {
@@ -225,5 +257,117 @@ describe("NekoLendingAdapter – capabilities", () => {
     await expect(adapter.claimRewards()).rejects.toBeInstanceOf(
       UnsupportedActionError
     );
+  });
+});
+
+describe("NekoLendingAdapter – borrow", () => {
+  it("converts the raw amount to a human amount and routes to the debt asset's pool", async () => {
+    const adapter = new NekoLendingAdapter();
+    const result = await adapter.borrow("USDC", "GUSER", 10_000_000n);
+
+    expect(borrowFromPool).toHaveBeenCalledWith(
+      "USDC",
+      "1",
+      7,
+      "GUSER",
+      "CPOOL1"
+    );
+    expect(result.xdr).toBe("BORROW_XDR");
+  });
+
+  it("wraps a builder failure in an AdapterError", async () => {
+    borrowFromPool.mockRejectedValue(new Error("rpc down"));
+    const adapter = new NekoLendingAdapter();
+
+    await expect(adapter.borrow("USDC", "GUSER", 1n)).rejects.toBeInstanceOf(
+      AdapterError
+    );
+  });
+});
+
+describe("NekoLendingAdapter – repay", () => {
+  it("converts underlying-asset amount to dTokens via the pool's d_token rate", async () => {
+    const adapter = new NekoLendingAdapter();
+    // d_rate = 1e12 (1:1) in the default mock, so 10_000_000 underlying -> 10_000_000 dTokens.
+    await adapter.repay("USDC", "GUSER", 10_000_000n);
+
+    expect(repayPool).toHaveBeenCalledWith(
+      "USDC",
+      10_000_000n,
+      "GUSER",
+      "CPOOL1"
+    );
+  });
+
+  it("scales dTokens down when the d_token rate is above 1:1", async () => {
+    // d_rate = 2e12 => underlying = dTokens * 2, so dTokens = underlying / 2.
+    clientMethods.get_d_token_rate.mockResolvedValue({
+      result: 2_000_000_000_000n,
+    });
+    const adapter = new NekoLendingAdapter();
+    await adapter.repay("USDC", "GUSER", 10_000_000n);
+
+    expect(repayPool).toHaveBeenCalledWith(
+      "USDC",
+      5_000_000n,
+      "GUSER",
+      "CPOOL1"
+    );
+  });
+
+  it("wraps a zero d_token rate (no active debt) in an AdapterError", async () => {
+    clientMethods.get_d_token_rate.mockResolvedValue({ result: 0n });
+    const adapter = new NekoLendingAdapter();
+
+    await expect(adapter.repay("USDC", "GUSER", 1n)).rejects.toBeInstanceOf(
+      AdapterError
+    );
+    expect(repayPool).not.toHaveBeenCalled();
+  });
+});
+
+describe("NekoLendingAdapter – supplyCollateral / withdrawCollateral", () => {
+  it("parses the <poolContractId>:<rwaTokenAddress> raw id and calls addCollateral", async () => {
+    const adapter = new NekoLendingAdapter();
+    const result = await adapter.supplyCollateral(
+      "CPOOL1:C_RWA_TOKEN",
+      "GUSER",
+      10_000_000n
+    );
+
+    expect(addCollateral).toHaveBeenCalledWith(
+      "C_RWA_TOKEN",
+      "1",
+      7,
+      "GUSER",
+      "CPOOL1"
+    );
+    expect(result.xdr).toBe("ADD_COLLATERAL_XDR");
+  });
+
+  it("parses the raw id and calls removeCollateral", async () => {
+    const adapter = new NekoLendingAdapter();
+    const result = await adapter.withdrawCollateral(
+      "CPOOL1:C_RWA_TOKEN",
+      "GUSER",
+      5_000_000n
+    );
+
+    expect(removeCollateral).toHaveBeenCalledWith(
+      "C_RWA_TOKEN",
+      "0.5",
+      7,
+      "GUSER",
+      "CPOOL1"
+    );
+    expect(result.xdr).toBe("REMOVE_COLLATERAL_XDR");
+  });
+
+  it("throws an AdapterError for a malformed raw id", async () => {
+    const adapter = new NekoLendingAdapter();
+    await expect(
+      adapter.supplyCollateral("no-colon-here", "GUSER", 1n)
+    ).rejects.toBeInstanceOf(AdapterError);
+    expect(addCollateral).not.toHaveBeenCalled();
   });
 });

--- a/apps/web-app/src/lib/strategy/__tests__/definitions.test.ts
+++ b/apps/web-app/src/lib/strategy/__tests__/definitions.test.ts
@@ -1,0 +1,577 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  nekoAdapterMethods,
+  NekoLendingAdapterMock,
+  blendAdapterMethods,
+  BlendPoolAdapterMock,
+  soroswapAdapterMethods,
+  SoroswapPoolAdapterMock,
+  defindexMethods,
+  DefindexClientMock,
+  getQuote,
+  buildTransaction,
+  getAvailableTokens,
+} = vi.hoisted(() => {
+  const nekoAdapterMethods = {
+    deposit: vi.fn(),
+    withdraw: vi.fn(),
+    borrow: vi.fn(),
+    repay: vi.fn(),
+    supplyCollateral: vi.fn(),
+    withdrawCollateral: vi.fn(),
+  };
+  class NekoLendingAdapterMock {
+    constructor() {
+      Object.assign(this, nekoAdapterMethods);
+    }
+  }
+  const blendAdapterMethods = {
+    deposit: vi.fn(),
+    withdraw: vi.fn(),
+    borrow: vi.fn(),
+    repay: vi.fn(),
+    supplyCollateral: vi.fn(),
+    withdrawCollateral: vi.fn(),
+  };
+  class BlendPoolAdapterMock {
+    constructor() {
+      Object.assign(this, blendAdapterMethods);
+    }
+  }
+  const soroswapAdapterMethods = { deposit: vi.fn() };
+  class SoroswapPoolAdapterMock {
+    constructor() {
+      Object.assign(this, soroswapAdapterMethods);
+    }
+  }
+  const defindexMethods = { deposit: vi.fn(), withdraw: vi.fn() };
+  class DefindexClientMock {
+    constructor(public options: unknown) {
+      Object.assign(this, defindexMethods);
+    }
+  }
+  return {
+    nekoAdapterMethods,
+    NekoLendingAdapterMock,
+    blendAdapterMethods,
+    BlendPoolAdapterMock,
+    soroswapAdapterMethods,
+    SoroswapPoolAdapterMock,
+    defindexMethods,
+    DefindexClientMock,
+    getQuote: vi.fn(),
+    buildTransaction: vi.fn(),
+    getAvailableTokens: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/orchestrator/adapters/NekoLendingAdapter", () => ({
+  NekoLendingAdapter: NekoLendingAdapterMock,
+}));
+vi.mock("@/lib/orchestrator/adapters/BlendPoolAdapter", () => ({
+  BlendPoolAdapter: BlendPoolAdapterMock,
+}));
+vi.mock("@/lib/orchestrator/adapters/SoroswapPoolAdapter", () => ({
+  SoroswapPoolAdapter: SoroswapPoolAdapterMock,
+}));
+vi.mock("@neko/defindex-vault", () => ({ Client: DefindexClientMock }));
+vi.mock("@/lib/helpers/stellar/soroswap", () => ({
+  getQuote,
+  buildTransaction,
+  getAvailableTokens,
+}));
+
+import {
+  swapSoroswapDefinition,
+  supplyNekoDefinition,
+  supplyBlendDefinition,
+  borrowNekoDefinition,
+  borrowBlendDefinition,
+  repayNekoDefinition,
+  repayBlendDefinition,
+  vaultDepositDefindexDefinition,
+  vaultWithdrawDefindexDefinition,
+  lpAddSoroswapDefinition,
+  lpRemoveSoroswapDefinition,
+  registerBuiltInStepDefinitions,
+} from "../definitions";
+import { strategyStepRegistry } from "../registry";
+import type { StepExecutionContext } from "../types";
+
+const USDC = {
+  contract: "C_USDC",
+  code: "USDC",
+  name: "USD Coin",
+  decimals: 7,
+};
+const XLM = {
+  contract: "C_XLM",
+  code: "XLM",
+  name: "Stellar Lumens",
+  decimals: 7,
+};
+
+function ctx(resolvedParams: Record<string, unknown>): StepExecutionContext {
+  return {
+    userAddress: "GUSER",
+    networkPassphrase: "p",
+    resolvedParams,
+    upstreamOutputs: {},
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAvailableTokens.mockReturnValue({ USDC, XLM });
+  nekoAdapterMethods.deposit.mockResolvedValue({
+    xdr: "N_DEPOSIT_XDR",
+    networkPassphrase: "p",
+  });
+  nekoAdapterMethods.withdraw.mockResolvedValue({
+    xdr: "N_WITHDRAW_XDR",
+    networkPassphrase: "p",
+  });
+  nekoAdapterMethods.borrow.mockResolvedValue({
+    xdr: "N_BORROW_XDR",
+    networkPassphrase: "p",
+  });
+  nekoAdapterMethods.repay.mockResolvedValue({
+    xdr: "N_REPAY_XDR",
+    networkPassphrase: "p",
+  });
+  nekoAdapterMethods.supplyCollateral.mockResolvedValue({
+    xdr: "N_SUPPLY_COLL_XDR",
+    networkPassphrase: "p",
+  });
+  nekoAdapterMethods.withdrawCollateral.mockResolvedValue({
+    xdr: "N_WITHDRAW_COLL_XDR",
+    networkPassphrase: "p",
+  });
+  blendAdapterMethods.deposit.mockResolvedValue({
+    xdr: "B_DEPOSIT_XDR",
+    networkPassphrase: "p",
+  });
+  blendAdapterMethods.withdraw.mockResolvedValue({
+    xdr: "B_WITHDRAW_XDR",
+    networkPassphrase: "p",
+  });
+  blendAdapterMethods.borrow.mockResolvedValue({
+    xdr: "B_BORROW_XDR",
+    networkPassphrase: "p",
+  });
+  blendAdapterMethods.repay.mockResolvedValue({
+    xdr: "B_REPAY_XDR",
+    networkPassphrase: "p",
+  });
+  blendAdapterMethods.supplyCollateral.mockResolvedValue({
+    xdr: "B_SUPPLY_COLL_XDR",
+    networkPassphrase: "p",
+  });
+  blendAdapterMethods.withdrawCollateral.mockResolvedValue({
+    xdr: "B_WITHDRAW_COLL_XDR",
+    networkPassphrase: "p",
+  });
+  soroswapAdapterMethods.deposit.mockResolvedValue({
+    xdr: "LP_ADD_XDR",
+    networkPassphrase: "p",
+  });
+  defindexMethods.deposit.mockResolvedValue({
+    toXDR: () => "VAULT_DEPOSIT_XDR",
+  });
+  defindexMethods.withdraw.mockResolvedValue({
+    toXDR: () => "VAULT_WITHDRAW_XDR",
+  });
+});
+
+describe("swapSoroswapDefinition", () => {
+  const params = { tokenIn: "XLM", tokenOut: "USDC", amountIn: "10" };
+
+  it("validate flags identical tokens and unknown asset codes", () => {
+    expect(
+      swapSoroswapDefinition.validate(
+        ctx({ tokenIn: "XLM", tokenOut: "XLM", amountIn: "1" })
+      )
+    ).toContainEqual(expect.objectContaining({ code: "INCOMPATIBLE_ASSET" }));
+    expect(
+      swapSoroswapDefinition.validate(
+        ctx({ tokenIn: "NOPE", tokenOut: "USDC", amountIn: "1" })
+      )
+    ).toContainEqual(expect.objectContaining({ code: "UNKNOWN_ASSET" }));
+    expect(swapSoroswapDefinition.validate(ctx(params))).toEqual([]);
+  });
+
+  it("simulate projects the quote's amountOut on the tokenOut port", async () => {
+    getQuote.mockResolvedValue({
+      amountOut: "95000000",
+      amountIn: "100000000",
+      priceImpact: "0.5",
+      protocol: "soroswap",
+    });
+    const projection = await swapSoroswapDefinition.simulate(ctx(params));
+    expect(getQuote).toHaveBeenCalledWith({
+      assetIn: "XLM",
+      assetOut: "USDC",
+      amount: "10",
+      tradeType: "EXACT_IN",
+    });
+    expect(projection.outputs["out.receivedAsset"]).toBe("95000000");
+    expect(projection.slippageBps).toBe(50);
+  });
+
+  it("simulate throws when no liquidity is found", async () => {
+    getQuote.mockResolvedValue(undefined);
+    await expect(swapSoroswapDefinition.simulate(ctx(params))).rejects.toThrow(
+      /No liquidity/
+    );
+  });
+
+  it("prepare quotes then builds the swap transaction", async () => {
+    const quote = { amountOut: "1", amountIn: "1", protocol: "soroswap" };
+    getQuote.mockResolvedValue(quote);
+    buildTransaction.mockResolvedValue({ xdr: "SWAP_XDR" });
+    const result = await swapSoroswapDefinition.prepare(ctx(params));
+    expect(buildTransaction).toHaveBeenCalledWith({
+      quote,
+      from: "GUSER",
+      to: "GUSER",
+    });
+    expect(result).toEqual({ xdr: "SWAP_XDR", networkPassphrase: "p" });
+  });
+
+  it("describeOutputs declares a single asset output port for tokenOut", () => {
+    expect(swapSoroswapDefinition.describeOutputs(params)).toEqual([
+      { id: "out.receivedAsset", assetCode: "USDC", kind: "asset" },
+    ]);
+  });
+});
+
+describe("supplyNekoDefinition", () => {
+  it("mode=supply calls deposit/withdraw by direction", async () => {
+    await supplyNekoDefinition.prepare(
+      ctx({
+        mode: "supply",
+        direction: "deposit",
+        assetCode: "USDC",
+        amount: "1",
+      })
+    );
+    expect(nekoAdapterMethods.deposit).toHaveBeenCalledWith(
+      "USDC",
+      "GUSER",
+      10_000_000n
+    );
+    await supplyNekoDefinition.prepare(
+      ctx({
+        mode: "supply",
+        direction: "withdraw",
+        assetCode: "USDC",
+        amount: "1",
+      })
+    );
+    expect(nekoAdapterMethods.withdraw).toHaveBeenCalledWith(
+      "USDC",
+      "GUSER",
+      10_000_000n
+    );
+  });
+
+  it("mode=collateral calls supplyCollateral/withdrawCollateral with the compound raw id", async () => {
+    await supplyNekoDefinition.prepare(
+      ctx({
+        mode: "collateral",
+        direction: "deposit",
+        poolContractId: "CPOOL1",
+        collateralTokenAddress: "C_RWA",
+        amount: "1",
+      })
+    );
+    expect(nekoAdapterMethods.supplyCollateral).toHaveBeenCalledWith(
+      "CPOOL1:C_RWA",
+      "GUSER",
+      10_000_000n
+    );
+  });
+
+  it("validate flags unknown asset / missing collateral params without throwing", () => {
+    expect(
+      supplyNekoDefinition.validate(
+        ctx({
+          mode: "supply",
+          direction: "deposit",
+          assetCode: "NOPE",
+          amount: "1",
+        })
+      )
+    ).toContainEqual(expect.objectContaining({ code: "UNKNOWN_ASSET" }));
+    expect(
+      supplyNekoDefinition.validate(
+        ctx({ mode: "collateral", direction: "deposit", amount: "1" })
+      )
+    ).toContainEqual(expect.objectContaining({ code: "MISSING_PARAM" }));
+  });
+
+  it("simulate reports a signed collateralDelta matching direction", async () => {
+    const deposit = await supplyNekoDefinition.simulate(
+      ctx({
+        mode: "collateral",
+        direction: "deposit",
+        poolContractId: "CPOOL1",
+        collateralTokenAddress: "C_RWA",
+        amount: "5",
+      })
+    );
+    expect(deposit.resultingPosition?.collateralDelta).toBe(5);
+    const withdraw = await supplyNekoDefinition.simulate(
+      ctx({
+        mode: "collateral",
+        direction: "withdraw",
+        poolContractId: "CPOOL1",
+        collateralTokenAddress: "C_RWA",
+        amount: "5",
+      })
+    );
+    expect(withdraw.resultingPosition?.collateralDelta).toBe(-5);
+  });
+});
+
+describe("supplyBlendDefinition", () => {
+  const base = {
+    mode: "supply",
+    direction: "deposit",
+    poolContractId: "CPOOL",
+    assetAddress: "C_ASSET",
+    amount: "1",
+  };
+
+  it("builds the compound raw id and calls the right adapter method per mode/direction", async () => {
+    await supplyBlendDefinition.prepare(ctx(base));
+    expect(blendAdapterMethods.deposit).toHaveBeenCalledWith(
+      "CPOOL:C_ASSET",
+      "GUSER",
+      10_000_000n
+    );
+    await supplyBlendDefinition.prepare(ctx({ ...base, mode: "collateral" }));
+    expect(blendAdapterMethods.supplyCollateral).toHaveBeenCalledWith(
+      "CPOOL:C_ASSET",
+      "GUSER",
+      10_000_000n
+    );
+    await supplyBlendDefinition.prepare(
+      ctx({ ...base, mode: "collateral", direction: "withdraw" })
+    );
+    expect(blendAdapterMethods.withdrawCollateral).toHaveBeenCalledWith(
+      "CPOOL:C_ASSET",
+      "GUSER",
+      10_000_000n
+    );
+  });
+
+  it("validate flags missing pool/asset params without throwing", () => {
+    const issues = supplyBlendDefinition.validate(
+      ctx({
+        mode: "supply",
+        direction: "deposit",
+        amount: "1",
+        poolContractId: "",
+        assetAddress: "",
+      })
+    );
+    expect(issues.length).toBeGreaterThan(0);
+  });
+});
+
+describe("borrowNekoDefinition / borrowBlendDefinition", () => {
+  it("Neko: converts amount and calls adapter.borrow with the asset code", async () => {
+    const result = await borrowNekoDefinition.prepare(
+      ctx({ assetCode: "USDC", amount: "1" })
+    );
+    expect(nekoAdapterMethods.borrow).toHaveBeenCalledWith(
+      "USDC",
+      "GUSER",
+      10_000_000n
+    );
+    expect(result.xdr).toBe("N_BORROW_XDR");
+  });
+
+  it("Neko: validate flags an unknown asset / malformed params without throwing", () => {
+    expect(
+      borrowNekoDefinition.validate(ctx({ assetCode: "NOPE", amount: "1" }))
+    ).toContainEqual(expect.objectContaining({ code: "UNKNOWN_ASSET" }));
+    expect(borrowNekoDefinition.validate(ctx({})).length).toBeGreaterThan(0);
+  });
+
+  it("Neko: simulate reports a positive debtDelta", async () => {
+    const projection = await borrowNekoDefinition.simulate(
+      ctx({ assetCode: "USDC", amount: "50" })
+    );
+    expect(projection.resultingPosition).toMatchObject({
+      protocol: "neko",
+      debtAssetCode: "USDC",
+      debtDelta: 50,
+    });
+  });
+
+  it("Blend: builds the compound raw id and calls adapter.borrow", async () => {
+    await borrowBlendDefinition.prepare(
+      ctx({ poolContractId: "CPOOL", assetAddress: "C_ASSET", amount: "1" })
+    );
+    expect(blendAdapterMethods.borrow).toHaveBeenCalledWith(
+      "CPOOL:C_ASSET",
+      "GUSER",
+      10_000_000n
+    );
+  });
+
+  it("Blend: validate flags missing params without throwing", () => {
+    expect(borrowBlendDefinition.validate(ctx({})).length).toBeGreaterThan(0);
+  });
+});
+
+describe("repayNekoDefinition / repayBlendDefinition", () => {
+  it("Neko: delegates to adapter.repay with underlying-asset units (dToken conversion is the adapter's job)", async () => {
+    const result = await repayNekoDefinition.prepare(
+      ctx({ assetCode: "USDC", amount: "1" })
+    );
+    expect(nekoAdapterMethods.repay).toHaveBeenCalledWith(
+      "USDC",
+      "GUSER",
+      10_000_000n
+    );
+    expect(result.xdr).toBe("N_REPAY_XDR");
+  });
+
+  it("Neko: simulate reports a negative debtDelta", async () => {
+    const projection = await repayNekoDefinition.simulate(
+      ctx({ assetCode: "USDC", amount: "20" })
+    );
+    expect(projection.resultingPosition?.debtDelta).toBe(-20);
+  });
+
+  it("Blend: builds the compound raw id and calls adapter.repay", async () => {
+    await repayBlendDefinition.prepare(
+      ctx({ poolContractId: "CPOOL", assetAddress: "C_ASSET", amount: "3" })
+    );
+    expect(blendAdapterMethods.repay).toHaveBeenCalledWith(
+      "CPOOL:C_ASSET",
+      "GUSER",
+      30_000_000n
+    );
+  });
+});
+
+describe("vaultDepositDefindexDefinition / vaultWithdrawDefindexDefinition", () => {
+  it("deposit applies the 1% slippage floor to amounts_min", async () => {
+    const result = await vaultDepositDefindexDefinition.prepare(
+      ctx({ amount: "100" })
+    );
+    expect(defindexMethods.deposit).toHaveBeenCalledWith({
+      amounts_desired: [1_000_000_000n],
+      amounts_min: [990_000_000n],
+      from: "GUSER",
+      invest: false,
+    });
+    expect(result.xdr).toBe("VAULT_DEPOSIT_XDR");
+  });
+
+  it("deposit validate rejects a zero/negative amount and accepts a positive one", () => {
+    expect(
+      vaultDepositDefindexDefinition.validate(ctx({ amount: "0" }))
+    ).toContainEqual(expect.objectContaining({ code: "INVALID_AMOUNT" }));
+    expect(
+      vaultDepositDefindexDefinition.validate(ctx({ amount: "5" }))
+    ).toEqual([]);
+  });
+
+  it("withdraw converts shares and requests zero-minimum output amounts", async () => {
+    const result = await vaultWithdrawDefindexDefinition.prepare(
+      ctx({ shares: "10" })
+    );
+    expect(defindexMethods.withdraw).toHaveBeenCalledWith({
+      withdraw_shares: 100_000_000n,
+      min_amounts_out: [0n],
+      from: "GUSER",
+    });
+    expect(result.xdr).toBe("VAULT_WITHDRAW_XDR");
+  });
+
+  it("withdraw validate rejects zero shares", () => {
+    expect(
+      vaultWithdrawDefindexDefinition.validate(ctx({ shares: "0" }))
+    ).toContainEqual(expect.objectContaining({ code: "INVALID_AMOUNT" }));
+  });
+});
+
+describe("lpAddSoroswapDefinition", () => {
+  it("builds the TOKEN_A-TOKEN_B pool id and calls adapter.deposit", async () => {
+    const result = await lpAddSoroswapDefinition.prepare(
+      ctx({ tokenA: "USDC", tokenB: "XLM", amount: "10" })
+    );
+    expect(soroswapAdapterMethods.deposit).toHaveBeenCalledWith(
+      "USDC-XLM",
+      "GUSER",
+      100_000_000n
+    );
+    expect(result.xdr).toBe("LP_ADD_XDR");
+  });
+
+  it("validate rejects identical tokenA/tokenB", () => {
+    expect(
+      lpAddSoroswapDefinition.validate(
+        ctx({ tokenA: "USDC", tokenB: "USDC", amount: "1" })
+      )
+    ).toContainEqual(expect.objectContaining({ code: "INCOMPATIBLE_ASSET" }));
+  });
+});
+
+describe("lpRemoveSoroswapDefinition", () => {
+  const params = { tokenA: "USDC", tokenB: "XLM", amount: "10" };
+
+  it("always fails validation with a clear unsupported-combination message", () => {
+    const issues = lpRemoveSoroswapDefinition.validate(ctx(params));
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      severity: "error",
+      code: "UNSUPPORTED_PROTOCOL_COMBINATION",
+    });
+    expect(issues[0].message).toMatch(/not yet supported/i);
+  });
+
+  it("simulate and prepare reject rather than silently succeeding", async () => {
+    await expect(
+      lpRemoveSoroswapDefinition.simulate(ctx(params))
+    ).rejects.toThrow(/not yet supported/i);
+    await expect(
+      lpRemoveSoroswapDefinition.prepare(ctx(params))
+    ).rejects.toThrow(/not yet supported/i);
+  });
+
+  it("still declares an output port so the composer can render it", () => {
+    expect(lpRemoveSoroswapDefinition.describeOutputs(params)).toEqual([
+      { id: "out.withdrawnAssets", assetCode: "USDC-XLM", kind: "asset" },
+    ]);
+  });
+});
+
+describe("registerBuiltInStepDefinitions (registration wiring)", () => {
+  const expectedKeys: Array<[string, string]> = [
+    ["swap", "soroswap"],
+    ["supply", "neko"],
+    ["supply", "blend"],
+    ["borrow", "neko"],
+    ["borrow", "blend"],
+    ["repay", "neko"],
+    ["repay", "blend"],
+    ["vaultDeposit", "defindex"],
+    ["vaultWithdraw", "defindex"],
+    ["lpAdd", "soroswap"],
+    ["lpRemove", "soroswap"],
+  ];
+
+  it("registers exactly the 11 built-in (stepType, protocol) pairs (already registered via module import side effect)", () => {
+    registerBuiltInStepDefinitions();
+    for (const [stepType, protocol] of expectedKeys) {
+      expect(strategyStepRegistry.has(stepType, protocol)).toBe(true);
+    }
+  });
+});

--- a/apps/web-app/src/lib/strategy/__tests__/engine.test.ts
+++ b/apps/web-app/src/lib/strategy/__tests__/engine.test.ts
@@ -1,0 +1,787 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  topologicalSort,
+  validateStrategy,
+  validateBalances,
+  simulateStrategy,
+  aggregateProjection,
+  computeSensitivity,
+  DEFAULT_SENSITIVITY_SCENARIOS,
+  evaluateRisk,
+  computeProtocolExposure,
+  DEFAULT_RISK_THRESHOLDS,
+  exceedsThresholds,
+  deviationThresholdFor,
+} from "../engine";
+import { StrategyStepRegistry } from "../registry";
+import type {
+  ResultingPosition,
+  RiskAssessment,
+  Strategy,
+  StrategyStep,
+  StrategyStepDefinition,
+  StepExecutionContext,
+  StepProjection,
+  StrategyProjection,
+  ValidationIssue,
+} from "../types";
+
+function step(
+  overrides: Partial<StrategyStep> & {
+    id: string;
+    type?: string;
+    protocol?: string;
+  }
+): StrategyStep {
+  return {
+    type: "swap",
+    protocol: "soroswap",
+    label: overrides.id,
+    params: {},
+    dependsOn: [],
+    ...overrides,
+  } as StrategyStep;
+}
+
+function strategyWith(steps: StrategyStep[]): Strategy {
+  return {
+    id: "s1",
+    version: 1,
+    name: "Test",
+    isTemplate: false,
+    steps,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+// ─── Cycle detection ─────────────────────────────────────────────────────────
+
+describe("topologicalSort", () => {
+  it("orders a linear chain respecting dependencies", () => {
+    const result = topologicalSort([
+      step({ id: "a" }),
+      step({ id: "b", dependsOn: ["a"] }),
+      step({ id: "c", dependsOn: ["b"] }),
+    ]);
+    expect(result.issues).toEqual([]);
+    expect(result.order).toEqual(["a", "b", "c"]);
+  });
+
+  it("orders a diamond graph respecting both branches before the merge step", () => {
+    const result = topologicalSort([
+      step({ id: "a" }),
+      step({ id: "b", dependsOn: ["a"] }),
+      step({ id: "c", dependsOn: ["a"] }),
+      step({ id: "d", dependsOn: ["b", "c"] }),
+    ]);
+    const order = result.order!;
+    expect(order.indexOf("a")).toBeLessThan(order.indexOf("b"));
+    expect(order.indexOf("b")).toBeLessThan(order.indexOf("d"));
+    expect(order.indexOf("c")).toBeLessThan(order.indexOf("d"));
+  });
+
+  it("orders disconnected components independently, preserving original order for ties", () => {
+    expect(
+      topologicalSort([
+        step({ id: "a" }),
+        step({ id: "b" }),
+        step({ id: "c", dependsOn: ["a"] }),
+      ]).order
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("detects a self-loop and a multi-node cycle as circular dependencies", () => {
+    const selfLoop = topologicalSort([step({ id: "a", dependsOn: ["a"] })]);
+    expect(selfLoop.order).toBeNull();
+    expect(selfLoop.issues[0]).toMatchObject({
+      severity: "error",
+      code: "CIRCULAR_DEPENDENCY",
+      stepId: "a",
+    });
+
+    const cycle = topologicalSort([
+      step({ id: "a", dependsOn: ["c"] }),
+      step({ id: "b", dependsOn: ["a"] }),
+      step({ id: "c", dependsOn: ["b"] }),
+    ]);
+    expect(cycle.order).toBeNull();
+    expect(cycle.issues[0].message).toContain("a");
+    expect(cycle.issues[0].message).toContain("b");
+    expect(cycle.issues[0].message).toContain("c");
+  });
+
+  it("silently ignores a dangling dependsOn reference and handles an empty strategy", () => {
+    expect(topologicalSort([step({ id: "a", dependsOn: ["ghost"] })])).toEqual({
+      order: ["a"],
+      issues: [],
+    });
+    expect(topologicalSort([])).toEqual({ order: [], issues: [] });
+  });
+});
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+function fakeDefinition(
+  stepType: string,
+  protocol: string,
+  overrides: Partial<StrategyStepDefinition> = {}
+): StrategyStepDefinition {
+  return {
+    stepType: stepType as StrategyStepDefinition["stepType"],
+    protocol,
+    submissionMode: "rpc",
+    paramsSchema: z.object({}).passthrough(),
+    describeOutputs: () => [
+      { id: "out.amount", assetCode: "USDC", kind: "asset" },
+    ],
+    validate: () => [],
+    simulate: async () => ({ outputs: {}, estimatedFee: "0", warnings: [] }),
+    prepare: async () => ({ xdr: "", networkPassphrase: "" }),
+    ...overrides,
+  };
+}
+
+function registryWith(
+  ...definitions: StrategyStepDefinition[]
+): StrategyStepRegistry {
+  const registry = new StrategyStepRegistry();
+  for (const d of definitions) registry.register(d);
+  return registry;
+}
+
+describe("validateStrategy", () => {
+  it("passes a valid two-step chain with a declared, bound dependency", () => {
+    const registry = registryWith(
+      fakeDefinition("swap", "soroswap"),
+      fakeDefinition("vaultDeposit", "defindex")
+    );
+    const strategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+      step({
+        id: "b",
+        type: "vaultDeposit",
+        protocol: "defindex",
+        dependsOn: ["a"],
+        params: {
+          amount: { source: "stepOutput", stepId: "a", portId: "out.amount" },
+        },
+      }),
+    ]);
+    const result = validateStrategy(strategy, { registry });
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  it("flags dependency structure errors: unknown/forward reference, undeclared binding, incompatible port", () => {
+    const registry = registryWith(
+      fakeDefinition("swap", "soroswap"),
+      fakeDefinition("vaultDeposit", "defindex")
+    );
+
+    expect(
+      validateStrategy(
+        strategyWith([step({ id: "a", dependsOn: ["ghost"] })]),
+        { registry }
+      ).issues
+    ).toContainEqual(
+      expect.objectContaining({ stepId: "a", code: "INVALID_DEPENDENCY" })
+    );
+
+    expect(
+      validateStrategy(
+        strategyWith([step({ id: "a", dependsOn: ["b"] }), step({ id: "b" })]),
+        { registry }
+      ).issues
+    ).toContainEqual(
+      expect.objectContaining({ stepId: "a", code: "INVALID_DEPENDENCY" })
+    );
+
+    expect(
+      validateStrategy(
+        strategyWith([
+          step({ id: "a", type: "swap", protocol: "soroswap" }),
+          step({
+            id: "b",
+            type: "vaultDeposit",
+            protocol: "defindex",
+            params: {
+              amount: {
+                source: "stepOutput",
+                stepId: "a",
+                portId: "out.amount",
+              },
+            },
+          }),
+        ]),
+        { registry }
+      ).issues
+    ).toContainEqual(
+      expect.objectContaining({ stepId: "b", code: "UNDECLARED_DEPENDENCY" })
+    );
+
+    expect(
+      validateStrategy(
+        strategyWith([
+          step({ id: "a", type: "swap", protocol: "soroswap" }),
+          step({
+            id: "b",
+            type: "vaultDeposit",
+            protocol: "defindex",
+            dependsOn: ["a"],
+            params: {
+              amount: {
+                source: "stepOutput",
+                stepId: "a",
+                portId: "out.nonexistent",
+              },
+            },
+          }),
+        ]),
+        { registry }
+      ).issues
+    ).toContainEqual(
+      expect.objectContaining({ stepId: "b", code: "INCOMPATIBLE_ASSET" })
+    );
+  });
+
+  it("detects a circular dependency and reports it as an issue, not a crash", () => {
+    const registry = registryWith(fakeDefinition("swap", "soroswap"));
+    const result = validateStrategy(
+      strategyWith([
+        step({ id: "a", dependsOn: ["b"] }),
+        step({ id: "b", dependsOn: ["a"] }),
+      ]),
+      { registry }
+    );
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "CIRCULAR_DEPENDENCY")).toBe(
+      true
+    );
+  });
+
+  it("flags an unregistered step type and surfaces a definition-level issue at the failing step", () => {
+    expect(
+      validateStrategy(
+        strategyWith([
+          step({ id: "a", type: "lpRemove", protocol: "soroswap" }),
+        ]),
+        { registry: registryWith() }
+      ).issues
+    ).toContainEqual(
+      expect.objectContaining({ stepId: "a", code: "UNSUPPORTED_STEP" })
+    );
+
+    const alwaysFails: ValidationIssue[] = [
+      {
+        stepId: null,
+        severity: "error",
+        code: "UNSUPPORTED_PROTOCOL_COMBINATION",
+        message: "not supported",
+      },
+    ];
+    const registry = registryWith(
+      fakeDefinition("lpRemove", "soroswap", { validate: () => alwaysFails })
+    );
+    expect(
+      validateStrategy(
+        strategyWith([
+          step({ id: "a", type: "lpRemove", protocol: "soroswap" }),
+        ]),
+        { registry }
+      ).issues
+    ).toContainEqual(
+      expect.objectContaining({
+        stepId: "a",
+        code: "UNSUPPORTED_PROTOCOL_COMBINATION",
+      })
+    );
+  });
+
+  it("never throws even when a definition's validate() throws", () => {
+    const registry = registryWith(
+      fakeDefinition("swap", "soroswap", {
+        validate: () => {
+          throw new Error("boom");
+        },
+      })
+    );
+    const strategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+    ]);
+    expect(() => validateStrategy(strategy, { registry })).not.toThrow();
+    expect(validateStrategy(strategy, { registry }).issues).toContainEqual(
+      expect.objectContaining({ stepId: "a", code: "VALIDATION_ERROR" })
+    );
+  });
+
+  it("includes balance issues only when a balances map is provided", () => {
+    const registry = registryWith(fakeDefinition("swap", "soroswap"));
+    const strategy = strategyWith([
+      step({
+        id: "a",
+        type: "swap",
+        protocol: "soroswap",
+        params: {
+          tokenIn: { source: "literal", value: "USDC" },
+          amountIn: { source: "literal", value: "1000" },
+        },
+      }),
+    ]);
+    expect(
+      validateStrategy(strategy, { registry, balances: { USDC: "1" } }).issues
+    ).toContainEqual(expect.objectContaining({ code: "INSUFFICIENT_BALANCE" }));
+    expect(validateStrategy(strategy, { registry }).issues).toEqual([]);
+  });
+});
+
+describe("validateBalances", () => {
+  it("flags a root step whose literal amount exceeds the wallet balance", () => {
+    const strategy = strategyWith([
+      step({
+        id: "a",
+        params: {
+          tokenIn: { source: "literal", value: "USDC" },
+          amountIn: { source: "literal", value: "100" },
+        },
+      }),
+    ]);
+    expect(validateBalances(strategy, { USDC: "50" })).toEqual([
+      expect.objectContaining({ stepId: "a", code: "INSUFFICIENT_BALANCE" }),
+    ]);
+  });
+
+  it("passes with enough balance, skips upstream-funded and unknown-asset steps", () => {
+    expect(
+      validateBalances(
+        strategyWith([
+          step({
+            id: "a",
+            params: {
+              assetCode: { source: "literal", value: "USDC" },
+              amount: { source: "literal", value: "50" },
+            },
+          }),
+        ]),
+        { USDC: "100" }
+      )
+    ).toEqual([]);
+    expect(
+      validateBalances(
+        strategyWith([
+          step({
+            id: "a",
+            dependsOn: ["x"],
+            params: {
+              assetCode: { source: "literal", value: "USDC" },
+              amount: { source: "literal", value: "999999" },
+            },
+          }),
+        ]),
+        { USDC: "1" }
+      )
+    ).toEqual([]);
+    expect(
+      validateBalances(
+        strategyWith([
+          step({
+            id: "a",
+            params: {
+              assetCode: { source: "literal", value: "USDC" },
+              amount: {
+                source: "stepOutput",
+                stepId: "x",
+                portId: "out.amount",
+              },
+            },
+          }),
+        ]),
+        { USDC: "0" }
+      )
+    ).toEqual([]);
+  });
+});
+
+// ─── Simulation ──────────────────────────────────────────────────────────────
+
+const execCtx = { userAddress: "GUSER", networkPassphrase: "p" };
+
+describe("simulateStrategy", () => {
+  it("feeds step A's simulate() output forward as step B's resolvedParams and aggregates fees bigint-safely", async () => {
+    const registry = new StrategyStepRegistry();
+    registry.register({
+      stepType: "swap",
+      protocol: "soroswap",
+      submissionMode: "soroswapApi",
+      paramsSchema: z.object({}).passthrough(),
+      describeOutputs: () => [
+        { id: "out.amount", assetCode: "USDC", kind: "asset" },
+      ],
+      validate: () => [],
+      simulate: async () => ({
+        outputs: { "out.amount": "42" },
+        estimatedFee: "0.0000001",
+        slippageBps: 10,
+        warnings: [],
+      }),
+      prepare: async () => ({ xdr: "", networkPassphrase: "" }),
+    });
+    let received: unknown;
+    registry.register({
+      stepType: "vaultDeposit",
+      protocol: "defindex",
+      submissionMode: "rpc",
+      paramsSchema: z.object({}).passthrough(),
+      describeOutputs: () => [],
+      validate: () => [],
+      simulate: async (ctx: StepExecutionContext) => {
+        received = ctx.resolvedParams;
+        return { outputs: {}, estimatedFee: "0.0000002", warnings: [] };
+      },
+      prepare: async () => ({ xdr: "", networkPassphrase: "" }),
+    });
+
+    const strategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+      step({
+        id: "b",
+        type: "vaultDeposit",
+        protocol: "defindex",
+        dependsOn: ["a"],
+        params: {
+          amount: { source: "stepOutput", stepId: "a", portId: "out.amount" },
+        },
+      }),
+    ]);
+    const projection = await simulateStrategy(strategy, {
+      ...execCtx,
+      registry,
+    });
+    expect(projection.success).toBe(true);
+    expect(received).toEqual({ amount: "42" });
+    expect(projection.cumulativeFee).toBe("0.0000003");
+  });
+
+  it("reports the exact blocking step on failure and never partially succeeds", async () => {
+    const registry = new StrategyStepRegistry();
+    registry.register({
+      stepType: "swap",
+      protocol: "soroswap",
+      submissionMode: "soroswapApi",
+      paramsSchema: z.object({}).passthrough(),
+      describeOutputs: () => [],
+      validate: () => [],
+      simulate: async () => {
+        throw new Error("No liquidity found");
+      },
+      prepare: async () => ({ xdr: "", networkPassphrase: "" }),
+    });
+    registry.register({
+      stepType: "vaultDeposit",
+      protocol: "defindex",
+      submissionMode: "rpc",
+      paramsSchema: z.object({}).passthrough(),
+      describeOutputs: () => [],
+      validate: () => [],
+      simulate: async () => ({ outputs: {}, estimatedFee: "0", warnings: [] }),
+      prepare: async () => ({ xdr: "", networkPassphrase: "" }),
+    });
+
+    const strategy = strategyWith([
+      step({ id: "boom-step", type: "swap", protocol: "soroswap" }),
+      step({
+        id: "b",
+        type: "vaultDeposit",
+        protocol: "defindex",
+        dependsOn: ["boom-step"],
+      }),
+    ]);
+    const projection = await simulateStrategy(strategy, {
+      ...execCtx,
+      registry,
+    });
+    expect(projection.success).toBe(false);
+    expect(projection.failedStepId).toBe("boom-step");
+    expect(projection.failureReason).toContain("No liquidity found");
+    expect(projection.steps.b).toBeUndefined();
+  });
+
+  it("reports a circular dependency without ever calling simulate(), and an unregistered step cleanly", async () => {
+    let called = false;
+    const registry = new StrategyStepRegistry();
+    registry.register({
+      stepType: "swap",
+      protocol: "soroswap",
+      submissionMode: "soroswapApi",
+      paramsSchema: z.object({}).passthrough(),
+      describeOutputs: () => [],
+      validate: () => [],
+      simulate: async () => {
+        called = true;
+        return { outputs: {}, estimatedFee: "0", warnings: [] };
+      },
+      prepare: async () => ({ xdr: "", networkPassphrase: "" }),
+    });
+    const cyclic = strategyWith([
+      step({ id: "a", dependsOn: ["b"] }),
+      step({ id: "b", dependsOn: ["a"] }),
+    ]);
+    const cyclicProjection = await simulateStrategy(cyclic, {
+      ...execCtx,
+      registry,
+    });
+    expect(cyclicProjection.success).toBe(false);
+    expect(called).toBe(false);
+
+    const unresolved = strategyWith([
+      step({ id: "a", type: "lpRemove", protocol: "soroswap" }),
+    ]);
+    const unresolvedProjection = await simulateStrategy(unresolved, {
+      ...execCtx,
+      registry: new StrategyStepRegistry(),
+    });
+    expect(unresolvedProjection.success).toBe(false);
+    expect(unresolvedProjection.failureReason).toContain("lpRemove:soroswap");
+  });
+
+  it("derives health factor from step resultingPosition deltas", async () => {
+    const registry = new StrategyStepRegistry();
+    registry.register({
+      stepType: "supply",
+      protocol: "neko",
+      submissionMode: "rpc",
+      paramsSchema: z.object({}).passthrough(),
+      describeOutputs: () => [],
+      validate: () => [],
+      simulate: async () => ({
+        outputs: {},
+        estimatedFee: "0",
+        warnings: [],
+        resultingPosition: {
+          protocol: "neko",
+          collateralAssetCode: "CETES",
+          collateralDelta: 100,
+          collateralFactorPct: 75,
+        },
+      }),
+      prepare: async () => ({ xdr: "", networkPassphrase: "" }),
+    });
+    registry.register({
+      stepType: "borrow",
+      protocol: "neko",
+      submissionMode: "rpc",
+      paramsSchema: z.object({}).passthrough(),
+      describeOutputs: () => [],
+      validate: () => [],
+      simulate: async () => ({
+        outputs: {},
+        estimatedFee: "0",
+        warnings: [],
+        resultingPosition: {
+          protocol: "neko",
+          debtAssetCode: "USDC",
+          debtDelta: 50,
+        },
+      }),
+      prepare: async () => ({ xdr: "", networkPassphrase: "" }),
+    });
+
+    const strategy = strategyWith([
+      step({ id: "a", type: "supply", protocol: "neko" }),
+      step({ id: "b", type: "borrow", protocol: "neko", dependsOn: ["a"] }),
+    ]);
+    const projection = await simulateStrategy(strategy, {
+      ...execCtx,
+      registry,
+    });
+    expect(projection.success).toBe(true);
+    expect(projection.projectedHealthFactor).toBeCloseTo(1.5); // (100 * 0.75) / 50
+  });
+});
+
+describe("aggregateProjection", () => {
+  function proj(overrides: Partial<StepProjection> = {}): StepProjection {
+    return { outputs: {}, estimatedFee: "0", warnings: [], ...overrides };
+  }
+
+  it("sums fees and slippage, averages-by-sum reported APY deltas, and zeroes out on an empty map", () => {
+    expect(
+      aggregateProjection({
+        a: proj({ estimatedFee: "0.0000001" }),
+        b: proj({ estimatedFee: "0.0000002" }),
+      }).cumulativeFee
+    ).toBe("0.0000003");
+    expect(
+      aggregateProjection({
+        a: proj({ slippageBps: 30 }),
+        b: proj({}),
+        c: proj({ slippageBps: 20 }),
+      }).cumulativeSlippageBps
+    ).toBe(50);
+    expect(
+      aggregateProjection({
+        a: proj({ projectedApyDelta: 2 }),
+        b: proj({}),
+        c: proj({ projectedApyDelta: 1.5 }),
+      }).projectedApy
+    ).toBeCloseTo(3.5);
+    expect(aggregateProjection({ a: proj({}) }).projectedApy).toBeNull();
+    expect(aggregateProjection({})).toEqual({
+      cumulativeFee: "0",
+      cumulativeSlippageBps: 0,
+      projectedApy: null,
+    });
+  });
+});
+
+describe("computeSensitivity", () => {
+  const baseline: StrategyProjection = {
+    success: true,
+    steps: {},
+    cumulativeFee: "0.0001",
+    cumulativeSlippageBps: 50,
+    projectedApy: 5,
+    effectiveLeverage: 2,
+    projectedHealthFactor: 1.5,
+    projectedLiquidationPrice: 10,
+  };
+
+  it("produces one scenario per config and scales slippage by the multiplier", () => {
+    const scenarios = computeSensitivity(baseline);
+    expect(scenarios).toHaveLength(DEFAULT_SENSITIVITY_SCENARIOS.length);
+    const doubled = computeSensitivity(baseline, [
+      { label: "2x", slippageMultiplier: 2, priceShockPct: 0 },
+    ]);
+    expect(doubled[0].projection.cumulativeSlippageBps).toBe(100);
+  });
+
+  it("degrades health factor and moves liquidation price under an adverse price shock, and leaves both untouched at 0% shock", () => {
+    const shocked = computeSensitivity(baseline, [
+      { label: "-10%", slippageMultiplier: 1, priceShockPct: -0.1 },
+    ])[0].projection;
+    expect(shocked.projectedHealthFactor).toBeCloseTo(1.35);
+    expect(shocked.projectedLiquidationPrice).toBeCloseTo(11);
+
+    const unshocked = computeSensitivity(baseline, [
+      { label: "none", slippageMultiplier: 1, priceShockPct: 0 },
+    ])[0].projection;
+    expect(unshocked.projectedHealthFactor).toBe(1.5);
+    expect(unshocked.projectedLiquidationPrice).toBe(10);
+  });
+
+  it("passes a failed baseline through unchanged for every scenario", () => {
+    const failed: StrategyProjection = {
+      success: false,
+      failedStepId: "x",
+      failureReason: "boom",
+      steps: {},
+      cumulativeFee: "0",
+      cumulativeSlippageBps: 0,
+      projectedApy: null,
+      effectiveLeverage: null,
+      projectedHealthFactor: null,
+      projectedLiquidationPrice: null,
+    };
+    expect(
+      computeSensitivity(failed).every((s) => s.projection === failed)
+    ).toBe(true);
+  });
+});
+
+// ─── Risk ────────────────────────────────────────────────────────────────────
+
+describe("evaluateRisk", () => {
+  it("computes health factor, liquidation price, leverage, and protocol exposure from resultingPosition deltas", () => {
+    const positions: ResultingPosition[] = [
+      {
+        protocol: "neko",
+        collateralAssetCode: "CETES",
+        collateralDelta: 100,
+        collateralFactorPct: 75,
+      },
+      { protocol: "neko", debtAssetCode: "USDC", debtDelta: 50 },
+    ];
+    const risk = evaluateRisk(positions, 0);
+    expect(risk.projectedHealthFactor).toBeCloseTo(1.5);
+    expect(risk.projectedLiquidationPrice).toBeCloseTo(0.6667, 3);
+    expect(risk.riskTier).toBe("safe");
+    expect(risk.protocolExposure).toEqual({ neko: 150 });
+  });
+
+  it("computes leverage, returns nulls/unknown tier with no position, and passes slippage through", () => {
+    expect(
+      evaluateRisk(
+        [
+          { protocol: "neko", collateralDelta: 200 },
+          { protocol: "neko", debtDelta: 100 },
+        ],
+        0
+      ).effectiveLeverage
+    ).toBeCloseTo(2);
+    const empty = evaluateRisk([], 0);
+    expect(empty.effectiveLeverage).toBeNull();
+    expect(empty.projectedHealthFactor).toBeNull();
+    expect(empty.riskTier).toBe("unknown");
+    expect(evaluateRisk([], 123).cumulativeSlippageBps).toBe(123);
+  });
+});
+
+describe("computeProtocolExposure", () => {
+  it("sums |collateralDelta| + |debtDelta| per protocol, omitting zero-exposure protocols", () => {
+    expect(
+      computeProtocolExposure([
+        { protocol: "neko", collateralDelta: 100 },
+        { protocol: "neko", debtDelta: 50 },
+        { protocol: "blend", collateralDelta: -20 },
+      ])
+    ).toEqual({ neko: 150, blend: 20 });
+    expect(computeProtocolExposure([{ protocol: "defindex" }])).toEqual({});
+    expect(computeProtocolExposure([])).toEqual({});
+  });
+});
+
+describe("exceedsThresholds / deviationThresholdFor", () => {
+  function assessment(overrides: Partial<RiskAssessment> = {}): RiskAssessment {
+    return {
+      effectiveLeverage: 1,
+      projectedHealthFactor: 2,
+      projectedLiquidationPrice: null,
+      cumulativeSlippageBps: 0,
+      riskTier: "safe",
+      protocolExposure: {},
+      ...overrides,
+    };
+  }
+
+  it("flags health factor, leverage, and slippage breaches; ignores null fields; respects a custom config", () => {
+    expect(exceedsThresholds(assessment())).toBe(false);
+    expect(exceedsThresholds(assessment({ projectedHealthFactor: 1.0 }))).toBe(
+      true
+    );
+    expect(exceedsThresholds(assessment({ effectiveLeverage: 5 }))).toBe(true);
+    expect(exceedsThresholds(assessment({ cumulativeSlippageBps: 1000 }))).toBe(
+      true
+    );
+    expect(
+      exceedsThresholds(
+        assessment({ projectedHealthFactor: null, effectiveLeverage: null })
+      )
+    ).toBe(false);
+    expect(
+      exceedsThresholds(assessment({ effectiveLeverage: 1.5 }), {
+        ...DEFAULT_RISK_THRESHOLDS,
+        maxLeverage: 1.1,
+      })
+    ).toBe(true);
+  });
+
+  it("returns the per-step-type override when configured, else the default", () => {
+    expect(deviationThresholdFor("swap")).toBe(
+      DEFAULT_RISK_THRESHOLDS.deviationThresholds.swap
+    );
+    expect(deviationThresholdFor("vaultDeposit")).toBe(
+      DEFAULT_RISK_THRESHOLDS.defaultDeviationThreshold
+    );
+  });
+});

--- a/apps/web-app/src/lib/strategy/__tests__/execution.test.ts
+++ b/apps/web-app/src/lib/strategy/__tests__/execution.test.ts
@@ -1,0 +1,588 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod";
+import {
+  checkDeviation,
+  ExecutionEngine,
+  reconcileExecution,
+  findResumableExecutions,
+  type ExecutionEngineDeps,
+} from "../execution";
+import { upsertExecution } from "../persistence";
+import { StrategyStepRegistry } from "../registry";
+import type {
+  ExecutionRecord,
+  Strategy,
+  StrategyStep,
+  StrategyStepDefinition,
+  StepProjection,
+} from "../types";
+
+// ─── Deviation check ─────────────────────────────────────────────────────────
+
+function projection(outputs: Record<string, unknown>): StepProjection {
+  return { outputs, estimatedFee: "0", warnings: [] };
+}
+
+describe("checkDeviation", () => {
+  it("reports no deviation within threshold, flags a breach with a message, and handles non-numeric/missing ports", () => {
+    expect(
+      checkDeviation("swap", projection({ "out.amount": "100" }), {
+        "out.amount": "100",
+      }).deviated
+    ).toBe(false);
+    expect(
+      checkDeviation("swap", projection({ "out.amount": "100" }), {
+        "out.amount": "97",
+      }).deviated
+    ).toBe(false); // within 5% swap threshold
+
+    const breach = checkDeviation("swap", projection({ "out.amount": "100" }), {
+      "out.amount": "80",
+    });
+    expect(breach.deviated).toBe(true);
+    expect(breach.relativeDeviation).toBeCloseTo(0.2);
+    expect(breach.message).toMatch(/deviates/);
+
+    // vaultDeposit has no override -> defaultDeviationThreshold (3%)
+    expect(
+      checkDeviation("vaultDeposit", projection({ "out.dfTokens": "100" }), {
+        "out.dfTokens": "96",
+      }).deviated
+    ).toBe(true);
+
+    expect(
+      checkDeviation("swap", projection({ "out.amount": "not-a-number" }), {
+        "out.amount": "also-not-a-number",
+      }).deviated
+    ).toBe(false);
+    expect(
+      checkDeviation(
+        "swap",
+        projection({ "out.other": "not-a-number", "out.amount": "100" }),
+        { "out.amount": "100" }
+      ).deviated
+    ).toBe(false);
+  });
+});
+
+// ─── Execution engine ────────────────────────────────────────────────────────
+
+function step(
+  overrides: Partial<StrategyStep> & {
+    id: string;
+    type: string;
+    protocol: string;
+  }
+): StrategyStep {
+  return {
+    label: overrides.id,
+    params: {},
+    dependsOn: [],
+    ...overrides,
+  } as StrategyStep;
+}
+function strategyWith(steps: StrategyStep[]): Strategy {
+  return {
+    id: "s1",
+    version: 1,
+    name: "Test",
+    isTemplate: false,
+    steps,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+function freshRecord(strategy: Strategy): ExecutionRecord {
+  return {
+    id: "e1",
+    strategyId: strategy.id,
+    strategySnapshot: strategy,
+    status: "in_progress",
+    startedAt: 0,
+    updatedAt: 0,
+    projectedOutcome: { steps: {} },
+    steps: [],
+  };
+}
+function fakeDefinition(
+  stepType: string,
+  protocol: string,
+  overrides: Partial<StrategyStepDefinition> = {}
+): StrategyStepDefinition {
+  return {
+    stepType: stepType as StrategyStepDefinition["stepType"],
+    protocol,
+    submissionMode: "rpc",
+    paramsSchema: z.object({}).passthrough(),
+    describeOutputs: () => [],
+    validate: () => [],
+    simulate: async () => ({ outputs: {}, estimatedFee: "0", warnings: [] }),
+    prepare: async () => ({ xdr: "UNSIGNED_XDR", networkPassphrase: "p" }),
+    ...overrides,
+  };
+}
+function baseDeps(
+  overrides: Partial<ExecutionEngineDeps> = {}
+): ExecutionEngineDeps {
+  return {
+    sign: vi.fn(async (xdr: string) => ({ signedTxXdr: `signed(${xdr})` })),
+    transports: {
+      rpc: {
+        submit: vi.fn(async () => ({ hash: "HASH" })),
+        confirm: vi.fn(async () => ({ status: "SUCCESS" })),
+      },
+      soroswapApi: {
+        submit: vi.fn(async () => ({ hash: "SORO_HASH" })),
+        confirm: vi.fn(async () => ({ status: "SUCCESS" })),
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("ExecutionEngine — sequential execution", () => {
+  it("executes each step in dependency order, propagates actual outputs, and routes submission by submissionMode", async () => {
+    const registry = new StrategyStepRegistry();
+    const calls: string[] = [];
+    registry.register(
+      fakeDefinition("swap", "soroswap", {
+        prepare: async () => {
+          calls.push("prepare:a");
+          return { xdr: "XDR_A", networkPassphrase: "p" };
+        },
+        interpretResult: async () => ({ outputs: { "out.amount": "42" } }),
+      })
+    );
+    let receivedParams: unknown;
+    registry.register(
+      fakeDefinition("vaultDeposit", "defindex", {
+        prepare: async (ctx) => {
+          calls.push("prepare:b");
+          receivedParams = ctx.resolvedParams;
+          return { xdr: "XDR_B", networkPassphrase: "p" };
+        },
+      })
+    );
+
+    const strategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+      step({
+        id: "b",
+        type: "vaultDeposit",
+        protocol: "defindex",
+        dependsOn: ["a"],
+        params: {
+          amount: { source: "stepOutput", stepId: "a", portId: "out.amount" },
+        },
+      }),
+    ]);
+    const deps = baseDeps();
+    const result = await new ExecutionEngine({
+      ...deps,
+      registry,
+    }).executeStrategy({
+      strategy,
+      execution: freshRecord(strategy),
+      userAddress: "GUSER",
+      networkPassphrase: "p",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(calls).toEqual(["prepare:a", "prepare:b"]);
+    expect(receivedParams).toEqual({ amount: "42" });
+    expect(result.record.steps.map((s) => s.status)).toEqual([
+      "completed",
+      "completed",
+    ]);
+    expect(deps.sign).toHaveBeenCalledTimes(2);
+    expect(deps.transports.rpc.submit).toHaveBeenCalledTimes(2);
+
+    const soroswapRegistry = new StrategyStepRegistry();
+    soroswapRegistry.register(
+      fakeDefinition("swap", "soroswap", { submissionMode: "soroswapApi" })
+    );
+    const soroDeps = baseDeps();
+    const soroStrategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+    ]);
+    await new ExecutionEngine({
+      ...soroDeps,
+      registry: soroswapRegistry,
+    }).executeStrategy({
+      strategy: soroStrategy,
+      execution: freshRecord(soroStrategy),
+      userAddress: "GUSER",
+      networkPassphrase: "p",
+    });
+    expect(soroDeps.transports.soroswapApi.submit).toHaveBeenCalledTimes(1);
+    expect(soroDeps.transports.rpc.submit).not.toHaveBeenCalled();
+  });
+});
+
+describe("ExecutionEngine — deviation handling", () => {
+  it("pauses instead of advancing when a step's actual result deviates beyond threshold", async () => {
+    const registry = new StrategyStepRegistry();
+    registry.register(
+      fakeDefinition("swap", "soroswap", {
+        interpretResult: async () => ({ outputs: { "out.amount": "80" } }),
+      })
+    ); // 20% below projection
+    registry.register(fakeDefinition("vaultDeposit", "defindex"));
+
+    const strategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+      step({
+        id: "b",
+        type: "vaultDeposit",
+        protocol: "defindex",
+        dependsOn: ["a"],
+      }),
+    ]);
+    const record = freshRecord(strategy);
+    record.projectedOutcome = {
+      steps: {
+        a: {
+          outputs: { "out.amount": "100" },
+          estimatedFee: "0",
+          warnings: [],
+        },
+      },
+    };
+
+    const result = await new ExecutionEngine({
+      ...baseDeps(),
+      registry,
+    }).executeStrategy({
+      strategy,
+      execution: record,
+      userAddress: "GUSER",
+      networkPassphrase: "p",
+    });
+    expect(result.status).toBe("paused-deviation");
+    expect(result.record.steps).toHaveLength(1); // step "b" never ran
+    expect(result.record.steps[0]).toMatchObject({
+      stepId: "a",
+      status: "paused_deviation",
+    });
+  });
+
+  it("resuming without acknowledgement re-pauses immediately without re-submitting", async () => {
+    const registry = new StrategyStepRegistry();
+    const prepareSpy = vi.fn(async () => ({
+      xdr: "X",
+      networkPassphrase: "p",
+    }));
+    registry.register(
+      fakeDefinition("swap", "soroswap", { prepare: prepareSpy })
+    );
+
+    const strategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+    ]);
+    const pausedRecord = freshRecord(strategy);
+    pausedRecord.status = "paused-deviation";
+    pausedRecord.steps = [
+      {
+        stepId: "a",
+        status: "paused_deviation",
+        actualOutputs: { "out.amount": "80" },
+        deviation: { deviated: true, relativeDeviation: 0.2, threshold: 0.05 },
+      },
+    ];
+
+    const deps = baseDeps();
+    const result = await new ExecutionEngine({
+      ...deps,
+      registry,
+    }).executeStrategy({
+      strategy,
+      execution: pausedRecord,
+      userAddress: "GUSER",
+      networkPassphrase: "p",
+    });
+    expect(result.status).toBe("paused-deviation");
+    expect(prepareSpy).not.toHaveBeenCalled();
+    expect(deps.transports.rpc.submit).not.toHaveBeenCalled();
+  });
+
+  it("resuming with acknowledgement accepts the recorded result and continues without re-submitting that step", async () => {
+    const registry = new StrategyStepRegistry();
+    const prepareSpyA = vi.fn(async () => ({
+      xdr: "X",
+      networkPassphrase: "p",
+    }));
+    registry.register(
+      fakeDefinition("swap", "soroswap", { prepare: prepareSpyA })
+    );
+    registry.register(fakeDefinition("vaultDeposit", "defindex"));
+
+    const strategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+      step({
+        id: "b",
+        type: "vaultDeposit",
+        protocol: "defindex",
+        dependsOn: ["a"],
+      }),
+    ]);
+    const pausedRecord = freshRecord(strategy);
+    pausedRecord.status = "paused-deviation";
+    pausedRecord.steps = [
+      {
+        stepId: "a",
+        status: "paused_deviation",
+        actualOutputs: { "out.amount": "80" },
+        deviation: { deviated: true, relativeDeviation: 0.2, threshold: 0.05 },
+      },
+    ];
+
+    const result = await new ExecutionEngine({
+      ...baseDeps(),
+      registry,
+    }).executeStrategy({
+      strategy,
+      execution: pausedRecord,
+      userAddress: "GUSER",
+      networkPassphrase: "p",
+      acknowledgedDeviationStepIds: ["a"],
+    });
+    expect(result.status).toBe("completed");
+    expect(prepareSpyA).not.toHaveBeenCalled();
+    expect(result.record.steps.find((s) => s.stepId === "a")?.status).toBe(
+      "completed"
+    );
+    expect(result.record.steps.find((s) => s.stepId === "b")?.status).toBe(
+      "completed"
+    );
+  });
+});
+
+describe("ExecutionEngine — failure and recovery", () => {
+  it("halts and marks the step failed when prepare() throws, without touching later steps", async () => {
+    const registry = new StrategyStepRegistry();
+    registry.register(
+      fakeDefinition("swap", "soroswap", {
+        prepare: async () => {
+          throw new Error("simulation rejected");
+        },
+      })
+    );
+    registry.register(fakeDefinition("vaultDeposit", "defindex"));
+    const strategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+      step({
+        id: "b",
+        type: "vaultDeposit",
+        protocol: "defindex",
+        dependsOn: ["a"],
+      }),
+    ]);
+
+    const result = await new ExecutionEngine({
+      ...baseDeps(),
+      registry,
+    }).executeStrategy({
+      strategy,
+      execution: freshRecord(strategy),
+      userAddress: "GUSER",
+      networkPassphrase: "p",
+    });
+    expect(result.status).toBe("failed");
+    expect(result.record.steps).toEqual([
+      expect.objectContaining({
+        stepId: "a",
+        status: "failed",
+        errorMessage: expect.stringContaining("simulation rejected"),
+      }),
+    ]);
+  });
+
+  it("resuming a partially-completed execution skips already-completed steps and seeds their outputs", async () => {
+    const registry = new StrategyStepRegistry();
+    const prepareSpyA = vi.fn(async () => ({
+      xdr: "X",
+      networkPassphrase: "p",
+    }));
+    registry.register(
+      fakeDefinition("swap", "soroswap", { prepare: prepareSpyA })
+    );
+    let receivedParams: unknown;
+    registry.register(
+      fakeDefinition("vaultDeposit", "defindex", {
+        prepare: async (ctx) => {
+          receivedParams = ctx.resolvedParams;
+          return { xdr: "X", networkPassphrase: "p" };
+        },
+      })
+    );
+
+    const strategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+      step({
+        id: "b",
+        type: "vaultDeposit",
+        protocol: "defindex",
+        dependsOn: ["a"],
+        params: {
+          amount: { source: "stepOutput", stepId: "a", portId: "out.amount" },
+        },
+      }),
+    ]);
+    const partialRecord = freshRecord(strategy);
+    partialRecord.steps = [
+      {
+        stepId: "a",
+        status: "completed",
+        actualOutputs: { "out.amount": "99" },
+      },
+    ];
+
+    const result = await new ExecutionEngine({
+      ...baseDeps(),
+      registry,
+    }).executeStrategy({
+      strategy,
+      execution: partialRecord,
+      userAddress: "GUSER",
+      networkPassphrase: "p",
+    });
+    expect(result.status).toBe("completed");
+    expect(prepareSpyA).not.toHaveBeenCalled();
+    expect(receivedParams).toEqual({ amount: "99" });
+  });
+
+  it("calls onStepUpdate after every status transition, in order", async () => {
+    const registry = new StrategyStepRegistry();
+    registry.register(fakeDefinition("swap", "soroswap"));
+    const strategy = strategyWith([
+      step({ id: "a", type: "swap", protocol: "soroswap" }),
+    ]);
+    const statuses: string[] = [];
+
+    await new ExecutionEngine({ ...baseDeps(), registry }).executeStrategy({
+      strategy,
+      execution: freshRecord(strategy),
+      userAddress: "GUSER",
+      networkPassphrase: "p",
+      onStepUpdate: (record) => {
+        const s = record.steps.find((st) => st.stepId === "a");
+        if (s) statuses.push(s.status);
+      },
+    });
+
+    // The final onStepUpdate call reflects overall record completion, re-reporting the
+    // already-"completed" step status once more — dedupe consecutive repeats.
+    const distinct = statuses.filter((s, i) => s !== statuses[i - 1]);
+    expect(distinct).toEqual([
+      "preparing",
+      "awaiting_signature",
+      "submitting",
+      "confirming",
+      "completed",
+    ]);
+  });
+});
+
+// ─── Recovery ────────────────────────────────────────────────────────────────
+
+const WALLET = "GALICE";
+function execution(
+  id: string,
+  overrides: Partial<ExecutionRecord> = {}
+): ExecutionRecord {
+  return {
+    id,
+    strategyId: "s1",
+    strategySnapshot: {},
+    status: "in_progress",
+    startedAt: 0,
+    updatedAt: 0,
+    projectedOutcome: {},
+    steps: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("reconcileExecution", () => {
+  it("marks a submitting/confirming step completed or failed per the chain status, without mutating the original record", async () => {
+    const successRecord = execution("e1", {
+      steps: [{ stepId: "a", status: "submitting", txHash: "H1" }],
+    });
+    const getSuccess = vi.fn().mockResolvedValue("SUCCESS");
+    const reconciledSuccess = await reconcileExecution(successRecord, {
+      getTransactionStatus: getSuccess,
+    });
+    expect(getSuccess).toHaveBeenCalledWith("H1");
+    expect(reconciledSuccess.steps[0].status).toBe("completed");
+    expect(reconciledSuccess.steps[0].confirmedAt).toBeDefined();
+    expect(successRecord.steps[0].status).toBe("submitting"); // original untouched
+
+    const failedRecord = execution("e2", {
+      steps: [{ stepId: "a", status: "confirming", txHash: "H1" }],
+    });
+    const reconciledFailed = await reconcileExecution(failedRecord, {
+      getTransactionStatus: vi.fn().mockResolvedValue("FAILED"),
+    });
+    expect(reconciledFailed.steps[0].status).toBe("failed");
+    expect(reconciledFailed.steps[0].errorMessage).toBeDefined();
+  });
+
+  it("leaves the status untouched on PENDING or a reconciliation poll error, and skips completed/never-submitted steps", async () => {
+    const pendingRecord = execution("e1", {
+      steps: [{ stepId: "a", status: "submitting", txHash: "H1" }],
+    });
+    expect(
+      (
+        await reconcileExecution(pendingRecord, {
+          getTransactionStatus: vi.fn().mockResolvedValue("PENDING"),
+        })
+      ).steps[0].status
+    ).toBe("submitting");
+
+    const erroringRecord = execution("e2", {
+      steps: [{ stepId: "a", status: "confirming", txHash: "H1" }],
+    });
+    expect(
+      (
+        await reconcileExecution(erroringRecord, {
+          getTransactionStatus: vi
+            .fn()
+            .mockRejectedValue(new Error("network down")),
+        })
+      ).steps[0].status
+    ).toBe("confirming");
+
+    const getStatus = vi.fn();
+    await reconcileExecution(
+      execution("e3", {
+        steps: [
+          { stepId: "a", status: "completed", txHash: "H1" },
+          { stepId: "b", status: "pending" },
+        ],
+      }),
+      { getTransactionStatus: getStatus }
+    );
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("findResumableExecutions", () => {
+  it("surfaces in_progress and paused-deviation executions for the resume prompt", () => {
+    upsertExecution(WALLET, execution("done", { status: "completed" }));
+    upsertExecution(WALLET, execution("running", { status: "in_progress" }));
+    upsertExecution(
+      WALLET,
+      execution("paused", { status: "paused-deviation" })
+    );
+    expect(
+      findResumableExecutions(WALLET)
+        .map((e) => e.id)
+        .sort()
+    ).toEqual(["paused", "running"]);
+  });
+});

--- a/apps/web-app/src/lib/strategy/__tests__/hooks.test.ts
+++ b/apps/web-app/src/lib/strategy/__tests__/hooks.test.ts
@@ -1,0 +1,335 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const {
+  useWalletMock,
+  simulateStrategyMock,
+  listStrategiesMock,
+  upsertStrategyMock,
+  removeStrategyMock,
+  upsertExecutionMock,
+  ExecutionEngineMock,
+  executeStrategyMock,
+  findResumableExecutionsMock,
+  reconcileExecutionMock,
+  ServerMock,
+} = vi.hoisted(() => {
+  const executeStrategyMock = vi.fn().mockResolvedValue({
+    record: { id: "e1", steps: [] },
+    status: "completed",
+  });
+  class ExecutionEngineMock {
+    deps: unknown;
+    executeStrategy = executeStrategyMock;
+    constructor(deps: unknown) {
+      this.deps = deps;
+    }
+  }
+  class ServerMock {
+    getTransaction = vi.fn();
+    sendTransaction = vi.fn();
+  }
+  return {
+    useWalletMock: vi.fn(),
+    simulateStrategyMock: vi.fn(),
+    listStrategiesMock: vi.fn(),
+    upsertStrategyMock: vi.fn(),
+    removeStrategyMock: vi.fn(),
+    upsertExecutionMock: vi.fn(),
+    ExecutionEngineMock,
+    executeStrategyMock,
+    findResumableExecutionsMock: vi.fn(),
+    reconcileExecutionMock: vi.fn(),
+    ServerMock,
+  };
+});
+
+vi.mock("@/hooks/useWallet", () => ({ useWallet: useWalletMock }));
+vi.mock("@stellar/stellar-sdk", () => ({
+  rpc: { Server: ServerMock },
+  TransactionBuilder: { fromXDR: vi.fn() },
+}));
+vi.mock("@/lib/helpers/stellar/soroswap", () => ({
+  sendTransaction: vi.fn(),
+  getQuote: vi.fn(),
+  buildTransaction: vi.fn(),
+  getAvailableTokens: vi.fn(() => ({})),
+}));
+vi.mock("@/lib/helpers/stellar/waitForTransaction", () => ({
+  waitForTransaction: vi.fn(),
+}));
+vi.mock("../engine", () => ({
+  validateStrategy: vi.fn(),
+  simulateStrategy: simulateStrategyMock,
+}));
+vi.mock("../persistence", () => ({
+  listStrategies: listStrategiesMock,
+  upsertStrategy: upsertStrategyMock,
+  removeStrategy: removeStrategyMock,
+  upsertExecution: upsertExecutionMock,
+}));
+vi.mock("../execution", () => ({
+  ExecutionEngine: ExecutionEngineMock,
+  findResumableExecutions: findResumableExecutionsMock,
+  reconcileExecution: reconcileExecutionMock,
+}));
+vi.mock("../definitions", () => ({}));
+vi.mock("../registry", () => ({
+  strategyStepRegistry: { listRegistered: () => [] },
+}));
+
+import {
+  useStrategySimulation,
+  useStrategyPersistence,
+  useStrategyExecution,
+  useExecutionRecovery,
+} from "../hooks";
+import type { ExecutionRecord, Strategy } from "../types";
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  Wrapper.displayName = "QueryWrapper";
+  return Wrapper;
+}
+
+const strategy: Strategy = {
+  id: "s1",
+  version: 1,
+  name: "Test",
+  isTemplate: false,
+  steps: [],
+  createdAt: 0,
+  updatedAt: 0,
+};
+const execution: ExecutionRecord = {
+  id: "e1",
+  strategyId: "s1",
+  strategySnapshot: strategy,
+  status: "in_progress",
+  startedAt: 0,
+  updatedAt: 0,
+  projectedOutcome: {},
+  steps: [],
+};
+
+function record(id: string, status: string) {
+  return {
+    id,
+    strategyId: "s1",
+    strategySnapshot: {},
+    status,
+    startedAt: 0,
+    updatedAt: 0,
+    projectedOutcome: {},
+    steps: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  executeStrategyMock.mockResolvedValue({
+    record: { id: "e1", steps: [] },
+    status: "completed",
+  });
+  useWalletMock.mockReturnValue({
+    address: "GUSER",
+    networkPassphrase: "Test SDF Network ; September 2015",
+    signTransaction: vi.fn(),
+    balances: {},
+  });
+  listStrategiesMock.mockReturnValue([]);
+});
+
+describe("useStrategySimulation", () => {
+  it("calls simulateStrategy with the wallet's address/passphrase once a strategy and wallet are present", async () => {
+    simulateStrategyMock.mockResolvedValue({ success: true, steps: {} });
+    const { result } = renderHook(() => useStrategySimulation(strategy), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(simulateStrategyMock).toHaveBeenCalledWith(strategy, {
+      userAddress: "GUSER",
+      networkPassphrase: "Test SDF Network ; September 2015",
+    });
+  });
+
+  it("stays disabled without a connected wallet or a null strategy", () => {
+    useWalletMock.mockReturnValue({
+      address: undefined,
+      networkPassphrase: undefined,
+      balances: {},
+    });
+    renderHook(() => useStrategySimulation(strategy), {
+      wrapper: createWrapper(),
+    });
+    expect(simulateStrategyMock).not.toHaveBeenCalled();
+
+    useWalletMock.mockReturnValue({
+      address: "GUSER",
+      networkPassphrase: "p",
+      balances: {},
+    });
+    renderHook(() => useStrategySimulation(null), { wrapper: createWrapper() });
+    expect(simulateStrategyMock).not.toHaveBeenCalled();
+  });
+
+  it("re-queries when the strategy's updatedAt changes (query key includes it)", async () => {
+    simulateStrategyMock.mockResolvedValue({ success: true, steps: {} });
+    const wrapper = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ s }: { s: Strategy }) => useStrategySimulation(s),
+      { wrapper, initialProps: { s: strategy } }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    rerender({ s: { ...strategy, updatedAt: 2 } });
+    await waitFor(() => expect(simulateStrategyMock).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("useStrategyPersistence", () => {
+  it("loads strategies scoped to the connected wallet and returns empty without one", async () => {
+    listStrategiesMock.mockReturnValue([strategy]);
+    const { result } = renderHook(() => useStrategyPersistence(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.strategies).toEqual([strategy]));
+    expect(listStrategiesMock).toHaveBeenCalledWith("GUSER");
+
+    useWalletMock.mockReturnValue({ address: undefined, balances: {} });
+    const { result: disconnected } = renderHook(
+      () => useStrategyPersistence(),
+      { wrapper: createWrapper() }
+    );
+    expect(disconnected.current.strategies).toEqual([]);
+  });
+
+  it("saveStrategy persists then refetches; deleteStrategy removes then refetches; both no-op without a wallet", async () => {
+    listStrategiesMock.mockReturnValue([strategy]);
+    const { result } = renderHook(() => useStrategyPersistence(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.strategies).toEqual([strategy]));
+
+    act(() => result.current.saveStrategy(strategy));
+    expect(upsertStrategyMock).toHaveBeenCalledWith("GUSER", strategy);
+
+    act(() => result.current.deleteStrategy("s1"));
+    expect(removeStrategyMock).toHaveBeenCalledWith("GUSER", "s1");
+
+    useWalletMock.mockReturnValue({ address: undefined, balances: {} });
+    const { result: disconnected } = renderHook(
+      () => useStrategyPersistence(),
+      { wrapper: createWrapper() }
+    );
+    act(() => disconnected.current.saveStrategy(strategy));
+    expect(upsertStrategyMock).toHaveBeenCalledTimes(1); // unchanged from the earlier call
+  });
+});
+
+describe("useStrategyExecution", () => {
+  it("constructs the engine with the wallet's signTransaction and both transports, passing params through to executeStrategy", async () => {
+    const signTransaction = vi.fn();
+    useWalletMock.mockReturnValue({
+      address: "GUSER",
+      networkPassphrase: "p",
+      signTransaction,
+      balances: {},
+    });
+
+    const { result } = renderHook(() => useStrategyExecution());
+    await act(async () => {
+      await result.current.execute(strategy, execution, {
+        acknowledgedDeviationStepIds: ["a"],
+      });
+    });
+
+    expect(executeStrategyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        strategy,
+        execution,
+        userAddress: "GUSER",
+        networkPassphrase: "p",
+        acknowledgedDeviationStepIds: ["a"],
+      })
+    );
+  });
+
+  it("wires onStepUpdate to persist the record via upsertExecution", async () => {
+    const { result } = renderHook(() => useStrategyExecution());
+    await act(async () => {
+      await result.current.execute(strategy, execution);
+    });
+    const onStepUpdate = executeStrategyMock.mock.calls[0][0].onStepUpdate;
+    const rec = { id: "e1", steps: [] } as unknown as ExecutionRecord;
+    onStepUpdate(rec);
+    expect(upsertExecutionMock).toHaveBeenCalledWith("GUSER", rec);
+  });
+
+  it("returns null and skips execution without a connected wallet", async () => {
+    useWalletMock.mockReturnValue({
+      address: undefined,
+      networkPassphrase: undefined,
+      signTransaction: vi.fn(),
+      balances: {},
+    });
+    const { result } = renderHook(() => useStrategyExecution());
+    let outcome;
+    await act(async () => {
+      outcome = await result.current.execute(strategy, execution);
+    });
+    expect(outcome).toBeNull();
+    expect(executeStrategyMock).not.toHaveBeenCalled();
+  });
+
+  it("toggles isExecuting around the execute() call", async () => {
+    const { result } = renderHook(() => useStrategyExecution());
+    expect(result.current.isExecuting).toBe(false);
+    await act(async () => {
+      await result.current.execute(strategy, execution);
+    });
+    expect(result.current.isExecuting).toBe(false);
+  });
+});
+
+describe("useExecutionRecovery", () => {
+  it("checks for resumable executions on mount, reconciles each, and persists the reconciled record", async () => {
+    findResumableExecutionsMock.mockReturnValue([record("e1", "in_progress")]);
+    reconcileExecutionMock.mockResolvedValue(record("e1", "completed"));
+
+    const { result } = renderHook(() => useExecutionRecovery());
+    await waitFor(() => expect(result.current.isChecking).toBe(false));
+    expect(findResumableExecutionsMock).toHaveBeenCalledWith("GUSER");
+    expect(reconcileExecutionMock).toHaveBeenCalled();
+    expect(upsertExecutionMock).toHaveBeenCalledWith(
+      "GUSER",
+      record("e1", "completed")
+    );
+    expect(result.current.resumable).toEqual([]); // reconciled to "completed" -> no longer resumable
+  });
+
+  it("does nothing without a connected wallet, and refresh() re-runs the check on demand", async () => {
+    useWalletMock.mockReturnValue({ address: undefined, balances: {} });
+    renderHook(() => useExecutionRecovery());
+    expect(findResumableExecutionsMock).not.toHaveBeenCalled();
+
+    useWalletMock.mockReturnValue({
+      address: "GUSER",
+      networkPassphrase: "p",
+      balances: {},
+      signTransaction: vi.fn(),
+    });
+    findResumableExecutionsMock.mockReturnValue([]);
+    const { result } = renderHook(() => useExecutionRecovery());
+    await waitFor(() => expect(result.current.isChecking).toBe(false));
+    findResumableExecutionsMock.mockClear();
+    await result.current.refresh();
+    expect(findResumableExecutionsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web-app/src/lib/strategy/__tests__/persistence.test.ts
+++ b/apps/web-app/src/lib/strategy/__tests__/persistence.test.ts
@@ -1,0 +1,365 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  strategyStorageSchema,
+  executionHistoryStorageSchema,
+  CURRENT_STRATEGY_STORAGE_VERSION,
+  CURRENT_EXECUTION_STORAGE_VERSION,
+  migrateDocument,
+  migrateStrategyDocument,
+  migrateExecutionHistoryDocument,
+  loadStrategyDocument,
+  listStrategies,
+  upsertStrategy,
+  removeStrategy,
+  loadExecutionHistoryDocument,
+  listExecutions,
+  upsertExecution,
+  findUnfinishedExecutions,
+  type MigrationFn,
+} from "../persistence";
+import type { ExecutionRecord, Strategy } from "../types";
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+const validStrategyDoc = {
+  version: CURRENT_STRATEGY_STORAGE_VERSION,
+  strategies: [
+    {
+      id: "s1",
+      version: 1,
+      name: "Swap then Deposit",
+      isTemplate: true,
+      steps: [
+        {
+          id: "a",
+          type: "swap",
+          protocol: "soroswap",
+          label: "Swap",
+          params: {
+            tokenIn: { source: "literal", value: "XLM" },
+            tokenOut: { source: "literal", value: "USDC" },
+          },
+          dependsOn: [],
+        },
+      ],
+      createdAt: 0,
+      updatedAt: 0,
+    },
+  ],
+};
+
+describe("strategyStorageSchema", () => {
+  it("accepts a well-formed document, forward-compatible steps, and both binding kinds", () => {
+    expect(strategyStorageSchema.safeParse(validStrategyDoc).success).toBe(
+      true
+    );
+
+    const forwardCompat = {
+      ...validStrategyDoc,
+      strategies: [
+        {
+          ...validStrategyDoc.strategies[0],
+          steps: [
+            {
+              id: "future",
+              type: "teleport",
+              protocol: "futureProtocol",
+              label: "Future step",
+              params: {},
+              dependsOn: [],
+            },
+          ],
+        },
+      ],
+    };
+    expect(strategyStorageSchema.safeParse(forwardCompat).success).toBe(true);
+
+    const boundBinding = {
+      ...validStrategyDoc,
+      strategies: [
+        {
+          ...validStrategyDoc.strategies[0],
+          steps: [
+            {
+              id: "a",
+              type: "swap",
+              protocol: "soroswap",
+              label: "Swap",
+              params: {
+                bound: {
+                  source: "stepOutput",
+                  stepId: "x",
+                  portId: "out.amount",
+                },
+              },
+              dependsOn: ["x"],
+            },
+          ],
+        },
+      ],
+    };
+    expect(strategyStorageSchema.safeParse(boundBinding).success).toBe(true);
+  });
+
+  it("rejects a document missing required fields or with an invalid param binding shape", () => {
+    expect(strategyStorageSchema.safeParse({ strategies: [] }).success).toBe(
+      false
+    );
+    const badBinding = {
+      ...validStrategyDoc,
+      strategies: [
+        {
+          ...validStrategyDoc.strategies[0],
+          steps: [
+            {
+              id: "a",
+              type: "swap",
+              protocol: "soroswap",
+              label: "Swap",
+              params: { bad: { source: "nonsense" } },
+              dependsOn: [],
+            },
+          ],
+        },
+      ],
+    };
+    expect(strategyStorageSchema.safeParse(badBinding).success).toBe(false);
+  });
+});
+
+describe("executionHistoryStorageSchema", () => {
+  it("accepts a well-formed execution record and rejects an unrecognized status", () => {
+    const doc = {
+      version: 1,
+      executions: [
+        {
+          id: "e1",
+          strategyId: "s1",
+          strategySnapshot: {},
+          status: "in_progress",
+          startedAt: 0,
+          updatedAt: 0,
+          projectedOutcome: {},
+          steps: [{ stepId: "a", status: "completed", txHash: "abc" }],
+        },
+      ],
+    };
+    expect(executionHistoryStorageSchema.safeParse(doc).success).toBe(true);
+    const bad = {
+      ...doc,
+      executions: [{ ...doc.executions[0], status: "not-a-real-status" }],
+    };
+    expect(executionHistoryStorageSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+// ─── Migrations ──────────────────────────────────────────────────────────────
+
+describe("migrateDocument — generic mechanics", () => {
+  it("applies a single migration, chains multiple, and leaves an already-current document untouched", () => {
+    const single: Record<number, MigrationFn> = {
+      0: (doc) => ({ ...doc, version: 1, isTemplate: doc.isTemplate ?? false }),
+    };
+    const migrated = migrateDocument({ strategies: [] }, 1, single) as {
+      version: number;
+      isTemplate: boolean;
+    };
+    expect(migrated).toMatchObject({ version: 1, isTemplate: false });
+
+    const chained: Record<number, MigrationFn> = {
+      0: (doc) => ({ ...doc, version: 1, addedInV1: true }),
+      1: (doc) => ({ ...doc, version: 2, addedInV2: true }),
+    };
+    expect(migrateDocument({ version: 0 }, 2, chained)).toMatchObject({
+      version: 2,
+      addedInV1: true,
+      addedInV2: true,
+    });
+
+    const shouldNotRun: Record<number, MigrationFn> = {
+      0: () => {
+        throw new Error("should not run");
+      },
+    };
+    const current = { version: 2, foo: "bar" };
+    expect(migrateDocument(current, 2, shouldNotRun)).toEqual(current);
+  });
+
+  it("stops without throwing when no migration is registered, treats a missing version as 0, and never infinite-loops", () => {
+    expect(migrateDocument({ version: 0 }, 5, {})).toEqual({ version: 0 });
+    const treatsMissingAsV0: Record<number, MigrationFn> = {
+      0: (doc) => ({ ...doc, version: 1 }),
+    };
+    expect(migrateDocument({}, 1, treatsMissingAsV0)).toEqual({ version: 1 });
+    const buggy: Record<number, MigrationFn> = { 0: (doc) => ({ ...doc }) }; // never bumps version
+    expect(migrateDocument({ version: 0 }, 3, buggy)).toBeDefined();
+  });
+});
+
+describe("migrateStrategyDocument / migrateExecutionHistoryDocument", () => {
+  it("are no-ops today (v1 is the first shipped version)", () => {
+    expect(migrateStrategyDocument({ version: 1, strategies: [] }, 1)).toEqual({
+      version: 1,
+      strategies: [],
+    });
+    expect(
+      migrateExecutionHistoryDocument({ version: 1, executions: [] }, 1)
+    ).toEqual({ version: 1, executions: [] });
+  });
+});
+
+// ─── Strategy storage ────────────────────────────────────────────────────────
+
+const WALLET_A = "GALICE";
+const WALLET_B = "GBOB";
+
+function strategy(id: string, overrides: Partial<Strategy> = {}): Strategy {
+  return {
+    id,
+    version: 1,
+    name: `Strategy ${id}`,
+    isTemplate: false,
+    steps: [],
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("strategyStorage", () => {
+  it("returns an empty current-version document when nothing is stored, and round-trips a saved strategy", () => {
+    expect(loadStrategyDocument(WALLET_A)).toEqual({
+      version: CURRENT_STRATEGY_STORAGE_VERSION,
+      strategies: [],
+    });
+    upsertStrategy(WALLET_A, strategy("s1"));
+    expect(listStrategies(WALLET_A)).toEqual([strategy("s1")]);
+  });
+
+  it("updates in place rather than duplicating, removes by id, and isolates storage per wallet", () => {
+    upsertStrategy(WALLET_A, strategy("s1", { name: "Original" }));
+    upsertStrategy(WALLET_A, strategy("s1", { name: "Renamed" }));
+    expect(listStrategies(WALLET_A)).toHaveLength(1);
+    expect(listStrategies(WALLET_A)[0].name).toBe("Renamed");
+
+    upsertStrategy(WALLET_A, strategy("s2"));
+    removeStrategy(WALLET_A, "s1");
+    expect(listStrategies(WALLET_A).map((s) => s.id)).toEqual(["s2"]);
+    expect(listStrategies(WALLET_B)).toEqual([]);
+  });
+
+  it("preserves an unrecognized step type verbatim on save/reload (forward compatibility)", () => {
+    const withUnknownStep = strategy("s1", {
+      steps: [
+        {
+          id: "future",
+          type: "teleport" as never,
+          protocol: "futureProtocol",
+          label: "Future step",
+          params: {},
+          dependsOn: [],
+        },
+      ],
+    });
+    upsertStrategy(WALLET_A, withUnknownStep);
+    expect(listStrategies(WALLET_A)[0].steps[0]).toMatchObject({
+      type: "teleport",
+      protocol: "futureProtocol",
+    });
+  });
+
+  it("resets to empty rather than throwing on corrupt JSON or a schema-invalid shape with no migration path", () => {
+    window.localStorage.setItem(
+      `neko_defi_strategies_${WALLET_A}`,
+      "{not json"
+    );
+    expect(() => loadStrategyDocument(WALLET_A)).not.toThrow();
+    expect(listStrategies(WALLET_A)).toEqual([]);
+
+    window.localStorage.setItem(
+      `neko_defi_strategies_${WALLET_A}`,
+      JSON.stringify({ version: 1, strategies: [{ totally: "wrong shape" }] })
+    );
+    expect(listStrategies(WALLET_A)).toEqual([]);
+  });
+});
+
+// ─── Execution history storage ───────────────────────────────────────────────
+
+function execution(
+  id: string,
+  overrides: Partial<ExecutionRecord> = {}
+): ExecutionRecord {
+  return {
+    id,
+    strategyId: "s1",
+    strategySnapshot: {},
+    status: "in_progress",
+    startedAt: 0,
+    updatedAt: 0,
+    projectedOutcome: {},
+    steps: [],
+    ...overrides,
+  };
+}
+
+describe("executionHistoryStorage", () => {
+  it("returns an empty current-version document, round-trips, and upserts by id", () => {
+    expect(loadExecutionHistoryDocument(WALLET_A)).toEqual({
+      version: CURRENT_EXECUTION_STORAGE_VERSION,
+      executions: [],
+    });
+    upsertExecution(WALLET_A, execution("e1"));
+    expect(listExecutions(WALLET_A)).toEqual([execution("e1")]);
+    upsertExecution(WALLET_A, execution("e1", { status: "completed" }));
+    expect(listExecutions(WALLET_A)).toHaveLength(1);
+    expect(listExecutions(WALLET_A)[0].status).toBe("completed");
+  });
+
+  it("never deletes history — an abandoned execution stays recorded", () => {
+    upsertExecution(WALLET_A, execution("e1", { status: "in_progress" }));
+    upsertExecution(WALLET_A, execution("e1", { status: "abandoned" }));
+    expect(listExecutions(WALLET_A)).toHaveLength(1);
+    expect(listExecutions(WALLET_A)[0].status).toBe("abandoned");
+  });
+
+  it("findUnfinishedExecutions returns only in_progress / paused-deviation records", () => {
+    upsertExecution(WALLET_A, execution("done", { status: "completed" }));
+    upsertExecution(WALLET_A, execution("running", { status: "in_progress" }));
+    upsertExecution(
+      WALLET_A,
+      execution("paused", { status: "paused-deviation" })
+    );
+    upsertExecution(WALLET_A, execution("gone", { status: "abandoned" }));
+    expect(
+      findUnfinishedExecutions(WALLET_A)
+        .map((e) => e.id)
+        .sort()
+    ).toEqual(["paused", "running"]);
+  });
+
+  it("preserves per-step tx hashes and actualOutputs for reconciliation on reload", () => {
+    upsertExecution(
+      WALLET_A,
+      execution("e1", {
+        steps: [
+          {
+            stepId: "a",
+            status: "completed",
+            txHash: "abc123",
+            actualOutputs: { "out.amount": "42" },
+          },
+        ],
+      })
+    );
+    expect(listExecutions(WALLET_A)[0].steps[0]).toMatchObject({
+      txHash: "abc123",
+      actualOutputs: { "out.amount": "42" },
+    });
+  });
+});

--- a/apps/web-app/src/lib/strategy/__tests__/registry.test.ts
+++ b/apps/web-app/src/lib/strategy/__tests__/registry.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { StrategyStepRegistry } from "../registry";
+import { UnknownStepDefinitionError } from "../types";
+import type { StrategyStepDefinition } from "../types";
+
+function fakeDefinition(
+  stepType: string,
+  protocol: string
+): StrategyStepDefinition {
+  return {
+    stepType: stepType as StrategyStepDefinition["stepType"],
+    protocol,
+    submissionMode: "rpc",
+    paramsSchema: z.object({}),
+    describeOutputs: () => [],
+    validate: () => [],
+    simulate: async () => ({ outputs: {}, estimatedFee: "0", warnings: [] }),
+    prepare: async () => ({ xdr: "", networkPassphrase: "" }),
+  };
+}
+
+describe("StrategyStepRegistry", () => {
+  it("registers and resolves a definition by (stepType, protocol)", () => {
+    const registry = new StrategyStepRegistry();
+    const def = fakeDefinition("swap", "soroswap");
+    registry.register(def);
+    expect(registry.resolve("swap", "soroswap")).toBe(def);
+  });
+
+  it("keeps distinct definitions for the same stepType across different protocols", () => {
+    const registry = new StrategyStepRegistry();
+    const nekoSupply = fakeDefinition("supply", "neko");
+    const blendSupply = fakeDefinition("supply", "blend");
+    registry.register(nekoSupply);
+    registry.register(blendSupply);
+    expect(registry.resolve("supply", "neko")).toBe(nekoSupply);
+    expect(registry.resolve("supply", "blend")).toBe(blendSupply);
+  });
+
+  it("throws UnknownStepDefinitionError for an unregistered key", () => {
+    const registry = new StrategyStepRegistry();
+    expect(() => registry.resolve("swap", "unknown-protocol")).toThrow(
+      UnknownStepDefinitionError
+    );
+  });
+
+  it("tryResolve returns null instead of throwing for an unregistered key", () => {
+    const registry = new StrategyStepRegistry();
+    expect(registry.tryResolve("swap", "unknown-protocol")).toBeNull();
+  });
+
+  it("has() reflects registration state", () => {
+    const registry = new StrategyStepRegistry();
+    expect(registry.has("swap", "soroswap")).toBe(false);
+    registry.register(fakeDefinition("swap", "soroswap"));
+    expect(registry.has("swap", "soroswap")).toBe(true);
+  });
+
+  it("listRegistered returns every registered definition", () => {
+    const registry = new StrategyStepRegistry();
+    registry.register(fakeDefinition("swap", "soroswap"));
+    registry.register(fakeDefinition("supply", "neko"));
+    expect(registry.listRegistered()).toHaveLength(2);
+  });
+
+  it("overwrites a definition registered twice under the same key", () => {
+    const registry = new StrategyStepRegistry();
+    const first = fakeDefinition("swap", "soroswap");
+    const second = fakeDefinition("swap", "soroswap");
+    registry.register(first);
+    registry.register(second);
+    expect(registry.resolve("swap", "soroswap")).toBe(second);
+    expect(registry.listRegistered()).toHaveLength(1);
+  });
+
+  it("resolveOrUnknown returns the real definition when registered", () => {
+    const registry = new StrategyStepRegistry();
+    const def = fakeDefinition("swap", "soroswap");
+    registry.register(def);
+    expect(registry.resolveOrUnknown("swap", "soroswap")).toBe(def);
+  });
+
+  it("resolveOrUnknown falls back to a graceful unknown-step definition instead of throwing", () => {
+    const registry = new StrategyStepRegistry();
+    const fallback = registry.resolveOrUnknown("teleport", "futureProtocol");
+    expect(fallback.stepType).toBe("teleport");
+    expect(fallback.protocol).toBe("futureProtocol");
+    expect(
+      fallback.validate({
+        userAddress: "G",
+        networkPassphrase: "p",
+        resolvedParams: {},
+        upstreamOutputs: {},
+      })
+    ).toEqual([expect.objectContaining({ code: "UNKNOWN_STEP_TYPE" })]);
+  });
+
+  it("the unknown-step fallback's simulate/prepare reject rather than fabricating a result", async () => {
+    const registry = new StrategyStepRegistry();
+    const fallback = registry.resolveOrUnknown("teleport", "futureProtocol");
+    const ctx = {
+      userAddress: "G",
+      networkPassphrase: "p",
+      resolvedParams: {},
+      upstreamOutputs: {},
+    };
+    await expect(fallback.simulate(ctx)).rejects.toThrow(
+      /Unrecognized step type/
+    );
+    await expect(fallback.prepare(ctx)).rejects.toThrow(
+      /Unrecognized step type/
+    );
+    expect(fallback.describeOutputs({})).toEqual([]);
+  });
+});

--- a/apps/web-app/src/lib/strategy/__tests__/templates.test.ts
+++ b/apps/web-app/src/lib/strategy/__tests__/templates.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import "../definitions"; // registers the real built-in step definitions
+import { STRATEGY_TEMPLATES, findTemplate } from "../templates";
+import { validateStrategy, topologicalSort } from "../engine";
+
+/**
+ * Templates ship with placeholder literal params (e.g. empty pool/asset
+ * addresses the user fills in via the composer before executing), so they
+ * intentionally are NOT expected to be issue-free — only structurally
+ * sound: acyclic, every dependency declared and resolvable, every step
+ * type actually registered. Parameter-completeness is the composer's/
+ * simulate-time's concern, not template authoring's.
+ */
+const STRUCTURAL_CODES = new Set([
+  "INVALID_DEPENDENCY",
+  "UNDECLARED_DEPENDENCY",
+  "CIRCULAR_DEPENDENCY",
+  "UNSUPPORTED_STEP",
+  "INCOMPATIBLE_ASSET",
+]);
+
+describe("STRATEGY_TEMPLATES — structural validity", () => {
+  it("ships exactly 4 templates, matching the spec's named list", () => {
+    expect(STRATEGY_TEMPLATES.map((t) => t.name)).toEqual([
+      "Swap → Vault Deposit",
+      "Leveraged Supply",
+      "Position Unwind",
+      "Single Asset Liquidity Position",
+    ]);
+  });
+
+  it.each(STRATEGY_TEMPLATES.map((t) => [t.name, t] as const))(
+    "%s has an acyclic, fully-ordered step graph",
+    (_name, template) => {
+      const { order, issues } = topologicalSort(template.steps);
+      expect(issues).toEqual([]);
+      expect(order).toHaveLength(template.steps.length);
+    }
+  );
+
+  it.each(STRATEGY_TEMPLATES.map((t) => [t.name, t] as const))(
+    "%s has no structural, dependency, or unsupported-step-type issues",
+    (_name, template) => {
+      const result = validateStrategy(template);
+      const structuralIssues = result.issues.filter((i) =>
+        STRUCTURAL_CODES.has(i.code)
+      );
+      expect(structuralIssues).toEqual([]);
+    }
+  );
+
+  it("every template is marked isTemplate:true and cloneAsEditable produces isTemplate:false", async () => {
+    const { cloneAsEditable } =
+      await import("../../../features/strategies/hooks");
+    for (const template of STRATEGY_TEMPLATES) {
+      expect(template.isTemplate).toBe(true);
+      expect(cloneAsEditable(template).isTemplate).toBe(false);
+    }
+  });
+
+  it("findTemplate resolves a known id and returns undefined for an unknown one", () => {
+    expect(findTemplate(STRATEGY_TEMPLATES[0].id)?.name).toBe(
+      STRATEGY_TEMPLATES[0].name
+    );
+    expect(findTemplate("does-not-exist")).toBeUndefined();
+  });
+});

--- a/apps/web-app/src/lib/strategy/definitions.ts
+++ b/apps/web-app/src/lib/strategy/definitions.ts
@@ -1,0 +1,922 @@
+import { z } from "zod";
+import {
+  getAvailableTokens,
+  getQuote,
+  buildTransaction,
+} from "@/lib/helpers/stellar/soroswap";
+import { fromSmallestUnit, toSmallestUnit } from "@/lib/helpers/tokenUtils";
+import { NekoLendingAdapter } from "@/lib/orchestrator/adapters/NekoLendingAdapter";
+import { BlendPoolAdapter } from "@/lib/orchestrator/adapters/BlendPoolAdapter";
+import { SoroswapPoolAdapter } from "@/lib/orchestrator/adapters/SoroswapPoolAdapter";
+import { Client as DefindexVaultClient } from "@neko/defindex-vault";
+import { rpcUrl, networkPassphrase } from "@/lib/constants/network";
+import { strategyStepRegistry } from "./registry";
+import type {
+  StepProjection,
+  StrategyStepDefinition,
+  TxResult,
+  ValidationIssue,
+} from "./types";
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+/** Base Stellar tx fee in stroops, matching the `fee: "100"` used throughout the adapters. */
+const BASE_FEE_STROOPS = "100";
+
+function baseFeeEstimate(): string {
+  return fromSmallestUnit(BASE_FEE_STROOPS, 7);
+}
+
+function knownAssetCode(assetCode: string): boolean {
+  return Boolean(getAvailableTokens()[assetCode]?.contract);
+}
+
+/** Mirrors features/vault/hooks/useVaultAction.ts — single deployed DeFindex vault. */
+const DEFINDEX_VAULT_CONTRACT_ID =
+  "CBHGX6TCHHVYJ7P3UZS7WI5TRAAA7GQA2L2Y7P2LCPIXWWD5FKDF2Z5S";
+const DEFINDEX_DEPOSIT_SLIPPAGE = 0.01;
+const DEFINDEX_SLIPPAGE_SCALE = 10_000_000n;
+
+type ParseResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; issues: ValidationIssue[] };
+
+/**
+ * validate() must never throw — a malformed/unresolved param is itself a
+ * validation issue, not a crash. Every definition's validate() starts with
+ * this instead of calling paramsSchema.parse() directly.
+ */
+function safeParseParams<T>(
+  schema: z.ZodType<T>,
+  input: unknown
+): ParseResult<T> {
+  const result = schema.safeParse(input);
+  if (result.success) return { ok: true, data: result.data };
+  return {
+    ok: false,
+    issues: result.error.issues.map((issue) => ({
+      stepId: null,
+      severity: "error" as const,
+      code: "INVALID_PARAMS",
+      message: `${issue.path.join(".") || "params"}: ${issue.message}`,
+    })),
+  };
+}
+
+// ─── Swap (SoroSwap) ─────────────────────────────────────────────────────────
+
+const swapParamsSchema = z.object({
+  tokenIn: z.string().min(1),
+  tokenOut: z.string().min(1),
+  amountIn: z.string().min(1),
+});
+type SwapParams = z.infer<typeof swapParamsSchema>;
+
+const swapSoroswapDefinition: StrategyStepDefinition<SwapParams> = {
+  stepType: "swap",
+  protocol: "soroswap",
+  submissionMode: "soroswapApi",
+  paramsSchema: swapParamsSchema,
+
+  describeOutputs(params) {
+    return [
+      { id: "out.receivedAsset", assetCode: params.tokenOut, kind: "asset" },
+    ];
+  },
+
+  validate(ctx) {
+    const parsed = safeParseParams(swapParamsSchema, ctx.resolvedParams);
+    if (!parsed.ok) return parsed.issues;
+    const { tokenIn, tokenOut } = parsed.data;
+    const issues: ValidationIssue[] = [];
+    if (tokenIn === tokenOut) {
+      issues.push({
+        stepId: null,
+        severity: "error",
+        code: "INCOMPATIBLE_ASSET",
+        message: "Swap tokenIn and tokenOut must be different assets.",
+      });
+    }
+    if (!knownAssetCode(tokenIn)) {
+      issues.push({
+        stepId: null,
+        severity: "error",
+        code: "UNKNOWN_ASSET",
+        message: `Unknown asset code: ${tokenIn}`,
+      });
+    }
+    if (!knownAssetCode(tokenOut)) {
+      issues.push({
+        stepId: null,
+        severity: "error",
+        code: "UNKNOWN_ASSET",
+        message: `Unknown asset code: ${tokenOut}`,
+      });
+    }
+    return issues;
+  },
+
+  async simulate(ctx) {
+    const { tokenIn, tokenOut, amountIn } = swapParamsSchema.parse(
+      ctx.resolvedParams
+    );
+    const quote = await getQuote({
+      assetIn: tokenIn,
+      assetOut: tokenOut,
+      amount: amountIn,
+      tradeType: "EXACT_IN",
+    });
+    if (!quote)
+      throw new Error(
+        `No liquidity found for ${tokenIn} -> ${tokenOut} — try a different pair`
+      );
+    const priceImpactBps = Math.round(
+      parseFloat(quote.priceImpact ?? "0") * 100
+    );
+    return {
+      outputs: { "out.receivedAsset": quote.amountOut },
+      resultingBalances: { [tokenOut]: quote.amountOut },
+      estimatedFee: baseFeeEstimate(),
+      slippageBps: Number.isFinite(priceImpactBps) ? priceImpactBps : 0,
+      warnings: [],
+    };
+  },
+
+  async prepare(ctx) {
+    const { tokenIn, tokenOut, amountIn } = swapParamsSchema.parse(
+      ctx.resolvedParams
+    );
+    const quote = await getQuote({
+      assetIn: tokenIn,
+      assetOut: tokenOut,
+      amount: amountIn,
+      tradeType: "EXACT_IN",
+    });
+    if (!quote)
+      throw new Error(
+        `No liquidity found for ${tokenIn} -> ${tokenOut} — try a different pair`
+      );
+    const built = await buildTransaction({
+      quote,
+      from: ctx.userAddress,
+      to: ctx.userAddress,
+    });
+    return { xdr: built.xdr, networkPassphrase: ctx.networkPassphrase };
+  },
+};
+
+// ─── Supply / Borrow / Repay — Neko ──────────────────────────────────────────
+
+/**
+ * "Supply" on Neko covers two on-chain actions selected via `mode`:
+ *  - "supply": plain pool lending (deposit/withdraw), earns yield, does not
+ *    affect borrowing health factor.
+ *  - "collateral": add_collateral/remove_collateral against a debt pool,
+ *    backs a Borrow step and does affect health factor.
+ * `direction` makes both bidirectional, which is how the Position Unwind
+ * template composes a withdraw using the same step type as a deposit.
+ */
+const supplyParamsSchema = z.object({
+  mode: z.enum(["supply", "collateral"]).default("supply"),
+  direction: z.enum(["deposit", "withdraw"]).default("deposit"),
+  assetCode: z.string().optional(),
+  poolContractId: z.string().optional(),
+  collateralTokenAddress: z.string().optional(),
+  decimals: z.number().default(7),
+  amount: z.string().min(1),
+});
+type SupplyNekoParams = z.infer<typeof supplyParamsSchema>;
+
+function supplyNekoPoolId(params: SupplyNekoParams): string {
+  if (params.mode === "collateral") {
+    if (!params.poolContractId || !params.collateralTokenAddress) {
+      throw new Error(
+        "supply(collateral) requires poolContractId and collateralTokenAddress"
+      );
+    }
+    return `${params.poolContractId}:${params.collateralTokenAddress}`;
+  }
+  if (!params.assetCode) throw new Error("supply(supply) requires assetCode");
+  return params.assetCode;
+}
+
+const supplyNekoDefinition: StrategyStepDefinition<SupplyNekoParams> = {
+  stepType: "supply",
+  protocol: "neko",
+  submissionMode: "rpc",
+  paramsSchema: supplyParamsSchema,
+
+  describeOutputs(params) {
+    return [
+      {
+        id: "out.resultingAmount",
+        assetCode: params.assetCode ?? params.collateralTokenAddress ?? null,
+        kind: params.mode === "collateral" ? "collateralPosition" : "asset",
+      },
+    ];
+  },
+
+  validate(ctx) {
+    const parsed = safeParseParams(supplyParamsSchema, ctx.resolvedParams);
+    if (!parsed.ok) return parsed.issues;
+    const params = parsed.data;
+    const issues: ValidationIssue[] = [];
+    if (params.mode === "supply") {
+      if (!params.assetCode) {
+        issues.push({
+          stepId: null,
+          severity: "error",
+          code: "MISSING_PARAM",
+          message: "assetCode is required for supply(mode=supply).",
+        });
+      } else if (!knownAssetCode(params.assetCode)) {
+        issues.push({
+          stepId: null,
+          severity: "error",
+          code: "UNKNOWN_ASSET",
+          message: `Unknown asset code: ${params.assetCode}`,
+        });
+      }
+    } else if (!params.poolContractId || !params.collateralTokenAddress) {
+      issues.push({
+        stepId: null,
+        severity: "error",
+        code: "MISSING_PARAM",
+        message:
+          "poolContractId and collateralTokenAddress are required for supply(mode=collateral).",
+      });
+    }
+    return issues;
+  },
+
+  async simulate(ctx) {
+    const params = supplyParamsSchema.parse(ctx.resolvedParams);
+    const signedAmount =
+      params.direction === "deposit"
+        ? Number(params.amount)
+        : -Number(params.amount);
+    return {
+      outputs: { "out.resultingAmount": params.amount },
+      estimatedFee: baseFeeEstimate(),
+      warnings: [],
+      resultingPosition:
+        params.mode === "collateral"
+          ? {
+              protocol: "neko",
+              collateralAssetCode: params.collateralTokenAddress,
+              collateralDelta: signedAmount,
+            }
+          : { protocol: "neko" },
+    };
+  },
+
+  async prepare(ctx) {
+    const params = supplyParamsSchema.parse(ctx.resolvedParams);
+    const adapter = new NekoLendingAdapter();
+    const poolId = supplyNekoPoolId(params);
+    const amountBigInt = toSmallestUnit(params.amount, params.decimals);
+    const method =
+      params.mode === "collateral"
+        ? params.direction === "deposit"
+          ? adapter.supplyCollateral?.bind(adapter)
+          : adapter.withdrawCollateral?.bind(adapter)
+        : params.direction === "deposit"
+          ? adapter.deposit.bind(adapter)
+          : adapter.withdraw.bind(adapter);
+    if (!method)
+      throw new Error(`NekoLendingAdapter has no method for ${params.mode}`);
+    return method(poolId, ctx.userAddress, amountBigInt);
+  },
+};
+
+const assetAmountParamsSchema = z.object({
+  assetCode: z.string().min(1),
+  decimals: z.number().default(7),
+  amount: z.string().min(1),
+});
+type AssetAmountParams = z.infer<typeof assetAmountParamsSchema>;
+
+const borrowNekoDefinition: StrategyStepDefinition<AssetAmountParams> = {
+  stepType: "borrow",
+  protocol: "neko",
+  submissionMode: "rpc",
+  paramsSchema: assetAmountParamsSchema,
+
+  describeOutputs(params) {
+    return [
+      { id: "out.borrowedAsset", assetCode: params.assetCode, kind: "asset" },
+    ];
+  },
+
+  validate(ctx) {
+    const parsed = safeParseParams(assetAmountParamsSchema, ctx.resolvedParams);
+    if (!parsed.ok) return parsed.issues;
+    const { assetCode } = parsed.data;
+    return knownAssetCode(assetCode)
+      ? []
+      : [
+          {
+            stepId: null,
+            severity: "error",
+            code: "UNKNOWN_ASSET",
+            message: `Unknown asset code: ${assetCode}`,
+          },
+        ];
+  },
+
+  async simulate(ctx) {
+    const params = assetAmountParamsSchema.parse(ctx.resolvedParams);
+    return {
+      outputs: { "out.borrowedAsset": params.amount },
+      estimatedFee: baseFeeEstimate(),
+      warnings: [],
+      resultingPosition: {
+        protocol: "neko",
+        debtAssetCode: params.assetCode,
+        debtDelta: Number(params.amount),
+      },
+    };
+  },
+
+  async prepare(ctx) {
+    const params = assetAmountParamsSchema.parse(ctx.resolvedParams);
+    const adapter = new NekoLendingAdapter();
+    return adapter.borrow(
+      params.assetCode,
+      ctx.userAddress,
+      toSmallestUnit(params.amount, params.decimals)
+    );
+  },
+};
+
+const repayNekoDefinition: StrategyStepDefinition<AssetAmountParams> = {
+  stepType: "repay",
+  protocol: "neko",
+  submissionMode: "rpc",
+  paramsSchema: assetAmountParamsSchema,
+
+  describeOutputs(params) {
+    return [
+      {
+        id: "out.remainingDebt",
+        assetCode: params.assetCode,
+        kind: "debtPosition",
+      },
+    ];
+  },
+
+  validate(ctx) {
+    const parsed = safeParseParams(assetAmountParamsSchema, ctx.resolvedParams);
+    if (!parsed.ok) return parsed.issues;
+    const { assetCode } = parsed.data;
+    return knownAssetCode(assetCode)
+      ? []
+      : [
+          {
+            stepId: null,
+            severity: "error",
+            code: "UNKNOWN_ASSET",
+            message: `Unknown asset code: ${assetCode}`,
+          },
+        ];
+  },
+
+  async simulate(ctx) {
+    const params = assetAmountParamsSchema.parse(ctx.resolvedParams);
+    return {
+      outputs: { "out.remainingDebt": params.amount },
+      estimatedFee: baseFeeEstimate(),
+      warnings: [],
+      resultingPosition: {
+        protocol: "neko",
+        debtAssetCode: params.assetCode,
+        debtDelta: -Number(params.amount),
+      },
+    };
+  },
+
+  /** amount is underlying-asset units (matching Blend's repay contract); NekoLendingAdapter.repay converts to dTokens internally. */
+  async prepare(ctx) {
+    const params = assetAmountParamsSchema.parse(ctx.resolvedParams);
+    const adapter = new NekoLendingAdapter();
+    return adapter.repay(
+      params.assetCode,
+      ctx.userAddress,
+      toSmallestUnit(params.amount, params.decimals)
+    );
+  },
+};
+
+// ─── Supply / Borrow / Repay — Blend ─────────────────────────────────────────
+
+const blendSupplyParamsSchema = z.object({
+  mode: z.enum(["supply", "collateral"]).default("supply"),
+  direction: z.enum(["deposit", "withdraw"]).default("deposit"),
+  poolContractId: z.string().min(1),
+  assetAddress: z.string().min(1),
+  decimals: z.number().default(7),
+  amount: z.string().min(1),
+});
+type SupplyBlendParams = z.infer<typeof blendSupplyParamsSchema>;
+
+const supplyBlendDefinition: StrategyStepDefinition<SupplyBlendParams> = {
+  stepType: "supply",
+  protocol: "blend",
+  submissionMode: "rpc",
+  paramsSchema: blendSupplyParamsSchema,
+
+  describeOutputs(params) {
+    return [
+      {
+        id: "out.resultingAmount",
+        assetCode: params.assetAddress,
+        kind: params.mode === "collateral" ? "collateralPosition" : "asset",
+      },
+    ];
+  },
+
+  validate(ctx) {
+    const parsed = safeParseParams(blendSupplyParamsSchema, ctx.resolvedParams);
+    if (!parsed.ok) return parsed.issues;
+    const params = parsed.data;
+    return params.poolContractId && params.assetAddress
+      ? []
+      : [
+          {
+            stepId: null,
+            severity: "error",
+            code: "MISSING_PARAM",
+            message: "poolContractId and assetAddress are required.",
+          },
+        ];
+  },
+
+  async simulate(ctx) {
+    const params = blendSupplyParamsSchema.parse(ctx.resolvedParams);
+    const signedAmount =
+      params.direction === "deposit"
+        ? Number(params.amount)
+        : -Number(params.amount);
+    return {
+      outputs: { "out.resultingAmount": params.amount },
+      estimatedFee: baseFeeEstimate(),
+      warnings: [],
+      resultingPosition:
+        params.mode === "collateral"
+          ? {
+              protocol: "blend",
+              collateralAssetCode: params.assetAddress,
+              collateralDelta: signedAmount,
+            }
+          : { protocol: "blend" },
+    };
+  },
+
+  async prepare(ctx) {
+    const params = blendSupplyParamsSchema.parse(ctx.resolvedParams);
+    const adapter = new BlendPoolAdapter(params.poolContractId);
+    const amountBigInt = toSmallestUnit(params.amount, params.decimals);
+    const rawId = `${params.poolContractId}:${params.assetAddress}`;
+    const method =
+      params.mode === "collateral"
+        ? params.direction === "deposit"
+          ? adapter.supplyCollateral?.bind(adapter)
+          : adapter.withdrawCollateral?.bind(adapter)
+        : params.direction === "deposit"
+          ? adapter.deposit.bind(adapter)
+          : adapter.withdraw.bind(adapter);
+    if (!method)
+      throw new Error(`BlendPoolAdapter has no method for ${params.mode}`);
+    return method(rawId, ctx.userAddress, amountBigInt);
+  },
+};
+
+const blendPoolAssetParamsSchema = z.object({
+  poolContractId: z.string().min(1),
+  assetAddress: z.string().min(1),
+  decimals: z.number().default(7),
+  amount: z.string().min(1),
+});
+type BlendPoolAssetParams = z.infer<typeof blendPoolAssetParamsSchema>;
+
+const borrowBlendDefinition: StrategyStepDefinition<BlendPoolAssetParams> = {
+  stepType: "borrow",
+  protocol: "blend",
+  submissionMode: "rpc",
+  paramsSchema: blendPoolAssetParamsSchema,
+
+  describeOutputs(params) {
+    return [
+      {
+        id: "out.borrowedAsset",
+        assetCode: params.assetAddress,
+        kind: "asset",
+      },
+    ];
+  },
+
+  validate(ctx) {
+    const parsed = safeParseParams(
+      blendPoolAssetParamsSchema,
+      ctx.resolvedParams
+    );
+    if (!parsed.ok) return parsed.issues;
+    const params = parsed.data;
+    return params.poolContractId && params.assetAddress
+      ? []
+      : [
+          {
+            stepId: null,
+            severity: "error",
+            code: "MISSING_PARAM",
+            message: "poolContractId and assetAddress are required.",
+          },
+        ];
+  },
+
+  async simulate(ctx) {
+    const params = blendPoolAssetParamsSchema.parse(ctx.resolvedParams);
+    return {
+      outputs: { "out.borrowedAsset": params.amount },
+      estimatedFee: baseFeeEstimate(),
+      warnings: [],
+      resultingPosition: {
+        protocol: "blend",
+        debtAssetCode: params.assetAddress,
+        debtDelta: Number(params.amount),
+      },
+    };
+  },
+
+  async prepare(ctx) {
+    const params = blendPoolAssetParamsSchema.parse(ctx.resolvedParams);
+    const adapter = new BlendPoolAdapter(params.poolContractId);
+    const rawId = `${params.poolContractId}:${params.assetAddress}`;
+    if (!adapter.borrow) throw new Error("BlendPoolAdapter.borrow unavailable");
+    return adapter.borrow(
+      rawId,
+      ctx.userAddress,
+      toSmallestUnit(params.amount, params.decimals)
+    );
+  },
+};
+
+const repayBlendDefinition: StrategyStepDefinition<BlendPoolAssetParams> = {
+  stepType: "repay",
+  protocol: "blend",
+  submissionMode: "rpc",
+  paramsSchema: blendPoolAssetParamsSchema,
+
+  describeOutputs(params) {
+    return [
+      {
+        id: "out.remainingDebt",
+        assetCode: params.assetAddress,
+        kind: "debtPosition",
+      },
+    ];
+  },
+
+  validate(ctx) {
+    const parsed = safeParseParams(
+      blendPoolAssetParamsSchema,
+      ctx.resolvedParams
+    );
+    if (!parsed.ok) return parsed.issues;
+    const params = parsed.data;
+    return params.poolContractId && params.assetAddress
+      ? []
+      : [
+          {
+            stepId: null,
+            severity: "error",
+            code: "MISSING_PARAM",
+            message: "poolContractId and assetAddress are required.",
+          },
+        ];
+  },
+
+  async simulate(ctx) {
+    const params = blendPoolAssetParamsSchema.parse(ctx.resolvedParams);
+    return {
+      outputs: { "out.remainingDebt": params.amount },
+      estimatedFee: baseFeeEstimate(),
+      warnings: [],
+      resultingPosition: {
+        protocol: "blend",
+        debtAssetCode: params.assetAddress,
+        debtDelta: -Number(params.amount),
+      },
+    };
+  },
+
+  async prepare(ctx) {
+    const params = blendPoolAssetParamsSchema.parse(ctx.resolvedParams);
+    const adapter = new BlendPoolAdapter(params.poolContractId);
+    const rawId = `${params.poolContractId}:${params.assetAddress}`;
+    if (!adapter.repay) throw new Error("BlendPoolAdapter.repay unavailable");
+    return adapter.repay(
+      rawId,
+      ctx.userAddress,
+      toSmallestUnit(params.amount, params.decimals)
+    );
+  },
+};
+
+// ─── Vault Deposit / Withdraw — DeFindex ─────────────────────────────────────
+
+const vaultDepositParamsSchema = z.object({
+  vaultContractId: z.string().default(DEFINDEX_VAULT_CONTRACT_ID),
+  amount: z.string().min(1),
+});
+type VaultDepositParams = z.infer<typeof vaultDepositParamsSchema>;
+
+const vaultDepositDefindexDefinition: StrategyStepDefinition<VaultDepositParams> =
+  {
+    stepType: "vaultDeposit",
+    protocol: "defindex",
+    submissionMode: "rpc",
+    paramsSchema: vaultDepositParamsSchema,
+
+    describeOutputs() {
+      return [{ id: "out.dfTokens", assetCode: null, kind: "shares" }];
+    },
+
+    validate(ctx) {
+      const parsed = safeParseParams(
+        vaultDepositParamsSchema,
+        ctx.resolvedParams
+      );
+      if (!parsed.ok) return parsed.issues;
+      return Number(parsed.data.amount) > 0
+        ? []
+        : [
+            {
+              stepId: null,
+              severity: "error",
+              code: "INVALID_AMOUNT",
+              message: "Vault deposit amount must be greater than zero.",
+            },
+          ];
+    },
+
+    async simulate(ctx) {
+      const params = vaultDepositParamsSchema.parse(ctx.resolvedParams);
+      return {
+        outputs: { "out.dfTokens": params.amount },
+        estimatedFee: baseFeeEstimate(),
+        warnings: [],
+        resultingPosition: { protocol: "defindex" },
+      };
+    },
+
+    async prepare(ctx) {
+      const params = vaultDepositParamsSchema.parse(ctx.resolvedParams);
+      const client = new DefindexVaultClient({
+        contractId: params.vaultContractId,
+        rpcUrl,
+        networkPassphrase,
+        publicKey: ctx.userAddress,
+      });
+      const amountBigInt = toSmallestUnit(params.amount, 7);
+      const slippageScaled = toSmallestUnit(
+        String(DEFINDEX_DEPOSIT_SLIPPAGE),
+        7
+      );
+      const minAmount =
+        amountBigInt -
+        (amountBigInt * slippageScaled) / DEFINDEX_SLIPPAGE_SCALE;
+      const depositTx = await client.deposit({
+        amounts_desired: [amountBigInt],
+        amounts_min: [minAmount],
+        from: ctx.userAddress,
+        invest: false,
+      });
+      return {
+        xdr: depositTx.toXDR(),
+        networkPassphrase: ctx.networkPassphrase,
+      };
+    },
+  };
+
+const vaultWithdrawParamsSchema = z.object({
+  vaultContractId: z.string().default(DEFINDEX_VAULT_CONTRACT_ID),
+  /** dfToken shares to redeem. */
+  shares: z.string().min(1),
+});
+type VaultWithdrawParams = z.infer<typeof vaultWithdrawParamsSchema>;
+
+const vaultWithdrawDefindexDefinition: StrategyStepDefinition<VaultWithdrawParams> =
+  {
+    stepType: "vaultWithdraw",
+    protocol: "defindex",
+    submissionMode: "rpc",
+    paramsSchema: vaultWithdrawParamsSchema,
+
+    describeOutputs() {
+      return [{ id: "out.withdrawnAsset", assetCode: null, kind: "asset" }];
+    },
+
+    validate(ctx) {
+      const parsed = safeParseParams(
+        vaultWithdrawParamsSchema,
+        ctx.resolvedParams
+      );
+      if (!parsed.ok) return parsed.issues;
+      return Number(parsed.data.shares) > 0
+        ? []
+        : [
+            {
+              stepId: null,
+              severity: "error",
+              code: "INVALID_AMOUNT",
+              message: "Vault withdraw shares must be greater than zero.",
+            },
+          ];
+    },
+
+    async simulate(ctx) {
+      const params = vaultWithdrawParamsSchema.parse(ctx.resolvedParams);
+      return {
+        outputs: { "out.withdrawnAsset": params.shares },
+        estimatedFee: baseFeeEstimate(),
+        warnings: [],
+        resultingPosition: { protocol: "defindex" },
+      };
+    },
+
+    async prepare(ctx) {
+      const params = vaultWithdrawParamsSchema.parse(ctx.resolvedParams);
+      const client = new DefindexVaultClient({
+        contractId: params.vaultContractId,
+        rpcUrl,
+        networkPassphrase,
+        publicKey: ctx.userAddress,
+      });
+      const withdrawTx = await client.withdraw({
+        withdraw_shares: toSmallestUnit(params.shares, 7),
+        min_amounts_out: [0n],
+        from: ctx.userAddress,
+      });
+      return {
+        xdr: withdrawTx.toXDR(),
+        networkPassphrase: ctx.networkPassphrase,
+      };
+    },
+  };
+
+// ─── LP Add / Remove — SoroSwap ──────────────────────────────────────────────
+
+const lpAddParamsSchema = z.object({
+  tokenA: z.string().min(1),
+  tokenB: z.string().min(1),
+  /** SoroswapPoolAdapter.deposit mirrors this amount to both sides of the pair. */
+  amount: z.string().min(1),
+  decimals: z.number().default(7),
+});
+type LpAddParams = z.infer<typeof lpAddParamsSchema>;
+
+function lpPoolId(params: LpAddParams | LpRemoveParams): string {
+  return `${params.tokenA}-${params.tokenB}`;
+}
+
+const lpAddSoroswapDefinition: StrategyStepDefinition<LpAddParams> = {
+  stepType: "lpAdd",
+  protocol: "soroswap",
+  submissionMode: "rpc",
+  paramsSchema: lpAddParamsSchema,
+
+  describeOutputs(params) {
+    return [
+      { id: "out.lpPosition", assetCode: lpPoolId(params), kind: "lpPosition" },
+    ];
+  },
+
+  validate(ctx) {
+    const parsed = safeParseParams(lpAddParamsSchema, ctx.resolvedParams);
+    if (!parsed.ok) return parsed.issues;
+    const params = parsed.data;
+    return params.tokenA === params.tokenB
+      ? [
+          {
+            stepId: null,
+            severity: "error",
+            code: "INCOMPATIBLE_ASSET",
+            message: "LP Add requires two different assets.",
+          },
+        ]
+      : [];
+  },
+
+  async simulate(ctx) {
+    const params = lpAddParamsSchema.parse(ctx.resolvedParams);
+    return {
+      outputs: { "out.lpPosition": params.amount },
+      estimatedFee: baseFeeEstimate(),
+      warnings: [],
+      resultingPosition: { protocol: "soroswap" },
+    };
+  },
+
+  async prepare(ctx) {
+    const params = lpAddParamsSchema.parse(ctx.resolvedParams);
+    const adapter = new SoroswapPoolAdapter();
+    return adapter.deposit(
+      lpPoolId(params),
+      ctx.userAddress,
+      toSmallestUnit(params.amount, params.decimals)
+    );
+  },
+};
+
+const lpRemoveParamsSchema = z.object({
+  tokenA: z.string().min(1),
+  tokenB: z.string().min(1),
+  amount: z.string().min(1),
+});
+type LpRemoveParams = z.infer<typeof lpRemoveParamsSchema>;
+
+const LP_REMOVE_UNSUPPORTED_MESSAGE =
+  "LP removal is not yet supported by the SoroSwap integration — SoroswapPoolAdapter.withdraw() has no removal API to call. This step will always fail validation until that capability ships.";
+
+/**
+ * Registered so strategies referencing lpRemove fail validation cleanly with
+ * a clear, step-scoped message instead of the registry throwing or a
+ * template silently omitting the step type. This is a real demonstration of
+ * "unsupported protocol combinations" validation, not a workaround — see
+ * SoroswapPoolAdapter.withdraw().
+ */
+const lpRemoveSoroswapDefinition: StrategyStepDefinition<LpRemoveParams> = {
+  stepType: "lpRemove",
+  protocol: "soroswap",
+  submissionMode: "rpc",
+  paramsSchema: lpRemoveParamsSchema,
+
+  describeOutputs(params) {
+    return [
+      { id: "out.withdrawnAssets", assetCode: lpPoolId(params), kind: "asset" },
+    ];
+  },
+
+  validate(): ValidationIssue[] {
+    return [
+      {
+        stepId: null,
+        severity: "error",
+        code: "UNSUPPORTED_PROTOCOL_COMBINATION",
+        message: LP_REMOVE_UNSUPPORTED_MESSAGE,
+      },
+    ];
+  },
+
+  async simulate(): Promise<StepProjection> {
+    throw new Error(LP_REMOVE_UNSUPPORTED_MESSAGE);
+  },
+
+  async prepare(): Promise<TxResult> {
+    throw new Error(LP_REMOVE_UNSUPPORTED_MESSAGE);
+  },
+};
+
+// ─── Registration ────────────────────────────────────────────────────────────
+
+/**
+ * Registers every built-in step definition into the shared registry
+ * singleton. Adding a protocol means adding a new definition above and one
+ * line here — nothing in validation/simulation/execution changes.
+ */
+export function registerBuiltInStepDefinitions(): void {
+  strategyStepRegistry.register(swapSoroswapDefinition);
+  strategyStepRegistry.register(supplyNekoDefinition);
+  strategyStepRegistry.register(supplyBlendDefinition);
+  strategyStepRegistry.register(borrowNekoDefinition);
+  strategyStepRegistry.register(borrowBlendDefinition);
+  strategyStepRegistry.register(repayNekoDefinition);
+  strategyStepRegistry.register(repayBlendDefinition);
+  strategyStepRegistry.register(vaultDepositDefindexDefinition);
+  strategyStepRegistry.register(vaultWithdrawDefindexDefinition);
+  strategyStepRegistry.register(lpAddSoroswapDefinition);
+  strategyStepRegistry.register(lpRemoveSoroswapDefinition);
+}
+
+registerBuiltInStepDefinitions();
+
+export {
+  baseFeeEstimate,
+  knownAssetCode,
+  safeParseParams,
+  DEFINDEX_VAULT_CONTRACT_ID,
+  DEFINDEX_DEPOSIT_SLIPPAGE,
+  DEFINDEX_SLIPPAGE_SCALE,
+  swapSoroswapDefinition,
+  supplyNekoDefinition,
+  supplyBlendDefinition,
+  borrowNekoDefinition,
+  borrowBlendDefinition,
+  repayNekoDefinition,
+  repayBlendDefinition,
+  vaultDepositDefindexDefinition,
+  vaultWithdrawDefindexDefinition,
+  lpAddSoroswapDefinition,
+  lpRemoveSoroswapDefinition,
+};

--- a/apps/web-app/src/lib/strategy/engine.ts
+++ b/apps/web-app/src/lib/strategy/engine.ts
@@ -1,0 +1,615 @@
+import { toSmallestUnit, fromSmallestUnit } from "@/lib/helpers/tokenUtils";
+import {
+  calculateProjectedHealthFactor,
+  calculateLiquidationPrice,
+  getRiskTier,
+} from "@/features/borrowing/utils/liquidationPrice";
+import { HF_WARNING } from "@/features/borrowing/const/riskThresholds";
+import { strategyStepRegistry, type StrategyStepRegistry } from "./registry";
+import type {
+  ParamBinding,
+  ResultingPosition,
+  RiskAssessment,
+  RiskThresholdConfig,
+  SensitivityScenario,
+  StepExecutionContext,
+  StepPort,
+  StepProjection,
+  Strategy,
+  StrategyStep,
+  StrategyStepDefinition,
+  StrategyProjection,
+  ValidationIssue,
+  ValidationResult,
+} from "./types";
+
+// ─── Cycle detection ─────────────────────────────────────────────────────────
+
+export interface TopologicalSortResult {
+  /** Execution order (topological). Null when the graph has a cycle. */
+  order: string[] | null;
+  issues: ValidationIssue[];
+}
+
+/**
+ * Kahn's algorithm over steps[].dependsOn. Dangling references (a dependsOn
+ * id that doesn't match any step) are silently skipped here — that's a
+ * structural issue validateStrategy reports separately, not a cycle.
+ */
+export function topologicalSort(steps: StrategyStep[]): TopologicalSortResult {
+  const ids = new Set(steps.map((s) => s.id));
+  const stepIndex = new Map(steps.map((s, i) => [s.id, i]));
+  const adjacency = new Map<string, string[]>();
+  const inDegree = new Map<string, number>();
+
+  for (const step of steps) {
+    inDegree.set(step.id, 0);
+    adjacency.set(step.id, []);
+  }
+  for (const step of steps) {
+    for (const depId of step.dependsOn) {
+      if (!ids.has(depId)) continue;
+      adjacency.get(depId)!.push(step.id);
+      inDegree.set(step.id, (inDegree.get(step.id) ?? 0) + 1);
+    }
+  }
+
+  const queue = [...inDegree.entries()]
+    .filter(([, deg]) => deg === 0)
+    .map(([id]) => id)
+    .sort((a, b) => stepIndex.get(a)! - stepIndex.get(b)!);
+
+  const remainingInDegree = new Map(inDegree);
+  const order: string[] = [];
+
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    order.push(id);
+    for (const next of adjacency.get(id) ?? []) {
+      const deg = (remainingInDegree.get(next) ?? 0) - 1;
+      remainingInDegree.set(next, deg);
+      if (deg === 0) queue.push(next);
+    }
+  }
+
+  if (order.length === steps.length) return { order, issues: [] };
+
+  const cyclicIds = steps.map((s) => s.id).filter((id) => !order.includes(id));
+  return {
+    order: null,
+    issues: [
+      {
+        stepId: cyclicIds[0] ?? null,
+        severity: "error",
+        code: "CIRCULAR_DEPENDENCY",
+        message: `Circular dependency detected among steps: ${cyclicIds.join(", ")}`,
+      },
+    ],
+  };
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+export interface ValidateStrategyContext {
+  userAddress?: string;
+  networkPassphrase?: string;
+  /** assetCode -> decimal string balance, from useWallet(). Omit to skip balance checks. */
+  balances?: Record<string, string>;
+  /** Defaults to the shared built-in registry singleton — injectable for tests. */
+  registry?: StrategyStepRegistry;
+}
+
+function literalString(binding: ParamBinding | undefined): string | null {
+  if (!binding || binding.source !== "literal") return null;
+  return typeof binding.value === "string" ? binding.value : null;
+}
+
+/**
+ * Cross-checks each root step's (no dependsOn — funded directly by the
+ * wallet, not an upstream step's output) literal amount against the
+ * connected wallet's balances. Common param names ("assetCode"/"tokenIn"
+ * and "amount"/"amountIn") are checked heuristically since the step model
+ * doesn't have one canonical "primary input" field name across all 8 step
+ * types; steps with bound (non-literal) inputs are skipped — their funding
+ * is validated at simulate-time as the upstream output resolves.
+ */
+export function validateBalances(
+  strategy: Strategy,
+  balances: Record<string, string>
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  for (const step of strategy.steps) {
+    if (step.dependsOn.length > 0) continue;
+    const assetCode =
+      literalString(step.params.assetCode) ??
+      literalString(step.params.tokenIn);
+    const amount =
+      literalString(step.params.amount) ?? literalString(step.params.amountIn);
+    if (!assetCode || !amount) continue;
+    const available = balances[assetCode];
+    if (available == null) continue;
+    if (toSmallestUnit(amount, 7) > toSmallestUnit(available, 7)) {
+      issues.push({
+        stepId: step.id,
+        severity: "error",
+        code: "INSUFFICIENT_BALANCE",
+        message: `Step "${step.label}" needs ${amount} ${assetCode} but the connected wallet only has ${available}.`,
+      });
+    }
+  }
+  return issues;
+}
+
+/**
+ * For structural validation we don't run the full simulate() pipeline (that
+ * requires live quotes/prices and is simulateStrategy's job), so
+ * stepOutput-bound params resolve to a placeholder "1" here — enough for a
+ * definition's own validate() to check literal fields (asset codes,
+ * required ids) without flagging a normally-valid bound amount as missing.
+ */
+function resolveParamsForStructuralValidation(
+  step: StrategyStep
+): Record<string, unknown> {
+  const resolved: Record<string, unknown> = {};
+  for (const [key, binding] of Object.entries(step.params)) {
+    resolved[key] = binding.source === "literal" ? binding.value : "1";
+  }
+  return resolved;
+}
+
+function safeValidate(
+  definition: StrategyStepDefinition,
+  ctx: StepExecutionContext
+): ValidationIssue[] {
+  try {
+    return definition.validate(ctx);
+  } catch (error) {
+    return [
+      {
+        stepId: null,
+        severity: "error",
+        code: "VALIDATION_ERROR",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    ];
+  }
+}
+
+function withStepId(issue: ValidationIssue, stepId: string): ValidationIssue {
+  return issue.stepId ? issue : { ...issue, stepId };
+}
+
+export function validateStrategy(
+  strategy: Strategy,
+  ctx: ValidateStrategyContext = {}
+): ValidationResult {
+  const registry = ctx.registry ?? strategyStepRegistry;
+  const issues: ValidationIssue[] = [];
+  const stepIds = new Set(strategy.steps.map((s) => s.id));
+  const indexById = new Map(strategy.steps.map((s, i) => [s.id, i]));
+
+  for (const step of strategy.steps) {
+    for (const depId of step.dependsOn) {
+      if (!stepIds.has(depId)) {
+        issues.push({
+          stepId: step.id,
+          severity: "error",
+          code: "INVALID_DEPENDENCY",
+          message: `Step "${step.label}" depends on unknown step id "${depId}".`,
+        });
+      } else if (indexById.get(depId)! >= indexById.get(step.id)!) {
+        issues.push({
+          stepId: step.id,
+          severity: "error",
+          code: "INVALID_DEPENDENCY",
+          message: `Step "${step.label}" depends on "${depId}", which is not ordered before it.`,
+        });
+      }
+    }
+  }
+
+  for (const step of strategy.steps) {
+    for (const [paramKey, binding] of Object.entries(step.params)) {
+      if (
+        binding.source === "stepOutput" &&
+        !step.dependsOn.includes(binding.stepId)
+      ) {
+        issues.push({
+          stepId: step.id,
+          severity: "error",
+          code: "UNDECLARED_DEPENDENCY",
+          message: `Step "${step.label}" param "${paramKey}" binds to step "${binding.stepId}"'s output but doesn't declare it in dependsOn.`,
+        });
+      }
+    }
+  }
+
+  const { order, issues: cycleIssues } = topologicalSort(strategy.steps);
+  issues.push(...cycleIssues);
+
+  const traversalOrder = order ?? strategy.steps.map((s) => s.id);
+  const stepsById = new Map(strategy.steps.map((s) => [s.id, s]));
+  const outputPortsByStep: Record<string, StepPort[]> = {};
+
+  for (const stepId of traversalOrder) {
+    const step = stepsById.get(stepId);
+    if (!step) continue;
+
+    const definition = registry.tryResolve(step.type, step.protocol);
+    if (!definition) {
+      issues.push({
+        stepId: step.id,
+        severity: "error",
+        code: "UNSUPPORTED_STEP",
+        message: `No step definition registered for "${step.type}:${step.protocol}".`,
+      });
+      continue;
+    }
+
+    for (const [paramKey, binding] of Object.entries(step.params)) {
+      if (binding.source !== "stepOutput") continue;
+      const upstreamPorts = outputPortsByStep[binding.stepId];
+      if (
+        upstreamPorts &&
+        !upstreamPorts.some((p) => p.id === binding.portId)
+      ) {
+        issues.push({
+          stepId: step.id,
+          severity: "error",
+          code: "INCOMPATIBLE_ASSET",
+          message: `Step "${step.label}" param "${paramKey}" binds to port "${binding.portId}" which step "${binding.stepId}" doesn't expose.`,
+        });
+      }
+    }
+
+    const resolvedParams = resolveParamsForStructuralValidation(step);
+    const definitionIssues = safeValidate(definition, {
+      userAddress: ctx.userAddress ?? "",
+      networkPassphrase: ctx.networkPassphrase ?? "",
+      resolvedParams,
+      upstreamOutputs: {},
+    });
+    issues.push(...definitionIssues.map((issue) => withStepId(issue, step.id)));
+
+    try {
+      outputPortsByStep[step.id] = definition.describeOutputs(
+        resolvedParams as never
+      );
+    } catch {
+      outputPortsByStep[step.id] = [];
+    }
+  }
+
+  if (ctx.balances) issues.push(...validateBalances(strategy, ctx.balances));
+
+  return { valid: !issues.some((i) => i.severity === "error"), issues };
+}
+
+// ─── Risk ────────────────────────────────────────────────────────────────────
+
+const DEFAULT_COLLATERAL_FACTOR_PCT = 75;
+
+/** Notional exposure per protocol: sum of |collateralDelta| + |debtDelta|. */
+export function computeProtocolExposure(
+  positions: ResultingPosition[]
+): Record<string, number> {
+  const exposure: Record<string, number> = {};
+  for (const position of positions) {
+    const amount =
+      Math.abs(position.collateralDelta ?? 0) +
+      Math.abs(position.debtDelta ?? 0);
+    if (amount <= 0) continue;
+    exposure[position.protocol] = (exposure[position.protocol] ?? 0) + amount;
+  }
+  return exposure;
+}
+
+/**
+ * Aggregates per-step resultingPosition deltas into one projected risk
+ * assessment for the whole strategy.
+ *
+ * Collateral/debt deltas are summed directly in their own reported units,
+ * not converted to a common USD basis — a documented simplification for
+ * this version. Real cross-asset value conversion via the oracle price
+ * feeds is tracked as follow-up work alongside the LP-remove gap.
+ */
+export function evaluateRisk(
+  positions: ResultingPosition[],
+  cumulativeSlippageBps: number
+): RiskAssessment {
+  let collateralValue = 0;
+  let debtValue = 0;
+  let collateralFactorPct = DEFAULT_COLLATERAL_FACTOR_PCT;
+  let sawPosition = false;
+
+  for (const position of positions) {
+    if (position.collateralDelta) {
+      collateralValue += position.collateralDelta;
+      sawPosition = true;
+    }
+    if (position.debtDelta) {
+      debtValue += position.debtDelta;
+      sawPosition = true;
+    }
+    if (position.collateralFactorPct != null)
+      collateralFactorPct = position.collateralFactorPct;
+  }
+
+  const projectedHealthFactor = sawPosition
+    ? calculateProjectedHealthFactor(
+        collateralValue,
+        debtValue,
+        collateralFactorPct
+      )
+    : null;
+  const projectedLiquidationPrice = sawPosition
+    ? calculateLiquidationPrice(collateralValue, debtValue, collateralFactorPct)
+    : null;
+  const effectiveLeverage =
+    collateralValue > 0 && collateralValue - debtValue > 0
+      ? collateralValue / (collateralValue - debtValue)
+      : null;
+
+  return {
+    effectiveLeverage,
+    projectedHealthFactor,
+    projectedLiquidationPrice,
+    cumulativeSlippageBps,
+    riskTier: getRiskTier(projectedHealthFactor),
+    protocolExposure: computeProtocolExposure(positions),
+  };
+}
+
+export const DEFAULT_RISK_THRESHOLDS: RiskThresholdConfig = {
+  // Reuses the app-wide submit-time warning threshold as the strategy-level minimum acknowledgeable health factor.
+  minHealthFactor: HF_WARNING,
+  maxLeverage: 3,
+  maxCumulativeSlippageBps: 300,
+  deviationThresholds: { swap: 0.05, lpAdd: 0.05, lpRemove: 0.05 },
+  defaultDeviationThreshold: 0.03,
+};
+
+export function exceedsThresholds(
+  assessment: RiskAssessment,
+  config: RiskThresholdConfig = DEFAULT_RISK_THRESHOLDS
+): boolean {
+  if (
+    assessment.projectedHealthFactor != null &&
+    assessment.projectedHealthFactor < config.minHealthFactor
+  )
+    return true;
+  if (
+    assessment.effectiveLeverage != null &&
+    assessment.effectiveLeverage > config.maxLeverage
+  )
+    return true;
+  if (assessment.cumulativeSlippageBps > config.maxCumulativeSlippageBps)
+    return true;
+  return false;
+}
+
+export function deviationThresholdFor(
+  stepType: string,
+  config: RiskThresholdConfig = DEFAULT_RISK_THRESHOLDS
+): number {
+  return (
+    config.deviationThresholds[stepType] ?? config.defaultDeviationThreshold
+  );
+}
+
+// ─── Simulation ──────────────────────────────────────────────────────────────
+
+export interface AggregatedProjection {
+  cumulativeFee: string;
+  cumulativeSlippageBps: number;
+  projectedApy: number | null;
+}
+
+export function aggregateProjection(
+  steps: Record<string, StepProjection>
+): AggregatedProjection {
+  const values = Object.values(steps);
+  let feeAcc = 0n;
+  let slippageAcc = 0;
+  let apySum = 0;
+  let apyCount = 0;
+
+  for (const step of values) {
+    feeAcc += toSmallestUnit(step.estimatedFee, 7);
+    slippageAcc += step.slippageBps ?? 0;
+    if (step.projectedApyDelta != null) {
+      apySum += step.projectedApyDelta;
+      apyCount += 1;
+    }
+  }
+
+  return {
+    cumulativeFee: fromSmallestUnit(feeAcc.toString(), 7),
+    cumulativeSlippageBps: slippageAcc,
+    projectedApy: apyCount > 0 ? apySum : null,
+  };
+}
+
+export interface SimulateStrategyContext {
+  userAddress: string;
+  networkPassphrase: string;
+  registry?: StrategyStepRegistry;
+}
+
+function resolveBinding(
+  binding: ParamBinding,
+  upstreamOutputs: Record<string, Record<string, unknown>>
+): unknown {
+  if (binding.source === "literal") return binding.value;
+  return upstreamOutputs[binding.stepId]?.[binding.portId];
+}
+
+function resolveParams(
+  step: StrategyStep,
+  upstreamOutputs: Record<string, Record<string, unknown>>
+): Record<string, unknown> {
+  const resolved: Record<string, unknown> = {};
+  for (const [key, binding] of Object.entries(step.params))
+    resolved[key] = resolveBinding(binding, upstreamOutputs);
+  return resolved;
+}
+
+function simulationFailure(
+  failedStepId: string | undefined,
+  failureReason: string,
+  steps: Record<string, StepProjection>
+): StrategyProjection {
+  return {
+    success: false,
+    failedStepId,
+    failureReason,
+    steps,
+    cumulativeFee: "0",
+    cumulativeSlippageBps: 0,
+    projectedApy: null,
+    effectiveLeverage: null,
+    projectedHealthFactor: null,
+    projectedLiquidationPrice: null,
+  };
+}
+
+/**
+ * Walks the strategy's steps in dependency order, calling each step
+ * definition's simulate() and feeding its outputs forward as the next
+ * step's upstreamOutputs — the automatic output-propagation the spec
+ * requires. Stops and reports the exact blocking step on any failure, never
+ * returns a silently-partial success.
+ */
+export async function simulateStrategy(
+  strategy: Strategy,
+  execCtx: SimulateStrategyContext
+): Promise<StrategyProjection> {
+  const registry = execCtx.registry ?? strategyStepRegistry;
+  const { order, issues: cycleIssues } = topologicalSort(strategy.steps);
+  if (!order)
+    return simulationFailure(
+      cycleIssues[0]?.stepId ?? undefined,
+      cycleIssues[0]?.message ?? "Circular dependency detected",
+      {}
+    );
+
+  const stepsById = new Map(strategy.steps.map((s) => [s.id, s]));
+  const outputsByStep: Record<string, Record<string, unknown>> = {};
+  const projections: Record<string, StepProjection> = {};
+
+  for (const stepId of order) {
+    const step = stepsById.get(stepId);
+    if (!step) continue;
+
+    const definition = registry.tryResolve(step.type, step.protocol);
+    if (!definition)
+      return simulationFailure(
+        step.id,
+        `No step definition registered for ${step.type}:${step.protocol}`,
+        projections
+      );
+
+    const ctx: StepExecutionContext = {
+      userAddress: execCtx.userAddress,
+      networkPassphrase: execCtx.networkPassphrase,
+      resolvedParams: resolveParams(step, outputsByStep),
+      upstreamOutputs: outputsByStep,
+    };
+
+    try {
+      const projection = await definition.simulate(ctx);
+      projections[step.id] = projection;
+      outputsByStep[step.id] = projection.outputs;
+    } catch (error) {
+      return simulationFailure(
+        step.id,
+        error instanceof Error ? error.message : String(error),
+        projections
+      );
+    }
+  }
+
+  const aggregate = aggregateProjection(projections);
+  const positions: ResultingPosition[] = Object.values(projections)
+    .map((p) => p.resultingPosition)
+    .filter((p): p is ResultingPosition => Boolean(p));
+  const risk = evaluateRisk(positions, aggregate.cumulativeSlippageBps);
+
+  return {
+    success: true,
+    steps: projections,
+    cumulativeFee: aggregate.cumulativeFee,
+    cumulativeSlippageBps: aggregate.cumulativeSlippageBps,
+    projectedApy: aggregate.projectedApy,
+    effectiveLeverage: risk.effectiveLeverage,
+    projectedHealthFactor: risk.projectedHealthFactor,
+    projectedLiquidationPrice: risk.projectedLiquidationPrice,
+  };
+}
+
+// ─── Sensitivity analysis ────────────────────────────────────────────────────
+
+type ScenarioConfig = Omit<SensitivityScenario, "projection">;
+
+export const DEFAULT_SENSITIVITY_SCENARIOS: ScenarioConfig[] = [
+  { label: "Base case", slippageMultiplier: 1, priceShockPct: 0 },
+  { label: "High slippage", slippageMultiplier: 2, priceShockPct: 0 },
+  {
+    label: "Adverse price move (-10%)",
+    slippageMultiplier: 1,
+    priceShockPct: -0.1,
+  },
+  {
+    label: "Stress (2x slippage, -10% price)",
+    slippageMultiplier: 2,
+    priceShockPct: -0.1,
+  },
+];
+
+/**
+ * Produces sensitivity scenarios by analytically scaling a single baseline
+ * StrategyProjection's slippage and price-dependent figures, rather than
+ * re-running every step definition's simulate() with perturbed live inputs
+ * (quotes, oracle prices) — that would require plumbing shock parameters
+ * through all step definitions, tracked as follow-up scope. Health factor
+ * and liquidation price are assumed to scale roughly linearly with a
+ * collateral-value price shock, accurate for small shocks and clearly a
+ * projection, not a guarantee.
+ */
+export function computeSensitivity(
+  baseline: StrategyProjection,
+  scenarios: ScenarioConfig[] = DEFAULT_SENSITIVITY_SCENARIOS
+): SensitivityScenario[] {
+  if (!baseline.success)
+    return scenarios.map((scenario) => ({ ...scenario, projection: baseline }));
+
+  return scenarios.map((scenario) => {
+    const cumulativeSlippageBps = Math.round(
+      baseline.cumulativeSlippageBps * scenario.slippageMultiplier
+    );
+    let projectedHealthFactor = baseline.projectedHealthFactor;
+    let projectedLiquidationPrice = baseline.projectedLiquidationPrice;
+
+    if (
+      scenario.priceShockPct !== 0 &&
+      baseline.projectedHealthFactor != null
+    ) {
+      projectedHealthFactor =
+        baseline.projectedHealthFactor * (1 + scenario.priceShockPct);
+      projectedLiquidationPrice =
+        baseline.projectedLiquidationPrice != null
+          ? baseline.projectedLiquidationPrice * (1 - scenario.priceShockPct)
+          : null;
+    }
+
+    return {
+      ...scenario,
+      projection: {
+        ...baseline,
+        cumulativeSlippageBps,
+        projectedHealthFactor,
+        projectedLiquidationPrice,
+      },
+    };
+  });
+}

--- a/apps/web-app/src/lib/strategy/execution.ts
+++ b/apps/web-app/src/lib/strategy/execution.ts
@@ -1,0 +1,361 @@
+import { topologicalSort, deviationThresholdFor } from "./engine";
+import { findUnfinishedExecutions } from "./persistence";
+import { strategyStepRegistry, type StrategyStepRegistry } from "./registry";
+import type {
+  DeviationReport,
+  ExecutionRecord,
+  ExecutionStatus,
+  ExecutionStepRecord,
+  ParamBinding,
+  StepExecutionContext,
+  StepProjection,
+  Strategy,
+  StrategyStep,
+  StrategyProjection,
+} from "./types";
+
+// ─── Deviation check ─────────────────────────────────────────────────────────
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (
+    typeof value === "string" &&
+    value.trim() !== "" &&
+    Number.isFinite(Number(value))
+  )
+    return Number(value);
+  return null;
+}
+
+/**
+ * Compares a step's actual on-chain outputs against its simulated
+ * projection. Finds the first output port with a numeric value on both
+ * sides and computes relative deviation from it. When nothing comparable
+ * exists, deviation can't be measured and the step is treated as
+ * non-deviated.
+ */
+export function checkDeviation(
+  stepType: string,
+  projected: StepProjection,
+  actualOutputs: Record<string, unknown>
+): DeviationReport {
+  const threshold = deviationThresholdFor(stepType);
+
+  for (const [portId, projectedValue] of Object.entries(projected.outputs)) {
+    const projectedNum = toNumber(projectedValue);
+    const actualNum = toNumber(actualOutputs[portId]);
+    if (projectedNum == null || actualNum == null || projectedNum === 0)
+      continue;
+
+    const relativeDeviation =
+      Math.abs(actualNum - projectedNum) / Math.abs(projectedNum);
+    const deviated = relativeDeviation > threshold;
+    return {
+      deviated,
+      relativeDeviation,
+      threshold,
+      message: deviated
+        ? `Actual output for "${portId}" (${actualNum}) deviates ${(relativeDeviation * 100).toFixed(1)}% from the projected ${projectedNum}, exceeding the ${(threshold * 100).toFixed(1)}% threshold.`
+        : undefined,
+    };
+  }
+
+  return { deviated: false, relativeDeviation: null, threshold };
+}
+
+// ─── Execution engine ────────────────────────────────────────────────────────
+
+export type SignFn = (
+  xdr: string,
+  options: { networkPassphrase: string; address?: string }
+) => Promise<{ signedTxXdr: string }>;
+
+/**
+ * Uniform submit+confirm transport, keyed by a step definition's
+ * submissionMode. Real wiring (rpc.Server + waitForTransaction for "rpc",
+ * the SoroSwap send API for "soroswapApi") lives in the useStrategyExecution
+ * hook — the engine itself never imports the Stellar SDK, which is what
+ * makes it fully unit-testable without a network.
+ */
+export interface TransportAdapter {
+  submit(
+    signedXdr: string,
+    networkPassphrase: string
+  ): Promise<{ hash: string }>;
+  confirm(hash: string): Promise<unknown>;
+}
+
+export interface ExecutionEngineDeps {
+  registry?: StrategyStepRegistry;
+  sign: SignFn;
+  transports: Record<"rpc" | "soroswapApi", TransportAdapter>;
+}
+
+export interface ExecuteStrategyParams {
+  strategy: Strategy;
+  /** Existing (possibly partially-completed, for resume) or freshly-created record. */
+  execution: ExecutionRecord;
+  userAddress: string;
+  networkPassphrase: string;
+  /** Step ids whose recorded "paused_deviation" the user has explicitly acknowledged — resume accepts the already-executed result instead of re-submitting. */
+  acknowledgedDeviationStepIds?: string[];
+  /** Called after every step status transition — wire to persistence (upsertExecution) and UI progress. */
+  onStepUpdate?: (record: ExecutionRecord) => void;
+}
+
+export interface ExecuteStrategyResult {
+  record: ExecutionRecord;
+  status: ExecutionStatus;
+}
+
+function cloneRecord(record: ExecutionRecord): ExecutionRecord {
+  return JSON.parse(JSON.stringify(record)) as ExecutionRecord;
+}
+
+function resolveExecBinding(
+  binding: ParamBinding,
+  upstreamOutputs: Record<string, Record<string, unknown>>
+): unknown {
+  if (binding.source === "literal") return binding.value;
+  return upstreamOutputs[binding.stepId]?.[binding.portId];
+}
+
+function resolveExecParams(
+  step: StrategyStep,
+  upstreamOutputs: Record<string, Record<string, unknown>>
+): Record<string, unknown> {
+  const resolved: Record<string, unknown> = {};
+  for (const [key, binding] of Object.entries(step.params))
+    resolved[key] = resolveExecBinding(binding, upstreamOutputs);
+  return resolved;
+}
+
+function updateStep(
+  record: ExecutionRecord,
+  stepId: string,
+  patch: Partial<ExecutionStepRecord>
+): ExecutionStepRecord {
+  const idx = record.steps.findIndex((s) => s.stepId === stepId);
+  if (idx === -1) {
+    const created: ExecutionStepRecord = {
+      stepId,
+      status: "pending",
+      ...patch,
+    };
+    record.steps.push(created);
+    return created;
+  }
+  record.steps[idx] = { ...record.steps[idx], ...patch };
+  record.updatedAt = Date.now();
+  return record.steps[idx];
+}
+
+/**
+ * Executes a strategy step-by-step: prepare -> sign -> submit -> confirm ->
+ * validate before continuing. Framework-agnostic (no React, no direct
+ * Stellar SDK imports) so it's usable from a hook and testable in
+ * isolation. Supports resuming a partially-completed ExecutionRecord —
+ * already-"completed" steps are skipped and their actualOutputs seed
+ * upstreamOutputs for the rest of the run; a "paused_deviation" step is
+ * only advanced past once its id appears in acknowledgedDeviationStepIds,
+ * and even then it is accepted (not re-submitted) to avoid a duplicate
+ * on-chain transaction.
+ */
+export class ExecutionEngine {
+  constructor(private readonly deps: ExecutionEngineDeps) {}
+
+  async executeStrategy(
+    params: ExecuteStrategyParams
+  ): Promise<ExecuteStrategyResult> {
+    const registry = this.deps.registry ?? strategyStepRegistry;
+    const { order } = topologicalSort(params.strategy.steps);
+    const record = cloneRecord(params.execution);
+
+    if (!order) {
+      record.status = "failed";
+      params.onStepUpdate?.(record);
+      return { record, status: "failed" };
+    }
+
+    const stepsById = new Map(params.strategy.steps.map((s) => [s.id, s]));
+    const upstreamOutputs: Record<string, Record<string, unknown>> = {};
+    for (const s of record.steps) {
+      if (s.status === "completed" && s.actualOutputs)
+        upstreamOutputs[s.stepId] = s.actualOutputs;
+    }
+
+    const acknowledged = new Set(params.acknowledgedDeviationStepIds ?? []);
+    const baselineProjection = record.projectedOutcome as
+      | StrategyProjection
+      | undefined;
+
+    for (const stepId of order) {
+      const step = stepsById.get(stepId);
+      if (!step) continue;
+
+      const existing = record.steps.find((s) => s.stepId === stepId);
+      if (existing?.status === "completed") continue;
+
+      if (existing?.status === "paused_deviation") {
+        if (!acknowledged.has(stepId)) {
+          record.status = "paused-deviation";
+          params.onStepUpdate?.(record);
+          return { record, status: "paused-deviation" };
+        }
+        updateStep(record, stepId, { status: "completed" });
+        if (existing.actualOutputs)
+          upstreamOutputs[stepId] = existing.actualOutputs;
+        continue;
+      }
+
+      const definition = registry.tryResolve(step.type, step.protocol);
+      if (!definition) {
+        updateStep(record, stepId, {
+          status: "failed",
+          errorMessage: `No step definition registered for ${step.type}:${step.protocol}`,
+        });
+        record.status = "failed";
+        params.onStepUpdate?.(record);
+        return { record, status: "failed" };
+      }
+
+      try {
+        updateStep(record, stepId, { status: "preparing" });
+        params.onStepUpdate?.(record);
+
+        const ctx: StepExecutionContext = {
+          userAddress: params.userAddress,
+          networkPassphrase: params.networkPassphrase,
+          resolvedParams: resolveExecParams(step, upstreamOutputs),
+          upstreamOutputs,
+        };
+
+        const tx = await definition.prepare(ctx);
+
+        updateStep(record, stepId, { status: "awaiting_signature" });
+        params.onStepUpdate?.(record);
+        const signed = await this.deps.sign(tx.xdr, {
+          networkPassphrase: tx.networkPassphrase,
+          address: params.userAddress,
+        });
+
+        updateStep(record, stepId, { status: "submitting" });
+        params.onStepUpdate?.(record);
+        const transport = this.deps.transports[definition.submissionMode];
+        const { hash } = await transport.submit(
+          signed.signedTxXdr,
+          tx.networkPassphrase
+        );
+        updateStep(record, stepId, {
+          status: "confirming",
+          txHash: hash,
+          submittedAt: Date.now(),
+        });
+        params.onStepUpdate?.(record);
+
+        const confirmedResult = await transport.confirm(hash);
+        const interpreted = definition.interpretResult
+          ? await definition.interpretResult(ctx, confirmedResult)
+          : {};
+        const actualOutputs = interpreted.outputs ?? {};
+
+        const stepProjection = baselineProjection?.steps?.[stepId];
+        const deviation = stepProjection
+          ? checkDeviation(step.type, stepProjection, actualOutputs)
+          : {
+              deviated: false,
+              relativeDeviation: null,
+              threshold: deviationThresholdFor(step.type),
+            };
+
+        if (deviation.deviated) {
+          updateStep(record, stepId, {
+            status: "paused_deviation",
+            confirmedAt: Date.now(),
+            actualOutputs,
+            deviation,
+          });
+          record.status = "paused-deviation";
+          params.onStepUpdate?.(record);
+          return { record, status: "paused-deviation" };
+        }
+
+        updateStep(record, stepId, {
+          status: "completed",
+          confirmedAt: Date.now(),
+          actualOutputs,
+          deviation,
+        });
+        upstreamOutputs[stepId] = actualOutputs;
+        record.status = "in_progress";
+        params.onStepUpdate?.(record);
+      } catch (error) {
+        updateStep(record, stepId, {
+          status: "failed",
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+        record.status = "failed";
+        params.onStepUpdate?.(record);
+        return { record, status: "failed" };
+      }
+    }
+
+    record.status = "completed";
+    record.completedAt = Date.now();
+    params.onStepUpdate?.(record);
+    return { record, status: "completed" };
+  }
+}
+
+// ─── Recovery ────────────────────────────────────────────────────────────────
+
+export type OnChainTxStatus = "SUCCESS" | "FAILED" | "PENDING" | "NOT_FOUND";
+
+export interface ReconcileDeps {
+  getTransactionStatus: (hash: string) => Promise<OnChainTxStatus>;
+}
+
+/**
+ * On reopen: for a record with a step still marked "submitting"/"confirming"
+ * (the app closed between submit and the confirm-write), re-poll the chain
+ * to determine the real outcome before the UI offers Resume — this is the
+ * "reconcile completed steps" half of execution recovery. A PENDING/
+ * NOT_FOUND result is left untouched (still genuinely in flight, or the
+ * poll itself failed) so a later resume attempt can retry rather than
+ * guessing.
+ */
+export async function reconcileExecution(
+  execution: ExecutionRecord,
+  deps: ReconcileDeps
+): Promise<ExecutionRecord> {
+  const record = cloneRecord(execution);
+
+  for (const step of record.steps) {
+    const inFlight =
+      step.status === "submitting" || step.status === "confirming";
+    if (!inFlight || !step.txHash) continue;
+
+    try {
+      const status = await deps.getTransactionStatus(step.txHash);
+      if (status === "SUCCESS") {
+        step.status = "completed";
+        step.confirmedAt = Date.now();
+      } else if (status === "FAILED") {
+        step.status = "failed";
+        step.errorMessage =
+          "Transaction failed on-chain while the app was closed.";
+      }
+    } catch {
+      // Reconciliation network error — leave the step's recorded status as-is; retried on a future resume.
+    }
+  }
+
+  return record;
+}
+
+/** Detects unfinished executions for the "resume or abandon" prompt on app reopen. */
+export function findResumableExecutions(
+  walletAddress: string
+): ExecutionRecord[] {
+  return findUnfinishedExecutions(walletAddress);
+}

--- a/apps/web-app/src/lib/strategy/hooks.ts
+++ b/apps/web-app/src/lib/strategy/hooks.ts
@@ -1,0 +1,313 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { rpc, TransactionBuilder } from "@stellar/stellar-sdk";
+import { useWallet } from "@/hooks/useWallet";
+import { rpcUrl, stellarNetwork } from "@/lib/constants/network";
+import { sendTransaction as soroswapSendTransaction } from "@/lib/helpers/stellar/soroswap";
+import { waitForTransaction } from "@/lib/helpers/stellar/waitForTransaction";
+import type { MappedBalances } from "@/lib/helpers/stellar/wallet";
+import { strategyStepRegistry } from "./registry";
+import "./definitions";
+import { validateStrategy, simulateStrategy } from "./engine";
+import {
+  listStrategies,
+  upsertStrategy as upsertStrategyStorage,
+  removeStrategy as removeStrategyStorage,
+  upsertExecution,
+} from "./persistence";
+import {
+  ExecutionEngine,
+  findResumableExecutions,
+  reconcileExecution,
+  type ExecuteStrategyResult,
+  type OnChainTxStatus,
+  type TransportAdapter,
+} from "./execution";
+import type { ExecutionRecord, Strategy, ValidationResult } from "./types";
+
+// ─── Balance flattening ──────────────────────────────────────────────────────
+
+/**
+ * useWallet().balances is keyed by Horizon/Soroban entry shape ("xlm",
+ * "CODE:ISSUER", "soroban:CODE"), not a plain asset code. validateStrategy's
+ * balance check needs a simple assetCode -> decimal-string map, so this
+ * flattens the common cases (native XLM, Soroban token balances) into that
+ * shape. Classic "CODE:ISSUER" trustline balances are intentionally left
+ * out — the strategy engine only moves Soroban-native/SAC assets today.
+ */
+export function flattenBalancesByAssetCode(
+  balances: MappedBalances
+): Record<string, string> {
+  const flattened: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(balances)) {
+    if (key === "xlm") {
+      flattened.XLM = entry.balance;
+      continue;
+    }
+    if (key.startsWith("soroban:"))
+      flattened[key.slice("soroban:".length)] = entry.balance;
+  }
+  return flattened;
+}
+
+// ─── Definitions ─────────────────────────────────────────────────────────────
+
+/** Lists every registered step definition, for the composer's step palette. */
+export function useStrategyDefinitions() {
+  return useMemo(() => strategyStepRegistry.listRegistered(), []);
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+const EMPTY_VALIDATION_RESULT: ValidationResult = { valid: true, issues: [] };
+
+/**
+ * validateStrategy() is pure and synchronous (no network calls), so this
+ * recomputes on every relevant change via useMemo rather than a debounced
+ * effect — there's no async work to throttle.
+ */
+export function useStrategyValidation(
+  strategy: Strategy | null
+): ValidationResult {
+  const { address, networkPassphrase, balances } = useWallet();
+  return useMemo(() => {
+    if (!strategy) return EMPTY_VALIDATION_RESULT;
+    return validateStrategy(strategy, {
+      userAddress: address,
+      networkPassphrase,
+      balances: flattenBalancesByAssetCode(balances),
+    });
+  }, [strategy, address, networkPassphrase, balances]);
+}
+
+// ─── Simulation ──────────────────────────────────────────────────────────────
+
+export const STRATEGY_SIMULATION_QUERY_KEY = "defi-strategy-simulation";
+
+export function useStrategySimulation(
+  strategy: Strategy | null,
+  enabled = true
+) {
+  const { address, networkPassphrase } = useWallet();
+  return useQuery({
+    queryKey: [
+      STRATEGY_SIMULATION_QUERY_KEY,
+      strategy?.id,
+      strategy?.updatedAt,
+      address,
+    ],
+    queryFn: () =>
+      simulateStrategy(strategy!, {
+        userAddress: address!,
+        networkPassphrase: networkPassphrase!,
+      }),
+    enabled:
+      enabled &&
+      Boolean(strategy) &&
+      Boolean(address) &&
+      Boolean(networkPassphrase),
+    staleTime: 10_000,
+    retry: false,
+    throwOnError: false,
+  });
+}
+
+// ─── Persistence ─────────────────────────────────────────────────────────────
+
+export const DEFI_STRATEGIES_QUERY_KEY = "defi-strategies";
+
+/** CRUD over versioned localStorage-backed strategy definitions, scoped to the connected wallet. */
+export function useStrategyPersistence() {
+  const { address } = useWallet();
+  const queryClient = useQueryClient();
+  const queryKey = [DEFI_STRATEGIES_QUERY_KEY, address];
+
+  const query = useQuery({
+    queryKey,
+    queryFn: () => listStrategies(address!),
+    enabled: Boolean(address),
+    staleTime: Infinity,
+  });
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryClient, address]);
+
+  const saveStrategy = useCallback(
+    (strategy: Strategy) => {
+      if (!address) return;
+      upsertStrategyStorage(address, strategy);
+      invalidate();
+    },
+    [address, invalidate]
+  );
+
+  const deleteStrategy = useCallback(
+    (strategyId: string) => {
+      if (!address) return;
+      removeStrategyStorage(address, strategyId);
+      invalidate();
+    },
+    [address, invalidate]
+  );
+
+  return {
+    strategies: query.data ?? [],
+    isLoading: query.isLoading,
+    saveStrategy,
+    deleteStrategy,
+  };
+}
+
+// ─── Execution ───────────────────────────────────────────────────────────────
+
+function makeRpcTransport(): TransportAdapter {
+  return {
+    async submit(signedXdr, networkPassphrase) {
+      const server = new rpc.Server(rpcUrl, {
+        allowHttp: stellarNetwork === "LOCAL",
+      });
+      const tx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
+      const result = await server.sendTransaction(tx);
+      return { hash: result.hash };
+    },
+    async confirm(hash) {
+      const server = new rpc.Server(rpcUrl, {
+        allowHttp: stellarNetwork === "LOCAL",
+      });
+      return waitForTransaction(hash, server);
+    },
+  };
+}
+
+function makeSoroswapTransport(): TransportAdapter {
+  return {
+    async submit(signedXdr) {
+      const result = await soroswapSendTransaction({
+        xdr: signedXdr,
+        launchtube: false,
+      });
+      return { hash: result.txHash };
+    },
+    async confirm(hash) {
+      const server = new rpc.Server(rpcUrl, {
+        allowHttp: stellarNetwork === "LOCAL",
+      });
+      return waitForTransaction(hash, server);
+    },
+  };
+}
+
+export interface ExecuteOptions {
+  acknowledgedDeviationStepIds?: string[];
+}
+
+/**
+ * Owns the guided ExecutionEngine, wiring its transport-agnostic
+ * prepare/sign/submit/confirm sequence to real RPC + SoroSwap-API
+ * submission, and persisting the record after every step (recovery reads
+ * this same store).
+ */
+export function useStrategyExecution() {
+  const { address, networkPassphrase, signTransaction } = useWallet();
+  const [isExecuting, setIsExecuting] = useState(false);
+
+  const execute = useCallback(
+    async (
+      strategy: Strategy,
+      execution: ExecutionRecord,
+      options?: ExecuteOptions
+    ): Promise<ExecuteStrategyResult | null> => {
+      if (!address || !networkPassphrase) return null;
+      setIsExecuting(true);
+      try {
+        const engine = new ExecutionEngine({
+          sign: signTransaction,
+          transports: {
+            rpc: makeRpcTransport(),
+            soroswapApi: makeSoroswapTransport(),
+          },
+        });
+        return await engine.executeStrategy({
+          strategy,
+          execution,
+          userAddress: address,
+          networkPassphrase,
+          acknowledgedDeviationStepIds: options?.acknowledgedDeviationStepIds,
+          onStepUpdate: (record) => upsertExecution(address, record),
+        });
+      } finally {
+        setIsExecuting(false);
+      }
+    },
+    [address, networkPassphrase, signTransaction]
+  );
+
+  return { execute, isExecuting, hasWallet: Boolean(address) };
+}
+
+// ─── Execution recovery ──────────────────────────────────────────────────────
+
+async function getTransactionStatus(
+  server: rpc.Server,
+  hash: string
+): Promise<OnChainTxStatus> {
+  try {
+    const result = await server.getTransaction(hash);
+    if (result.status === "SUCCESS") return "SUCCESS";
+    if (result.status === "FAILED") return "FAILED";
+    if (result.status === "NOT_FOUND") return "NOT_FOUND";
+    return "PENDING";
+  } catch {
+    return "NOT_FOUND";
+  }
+}
+
+/**
+ * On mount (app reopen), scans persisted execution history for unfinished
+ * runs, reconciles any still-in-flight step against the chain, and
+ * surfaces what's left as resumable — the data ResumeExecutionBanner reads.
+ */
+export function useExecutionRecovery() {
+  const { address } = useWallet();
+  const [resumable, setResumable] = useState<ExecutionRecord[]>([]);
+  const [isChecking, setIsChecking] = useState(false);
+
+  const check = useCallback(async () => {
+    if (!address) {
+      setResumable([]);
+      return;
+    }
+    setIsChecking(true);
+    try {
+      const unfinished = findResumableExecutions(address);
+      const server = new rpc.Server(rpcUrl, {
+        allowHttp: stellarNetwork === "LOCAL",
+      });
+      const reconciled = await Promise.all(
+        unfinished.map((record) =>
+          reconcileExecution(record, {
+            getTransactionStatus: (hash) => getTransactionStatus(server, hash),
+          })
+        )
+      );
+      reconciled.forEach((record) => upsertExecution(address, record));
+      setResumable(
+        reconciled.filter(
+          (r) => r.status === "in_progress" || r.status === "paused-deviation"
+        )
+      );
+    } finally {
+      setIsChecking(false);
+    }
+  }, [address]);
+
+  useEffect(() => {
+    void check();
+  }, [check]);
+
+  return { resumable, isChecking, refresh: check };
+}

--- a/apps/web-app/src/lib/strategy/persistence.ts
+++ b/apps/web-app/src/lib/strategy/persistence.ts
@@ -1,0 +1,361 @@
+import { z } from "zod";
+import type { ExecutionRecord, Strategy } from "./types";
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+export const CURRENT_STRATEGY_STORAGE_VERSION = 1;
+export const CURRENT_EXECUTION_STORAGE_VERSION = 1;
+
+const paramBindingSchema = z.union([
+  z.object({ source: z.literal("literal"), value: z.unknown() }),
+  z.object({
+    source: z.literal("stepOutput"),
+    stepId: z.string(),
+    portId: z.string(),
+  }),
+]);
+
+/**
+ * `type`/`protocol` are intentionally z.string(), not the current StepType
+ * enum — a stored strategy referencing a step type this build doesn't know
+ * about (an older build opening newer data, or vice versa) must still parse
+ * successfully. Resolving it to something executable is the registry's job
+ * (StrategyStepRegistry.resolveOrUnknown), not the storage schema's.
+ */
+const strategyStepSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  protocol: z.string(),
+  label: z.string(),
+  params: z.record(z.string(), paramBindingSchema),
+  dependsOn: z.array(z.string()),
+});
+
+const strategySchema = z.object({
+  id: z.string(),
+  version: z.number(),
+  name: z.string(),
+  description: z.string().optional(),
+  isTemplate: z.boolean(),
+  steps: z.array(strategyStepSchema),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const strategyStorageSchema = z.object({
+  version: z.number(),
+  strategies: z.array(strategySchema),
+});
+
+const executionStepStatusSchema = z.enum([
+  "pending",
+  "preparing",
+  "awaiting_signature",
+  "submitting",
+  "confirming",
+  "completed",
+  "failed",
+  "paused_deviation",
+  "cancelled",
+]);
+
+const deviationReportSchema = z.object({
+  deviated: z.boolean(),
+  relativeDeviation: z.number().nullable(),
+  threshold: z.number(),
+  message: z.string().optional(),
+});
+
+const executionStepRecordSchema = z.object({
+  stepId: z.string(),
+  status: executionStepStatusSchema,
+  txHash: z.string().optional(),
+  submittedAt: z.number().optional(),
+  confirmedAt: z.number().optional(),
+  actualOutputs: z.record(z.string(), z.unknown()).optional(),
+  deviation: deviationReportSchema.optional(),
+  errorMessage: z.string().optional(),
+});
+
+const executionStatusSchema = z.enum([
+  "in_progress",
+  "completed",
+  "failed",
+  "paused-deviation",
+  "abandoned",
+]);
+
+const executionRecordSchema = z.object({
+  id: z.string(),
+  strategyId: z.string(),
+  strategySnapshot: z.unknown(),
+  status: executionStatusSchema,
+  startedAt: z.number(),
+  updatedAt: z.number(),
+  completedAt: z.number().optional(),
+  projectedOutcome: z.unknown(),
+  actualOutcome: z.unknown().optional(),
+  steps: z.array(executionStepRecordSchema),
+});
+
+export const executionHistoryStorageSchema = z.object({
+  version: z.number(),
+  executions: z.array(executionRecordSchema),
+});
+
+export type StoredStrategyDocument = z.infer<typeof strategyStorageSchema>;
+export type StoredExecutionHistoryDocument = z.infer<
+  typeof executionHistoryStorageSchema
+>;
+
+// ─── Migrations ──────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type MigrationFn = (doc: any) => any;
+
+function currentVersionOf(doc: unknown): number {
+  const v = (doc as { version?: unknown } | null | undefined)?.version;
+  return typeof v === "number" ? v : 0;
+}
+
+/**
+ * Ordered migrations for each document, keyed by the version being
+ * migrated FROM. Applied repeatedly until the document reports the target
+ * version or no further migration is registered (the caller's schema parse
+ * then accepts or rejects the result). Empty today (schema v1 is the first
+ * version) — the framework itself is proven with a synthetic v0 fixture in
+ * the test suite, ahead of ever needing it for real.
+ */
+export const STRATEGY_MIGRATIONS: Record<number, MigrationFn> = {};
+export const EXECUTION_HISTORY_MIGRATIONS: Record<number, MigrationFn> = {};
+
+export function migrateDocument(
+  raw: unknown,
+  targetVersion: number,
+  migrations: Record<number, MigrationFn>
+): unknown {
+  let doc = raw;
+  let fromVersion = currentVersionOf(doc);
+  const seen = new Set<number>();
+
+  while (fromVersion < targetVersion) {
+    if (seen.has(fromVersion)) break; // guard against a misconfigured migration loop
+    seen.add(fromVersion);
+    const migrate = migrations[fromVersion];
+    if (!migrate) break;
+    doc = migrate(doc);
+    const nextVersion = currentVersionOf(doc);
+    fromVersion = nextVersion > fromVersion ? nextVersion : fromVersion + 1;
+  }
+
+  return doc;
+}
+
+export function migrateStrategyDocument(
+  raw: unknown,
+  targetVersion: number
+): unknown {
+  return migrateDocument(raw, targetVersion, STRATEGY_MIGRATIONS);
+}
+
+export function migrateExecutionHistoryDocument(
+  raw: unknown,
+  targetVersion: number
+): unknown {
+  return migrateDocument(raw, targetVersion, EXECUTION_HISTORY_MIGRATIONS);
+}
+
+// ─── Strategy storage ────────────────────────────────────────────────────────
+
+/**
+ * Unlike features/swap/hooks/useLimitOrders.ts, the version is NOT baked
+ * into the key — a stable key lets migrateStrategyDocument() upgrade
+ * old-version data in place instead of orphaning it under a key the app
+ * never reads again. Version travels inside the stored payload only.
+ */
+function strategyStorageKey(walletAddress: string): string {
+  return `neko_defi_strategies_${walletAddress}`;
+}
+
+function emptyStrategyDocument(): StoredStrategyDocument {
+  return { version: CURRENT_STRATEGY_STORAGE_VERSION, strategies: [] };
+}
+
+export function loadStrategyDocument(
+  walletAddress: string
+): StoredStrategyDocument {
+  if (typeof window === "undefined" || !window.localStorage)
+    return emptyStrategyDocument();
+  try {
+    const raw = window.localStorage.getItem(strategyStorageKey(walletAddress));
+    if (!raw) return emptyStrategyDocument();
+    const parsed: unknown = JSON.parse(raw);
+    const migrated = migrateStrategyDocument(
+      parsed,
+      CURRENT_STRATEGY_STORAGE_VERSION
+    );
+    const result = strategyStorageSchema.safeParse(migrated);
+    if (!result.success) {
+      console.warn(
+        "[strategyStorage] Corrupt or unmigratable strategies document, resetting.",
+        result.error
+      );
+      return emptyStrategyDocument();
+    }
+    return result.data;
+  } catch (err) {
+    console.warn("[strategyStorage] Failed to load strategies:", err);
+    return emptyStrategyDocument();
+  }
+}
+
+export function saveStrategyDocument(
+  walletAddress: string,
+  doc: StoredStrategyDocument
+): void {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(
+      strategyStorageKey(walletAddress),
+      JSON.stringify(doc)
+    );
+  } catch (err) {
+    console.warn("[strategyStorage] Failed to save strategies:", err);
+  }
+}
+
+export function listStrategies(walletAddress: string): Strategy[] {
+  return loadStrategyDocument(walletAddress).strategies as Strategy[];
+}
+
+export function upsertStrategy(
+  walletAddress: string,
+  strategy: Strategy
+): Strategy[] {
+  const doc = loadStrategyDocument(walletAddress);
+  const idx = doc.strategies.findIndex((s) => s.id === strategy.id);
+  const strategies = [...doc.strategies];
+  if (idx === -1)
+    strategies.push(strategy as StoredStrategyDocument["strategies"][number]);
+  else
+    strategies[idx] = strategy as StoredStrategyDocument["strategies"][number];
+  const next: StoredStrategyDocument = {
+    version: CURRENT_STRATEGY_STORAGE_VERSION,
+    strategies,
+  };
+  saveStrategyDocument(walletAddress, next);
+  return next.strategies as Strategy[];
+}
+
+export function removeStrategy(
+  walletAddress: string,
+  strategyId: string
+): Strategy[] {
+  const doc = loadStrategyDocument(walletAddress);
+  const next: StoredStrategyDocument = {
+    version: CURRENT_STRATEGY_STORAGE_VERSION,
+    strategies: doc.strategies.filter((s) => s.id !== strategyId),
+  };
+  saveStrategyDocument(walletAddress, next);
+  return next.strategies as Strategy[];
+}
+
+// ─── Execution history storage ───────────────────────────────────────────────
+
+function executionStorageKey(walletAddress: string): string {
+  return `neko_defi_strategy_executions_${walletAddress}`;
+}
+
+function emptyExecutionDocument(): StoredExecutionHistoryDocument {
+  return { version: CURRENT_EXECUTION_STORAGE_VERSION, executions: [] };
+}
+
+export function loadExecutionHistoryDocument(
+  walletAddress: string
+): StoredExecutionHistoryDocument {
+  if (typeof window === "undefined" || !window.localStorage)
+    return emptyExecutionDocument();
+  try {
+    const raw = window.localStorage.getItem(executionStorageKey(walletAddress));
+    if (!raw) return emptyExecutionDocument();
+    const parsed: unknown = JSON.parse(raw);
+    const migrated = migrateExecutionHistoryDocument(
+      parsed,
+      CURRENT_EXECUTION_STORAGE_VERSION
+    );
+    const result = executionHistoryStorageSchema.safeParse(migrated);
+    if (!result.success) {
+      console.warn(
+        "[executionHistoryStorage] Corrupt or unmigratable execution history, resetting.",
+        result.error
+      );
+      return emptyExecutionDocument();
+    }
+    return result.data;
+  } catch (err) {
+    console.warn(
+      "[executionHistoryStorage] Failed to load execution history:",
+      err
+    );
+    return emptyExecutionDocument();
+  }
+}
+
+export function saveExecutionHistoryDocument(
+  walletAddress: string,
+  doc: StoredExecutionHistoryDocument
+): void {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(
+      executionStorageKey(walletAddress),
+      JSON.stringify(doc)
+    );
+  } catch (err) {
+    console.warn(
+      "[executionHistoryStorage] Failed to save execution history:",
+      err
+    );
+  }
+}
+
+export function listExecutions(walletAddress: string): ExecutionRecord[] {
+  return loadExecutionHistoryDocument(walletAddress)
+    .executions as ExecutionRecord[];
+}
+
+/**
+ * Called after every completed step (per the guided execution engine) so an
+ * interrupted app close never loses more than the in-flight step's result.
+ * Upserts by id — never deletes, so execution history is preserved even
+ * when the user later abandons the run.
+ */
+export function upsertExecution(
+  walletAddress: string,
+  execution: ExecutionRecord
+): ExecutionRecord[] {
+  const doc = loadExecutionHistoryDocument(walletAddress);
+  const idx = doc.executions.findIndex((e) => e.id === execution.id);
+  const executions = [...doc.executions];
+  if (idx === -1)
+    executions.push(
+      execution as StoredExecutionHistoryDocument["executions"][number]
+    );
+  else
+    executions[idx] =
+      execution as StoredExecutionHistoryDocument["executions"][number];
+  const next: StoredExecutionHistoryDocument = {
+    version: CURRENT_EXECUTION_STORAGE_VERSION,
+    executions,
+  };
+  saveExecutionHistoryDocument(walletAddress, next);
+  return next.executions as ExecutionRecord[];
+}
+
+export function findUnfinishedExecutions(
+  walletAddress: string
+): ExecutionRecord[] {
+  return listExecutions(walletAddress).filter(
+    (e) => e.status === "in_progress" || e.status === "paused-deviation"
+  );
+}

--- a/apps/web-app/src/lib/strategy/registry.ts
+++ b/apps/web-app/src/lib/strategy/registry.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+import {
+  UnknownStepDefinitionError,
+  type StepType,
+  type StrategyStepDefinition,
+  type ValidationIssue,
+} from "./types";
+
+function key(stepType: string, protocol: string): string {
+  return `${stepType}:${protocol}`;
+}
+
+/**
+ * Fallback definition for a (stepType, protocol) pair the registry doesn't
+ * recognize — a future app version's step type opened in an older build, or
+ * vice versa. Persistence keeps the step's raw data verbatim; this
+ * definition lets the rest of the engine (validation/simulation/composer
+ * UI) handle it gracefully instead of crashing or silently dropping user
+ * data.
+ */
+function createUnknownStepDefinition(
+  stepType: string,
+  protocol: string
+): StrategyStepDefinition {
+  const message = `Unrecognized step type "${stepType}:${protocol}" — this step is preserved but cannot be validated, simulated, or executed in this version of the app.`;
+
+  return {
+    stepType: stepType as StepType,
+    protocol,
+    submissionMode: "rpc",
+    paramsSchema: z.record(z.string(), z.unknown()),
+    describeOutputs: () => [],
+    validate: (): ValidationIssue[] => [
+      { stepId: null, severity: "error", code: "UNKNOWN_STEP_TYPE", message },
+    ],
+    simulate: async () => {
+      throw new Error(message);
+    },
+    prepare: async () => {
+      throw new Error(message);
+    },
+  };
+}
+
+/**
+ * Maps (stepType, protocol) -> StrategyStepDefinition. Mirrors
+ * lib/orchestrator/core/PoolRegistry.ts's register/resolve shape so the
+ * engine's validation/simulation/execution layers never import a concrete
+ * protocol — only this registry.
+ */
+export class StrategyStepRegistry {
+  private definitions = new Map<string, StrategyStepDefinition>();
+
+  register(definition: StrategyStepDefinition): void {
+    this.definitions.set(
+      key(definition.stepType, definition.protocol),
+      definition
+    );
+  }
+
+  /** Throws UnknownStepDefinitionError unless a fallback has been registered for the given key. */
+  resolve(
+    stepType: StepType | string,
+    protocol: string
+  ): StrategyStepDefinition {
+    const found = this.definitions.get(key(stepType, protocol));
+    if (!found) throw new UnknownStepDefinitionError(stepType, protocol);
+    return found;
+  }
+
+  tryResolve(
+    stepType: StepType | string,
+    protocol: string
+  ): StrategyStepDefinition | null {
+    return this.definitions.get(key(stepType, protocol)) ?? null;
+  }
+
+  /** Never throws — falls back to a graceful "unknown step" definition. */
+  resolveOrUnknown(
+    stepType: StepType | string,
+    protocol: string
+  ): StrategyStepDefinition {
+    return (
+      this.tryResolve(stepType, protocol) ??
+      createUnknownStepDefinition(stepType, protocol)
+    );
+  }
+
+  has(stepType: StepType | string, protocol: string): boolean {
+    return this.definitions.has(key(stepType, protocol));
+  }
+
+  listRegistered(): StrategyStepDefinition[] {
+    return [...this.definitions.values()];
+  }
+}
+
+export const strategyStepRegistry = new StrategyStepRegistry();
+export { createUnknownStepDefinition };

--- a/apps/web-app/src/lib/strategy/templates.ts
+++ b/apps/web-app/src/lib/strategy/templates.ts
@@ -1,0 +1,187 @@
+import type { Strategy } from "./types";
+
+/**
+ * The 4 built-in templates, as plain Strategy data (isTemplate: true) — not
+ * separate code paths. "Use Template" in the composer clones one of these
+ * into an editable draft (new id, isTemplate: false); the composer, the
+ * validator, the simulator, and the execution engine treat a cloned
+ * template exactly like any user-authored strategy.
+ */
+export const STRATEGY_TEMPLATES: Strategy[] = [
+  {
+    id: "template-swap-then-vault-deposit",
+    version: 1,
+    name: "Swap → Vault Deposit",
+    description:
+      "Swap an asset you're holding into a DeFindex vault's base asset, then deposit the proceeds in one composed strategy.",
+    isTemplate: true,
+    createdAt: 0,
+    updatedAt: 0,
+    steps: [
+      {
+        id: "swap",
+        type: "swap",
+        protocol: "soroswap",
+        label: "Swap",
+        dependsOn: [],
+        params: {
+          tokenIn: { source: "literal", value: "XLM" },
+          tokenOut: { source: "literal", value: "USDC" },
+          amountIn: { source: "literal", value: "100" },
+        },
+      },
+      {
+        id: "deposit",
+        type: "vaultDeposit",
+        protocol: "defindex",
+        label: "Vault Deposit",
+        dependsOn: ["swap"],
+        params: {
+          amount: {
+            source: "stepOutput",
+            stepId: "swap",
+            portId: "out.receivedAsset",
+          },
+        },
+      },
+    ],
+  },
+  {
+    id: "template-leveraged-supply",
+    version: 1,
+    name: "Leveraged Supply",
+    description:
+      "Supply an RWA asset as collateral, borrow against it, and re-supply the borrowed asset to amplify yield exposure.",
+    isTemplate: true,
+    createdAt: 0,
+    updatedAt: 0,
+    steps: [
+      {
+        id: "supply-collateral",
+        type: "supply",
+        protocol: "blend",
+        label: "Supply Collateral",
+        dependsOn: [],
+        params: {
+          mode: { source: "literal", value: "collateral" },
+          direction: { source: "literal", value: "deposit" },
+          poolContractId: { source: "literal", value: "" },
+          assetAddress: { source: "literal", value: "" },
+          amount: { source: "literal", value: "100" },
+        },
+      },
+      {
+        id: "borrow",
+        type: "borrow",
+        protocol: "blend",
+        label: "Borrow",
+        dependsOn: ["supply-collateral"],
+        params: {
+          poolContractId: { source: "literal", value: "" },
+          assetAddress: { source: "literal", value: "" },
+          amount: { source: "literal", value: "50" },
+        },
+      },
+      {
+        id: "resupply",
+        type: "supply",
+        protocol: "blend",
+        label: "Re-supply Borrowed Asset",
+        dependsOn: ["borrow"],
+        params: {
+          mode: { source: "literal", value: "supply" },
+          direction: { source: "literal", value: "deposit" },
+          poolContractId: { source: "literal", value: "" },
+          assetAddress: { source: "literal", value: "" },
+          amount: {
+            source: "stepOutput",
+            stepId: "borrow",
+            portId: "out.borrowedAsset",
+          },
+        },
+      },
+    ],
+  },
+  {
+    id: "template-position-unwind",
+    version: 1,
+    name: "Position Unwind",
+    description:
+      "Repay outstanding debt and withdraw the underlying collateral — the reverse of a leveraged position, composed from the same Repay and Supply(withdraw) step types.",
+    isTemplate: true,
+    createdAt: 0,
+    updatedAt: 0,
+    steps: [
+      {
+        id: "repay",
+        type: "repay",
+        protocol: "blend",
+        label: "Repay",
+        dependsOn: [],
+        params: {
+          poolContractId: { source: "literal", value: "" },
+          assetAddress: { source: "literal", value: "" },
+          amount: { source: "literal", value: "50" },
+        },
+      },
+      {
+        id: "withdraw-collateral",
+        type: "supply",
+        protocol: "blend",
+        label: "Withdraw Collateral",
+        dependsOn: ["repay"],
+        params: {
+          mode: { source: "literal", value: "collateral" },
+          direction: { source: "literal", value: "withdraw" },
+          poolContractId: { source: "literal", value: "" },
+          assetAddress: { source: "literal", value: "" },
+          amount: { source: "literal", value: "100" },
+        },
+      },
+    ],
+  },
+  {
+    id: "template-single-asset-liquidity",
+    version: 1,
+    name: "Single Asset Liquidity Position",
+    description:
+      "Start from one asset, swap half into its pair, and add both sides to a SoroSwap liquidity pool.",
+    isTemplate: true,
+    createdAt: 0,
+    updatedAt: 0,
+    steps: [
+      {
+        id: "swap-half",
+        type: "swap",
+        protocol: "soroswap",
+        label: "Swap Half",
+        dependsOn: [],
+        params: {
+          tokenIn: { source: "literal", value: "XLM" },
+          tokenOut: { source: "literal", value: "USDC" },
+          amountIn: { source: "literal", value: "50" },
+        },
+      },
+      {
+        id: "lp-add",
+        type: "lpAdd",
+        protocol: "soroswap",
+        label: "Add Liquidity",
+        dependsOn: ["swap-half"],
+        params: {
+          tokenA: { source: "literal", value: "XLM" },
+          tokenB: { source: "literal", value: "USDC" },
+          amount: {
+            source: "stepOutput",
+            stepId: "swap-half",
+            portId: "out.receivedAsset",
+          },
+        },
+      },
+    ],
+  },
+];
+
+export function findTemplate(id: string): Strategy | undefined {
+  return STRATEGY_TEMPLATES.find((t) => t.id === id);
+}

--- a/apps/web-app/src/lib/strategy/types.ts
+++ b/apps/web-app/src/lib/strategy/types.ts
@@ -1,0 +1,294 @@
+import type { z } from "zod";
+import type { RiskTier } from "@/features/borrowing/const/riskThresholds";
+
+// ─── Strategy model ──────────────────────────────────────────────────────────
+
+export type StepType =
+  | "swap"
+  | "supply"
+  | "borrow"
+  | "repay"
+  | "vaultDeposit"
+  | "vaultWithdraw"
+  | "lpAdd"
+  | "lpRemove";
+
+export type StepDirection = "deposit" | "withdraw";
+
+export type PortKind =
+  | "asset"
+  | "shares"
+  | "debtPosition"
+  | "collateralPosition"
+  | "lpPosition";
+
+/** A typed output port produced by a step, consumable by a later step's input binding. */
+export interface StepPort {
+  id: string;
+  assetCode: string | null;
+  kind: PortKind;
+}
+
+/**
+ * Binds a step's parameter to either a literal value the user typed, or an
+ * upstream step's output port. Resolved at simulate-time/prepare-time, never
+ * at edit-time — the composer only needs port compatibility, not protocol
+ * knowledge, to offer valid bindings.
+ */
+export type ParamBinding<T = unknown> =
+  | { source: "literal"; value: T }
+  | { source: "stepOutput"; stepId: string; portId: string };
+
+export interface StrategyStep {
+  id: string;
+  type: StepType;
+  protocol: string;
+  label: string;
+  params: Record<string, ParamBinding>;
+  /**
+   * Explicit upstream step ids. Kept separate from stepOutput bindings so
+   * validation can catch a *declared* dependency with no matching binding,
+   * and a binding that references an *undeclared* dependency.
+   */
+  dependsOn: string[];
+}
+
+export interface Strategy {
+  id: string;
+  /** Document schema version — see the persistence types below. Not the app version. */
+  version: number;
+  name: string;
+  description?: string;
+  isTemplate: boolean;
+  steps: StrategyStep[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ─── Step definition plugin interface ───────────────────────────────────────
+
+export interface TxResult {
+  xdr: string;
+  networkPassphrase: string;
+}
+
+export interface StepExecutionContext {
+  userAddress: string;
+  networkPassphrase: string;
+  /** ParamBindings already resolved to concrete values (literals or upstream outputs). */
+  resolvedParams: Record<string, unknown>;
+  /** stepId -> that step's StepProjection.outputs, for steps this one depends on. */
+  upstreamOutputs: Record<string, Record<string, unknown>>;
+}
+
+/**
+ * The plugin interface every protocol integration implements once per
+ * (stepType, protocol) pair. The engine (validation/simulation/execution)
+ * only ever talks to this interface via the registry — adding a protocol
+ * means adding a definition and registering it, never touching the engine.
+ */
+export interface StrategyStepDefinition<TParams = Record<string, unknown>> {
+  readonly stepType: StepType;
+  readonly protocol: string;
+  /** How prepare()'s xdr gets submitted — the engine branches on this once, centrally. */
+  readonly submissionMode: "rpc" | "soroswapApi";
+  readonly paramsSchema: z.ZodType<TParams>;
+
+  /** Declares this step's output ports so downstream steps can bind to them. */
+  describeOutputs(params: TParams): StepPort[];
+
+  /** Structural + protocol-specific validation for this step only. Empty array when valid. */
+  validate(ctx: StepExecutionContext): ValidationIssue[];
+
+  /** Off-chain financial projection. No signing, no submission. */
+  simulate(ctx: StepExecutionContext): Promise<StepProjection>;
+
+  /** Builds the unsigned tx for this step. */
+  prepare(ctx: StepExecutionContext): Promise<TxResult>;
+
+  /** Parses the actual on-chain result (post-confirm) for deviation checks. */
+  interpretResult?(
+    ctx: StepExecutionContext,
+    confirmedResult: unknown
+  ): Promise<Partial<StepProjection>>;
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+export type ValidationSeverity = "error" | "warning";
+
+export interface ValidationIssue {
+  /** The step this issue is about. Null for strategy-wide issues (e.g. a cycle spanning steps). */
+  stepId: string | null;
+  severity: ValidationSeverity;
+  code: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  issues: ValidationIssue[];
+}
+
+// ─── Simulation ──────────────────────────────────────────────────────────────
+
+export interface ResultingPosition {
+  protocol: string;
+  /**
+   * Collateral/debt deltas in the asset's OWN decimal units (not USD) —
+   * conversion to a common value basis happens centrally in the risk
+   * evaluator using live oracle prices, not per step definition.
+   */
+  collateralAssetCode?: string;
+  collateralDelta?: number;
+  debtAssetCode?: string;
+  debtDelta?: number;
+  collateralFactorPct?: number;
+  healthFactor?: number | null;
+  liquidationPrice?: number | null;
+}
+
+export interface StepProjection {
+  /** portId -> projected value, consumed by downstream steps as upstreamOutputs. */
+  outputs: Record<string, unknown>;
+  /** assetCode -> projected balance (decimal string), for steps that move wallet-held assets. */
+  resultingBalances?: Record<string, string>;
+  resultingPosition?: ResultingPosition;
+  /** Decimal string, native asset units. */
+  estimatedFee: string;
+  slippageBps?: number;
+  projectedApyDelta?: number;
+  warnings: string[];
+}
+
+export interface StrategyProjection {
+  success: boolean;
+  /** Set when success is false — the step whose simulate() failed or couldn't resolve inputs. */
+  failedStepId?: string;
+  failureReason?: string;
+  steps: Record<string, StepProjection>;
+  cumulativeFee: string;
+  cumulativeSlippageBps: number;
+  projectedApy: number | null;
+  effectiveLeverage: number | null;
+  projectedHealthFactor: number | null;
+  projectedLiquidationPrice: number | null;
+}
+
+export interface SensitivityScenario {
+  label: string;
+  slippageMultiplier: number;
+  priceShockPct: number;
+  projection: StrategyProjection;
+}
+
+// ─── Execution ───────────────────────────────────────────────────────────────
+
+export type StepExecutionStatus =
+  | "pending"
+  | "preparing"
+  | "awaiting_signature"
+  | "submitting"
+  | "confirming"
+  | "completed"
+  | "failed"
+  | "paused_deviation"
+  | "cancelled";
+
+export interface DeviationReport {
+  deviated: boolean;
+  /** Relative deviation, e.g. 0.05 = 5% off projection. */
+  relativeDeviation: number | null;
+  threshold: number;
+  message?: string;
+}
+
+export interface ExecutionStepRecord {
+  stepId: string;
+  status: StepExecutionStatus;
+  txHash?: string;
+  submittedAt?: number;
+  confirmedAt?: number;
+  actualOutputs?: Record<string, unknown>;
+  deviation?: DeviationReport;
+  errorMessage?: string;
+}
+
+export type ExecutionStatus =
+  | "in_progress"
+  | "completed"
+  | "failed"
+  | "paused-deviation"
+  | "abandoned";
+
+export interface ExecutionRecord {
+  id: string;
+  strategyId: string;
+  strategySnapshot: unknown; // Strategy at the time execution started
+  status: ExecutionStatus;
+  startedAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  projectedOutcome: unknown; // StrategyProjection snapshot
+  actualOutcome?: unknown;
+  steps: ExecutionStepRecord[];
+}
+
+// ─── Persistence ─────────────────────────────────────────────────────────────
+
+export interface StrategyStorageSchema {
+  version: number;
+  strategies: Strategy[];
+}
+
+export interface ExecutionHistoryStorageSchema {
+  version: number;
+  executions: ExecutionRecord[];
+}
+
+// ─── Risk ────────────────────────────────────────────────────────────────────
+
+export interface RiskAssessment {
+  effectiveLeverage: number | null;
+  projectedHealthFactor: number | null;
+  projectedLiquidationPrice: number | null;
+  cumulativeSlippageBps: number;
+  riskTier: RiskTier;
+  /** protocol -> notional exposure. */
+  protocolExposure: Record<string, number>;
+}
+
+export interface RiskThresholdConfig {
+  minHealthFactor: number;
+  maxLeverage: number;
+  maxCumulativeSlippageBps: number;
+  /** Per step-type override of the guided-execution deviation-pause threshold (relative, e.g. 0.03). */
+  deviationThresholds: Partial<Record<string, number>>;
+  defaultDeviationThreshold: number;
+}
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+
+export class StrategyEngineError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "StrategyEngineError";
+  }
+}
+
+export class UnknownStepDefinitionError extends StrategyEngineError {
+  constructor(
+    public readonly stepType: string,
+    public readonly protocol: string
+  ) {
+    super(`No step definition registered for ${stepType}:${protocol}`);
+    this.name = "UnknownStepDefinitionError";
+  }
+}
+
+export class CircularDependencyError extends StrategyEngineError {
+  constructor(public readonly stepIds: string[]) {
+    super(`Circular dependency detected among steps: ${stepIds.join(", ")}`);
+    this.name = "CircularDependencyError";
+  }
+}

--- a/apps/web-app/vitest.config.ts
+++ b/apps/web-app/vitest.config.ts
@@ -12,11 +12,19 @@ import { defineConfig } from "vitest/config";
  * `it` / `expect` / `vi` explicitly. React-hook tests opt into the jsdom
  * environment per-file with a `// @vitest-environment jsdom` docblock, so the
  * default (node) stays fast for the pure-logic and adapter suites.
+ *
+ * `esbuild.jsx` overrides the `jsx: "preserve"` this project's shared
+ * tsconfig sets for Next.js's own SWC-based build pipeline — Vitest's
+ * esbuild transform needs an actual JSX transform (not "preserve") to parse
+ * `.tsx` component tests, which this config previously had no need to run.
  */
 export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
+  },
+  oxc: {
+    jsx: { runtime: "automatic" },
   },
 });


### PR DESCRIPTION
## Summary Closes #265

Replaces the pattern of isolated, per-protocol DeFi workflows with a
protocol-agnostic **Unified DeFi Strategy Engine**: a typed step model,
a validator, a simulator with automatic output propagation, a
risk-evaluation layer, a guided step-by-step executor with deviation
detection and crash recovery, and versioned persistence — all driven by
a common `StrategyStepDefinition` plugin interface, plus a Composer UI
surfaced as a new **"Strategies"** entry in the sidebar.

Closes #265

## Why

Neko already integrates SoroSwap, RWA Lending (Neko + Blend), DeFindex
vaults, and Soroswap LPs, but each is exposed as an isolated workflow.
A user who wants to run a common cross-protocol strategy (swap → vault
deposit, leveraged supply, position unwind, single-asset LP entry) has
to manually chain separate screens with no way to preview the combined
outcome, no way to resume an interrupted multi-step flow, and no way to
save the sequence for reuse. This PR moves that composition logic out of
one-off feature hooks and into one protocol-agnostic engine driven by a
step-definition registry, mirroring the pattern the existing
`lib/orchestrator/` pool registry already established for single-action
pool operations.

## What was built

`src/lib/strategy/` — the engine core:

| File | What it contains |
|---|---|
| `types.ts` | Every type contract: `Strategy`/`StrategyStep`/`ParamBinding` (the model — steps bind params to either a literal value or an upstream step's output port), `StrategyStepDefinition` (the plugin interface every protocol implements once per `(stepType, protocol)` pair), `ValidationIssue`/`StepProjection`/`StrategyProjection`, `ExecutionRecord`/`ExecutionStepRecord`/`DeviationReport`, `RiskAssessment`/`RiskThresholdConfig`, the persistence document shapes, and the engine's error classes |
| `registry.ts` | `StrategyStepRegistry` (register/resolve/tryResolve/resolveOrUnknown), mirroring `lib/orchestrator/core/PoolRegistry.ts`'s shape. `resolveOrUnknown` never throws — an unrecognized `(stepType, protocol)` falls back to a graceful definition that reports a clear validation error instead of crashing or dropping the step |
| `definitions.ts` | The 11 built-in `(stepType, protocol)` definitions — `swap` (SoroSwap), `supply`/`borrow`/`repay` (Neko, Blend), `vaultDeposit`/`vaultWithdraw` (DeFindex), `lpAdd`/`lpRemove` (SoroSwap) — each wrapping an existing helper/adapter rather than reimplementing tx-building logic. `registerBuiltInStepDefinitions()` is the only place that touches the registry; adding a protocol means adding one definition and one registration line here, nothing else |
| `engine.ts` | `topologicalSort` (Kahn's-algorithm cycle detection), `validateStrategy`/`validateBalances` (dependency/binding/protocol validation, every issue names the exact failing step), `simulateStrategy`/`aggregateProjection`/`computeSensitivity` (walks steps in dependency order, feeding each step's projected output forward as the next step's input — automatic output propagation), `evaluateRisk`/`computeProtocolExposure`/`exceedsThresholds` (reuses the existing `features/borrowing` health-factor/liquidation-price math rather than reimplementing it) |
| `persistence.ts` | Zod schemas that keep a stored step's `type`/`protocol` as plain strings (forward-compatible with a future step type this build doesn't recognize yet), a `migrateDocument` migration framework (version travels inside the payload, not the storage key, so old data upgrades in place instead of being orphaned), and versioned localStorage CRUD for strategies and execution history |
| `execution.ts` | `checkDeviation` (compares actual vs. projected step output against a per-step-type threshold), `ExecutionEngine` (framework-agnostic prepare → sign → submit → confirm sequence via an injected transport per submission mode; resumable — already-completed steps are skipped, a deviation-paused step is only advanced past once explicitly acknowledged, and never re-submitted), `reconcileExecution`/`findResumableExecutions` (re-polls the chain for any step still in flight when the app reopens) |
| `hooks.ts` | `useStrategyDefinitions`, `useStrategyValidation`, `useStrategySimulation`, `useStrategyPersistence`, `useStrategyExecution` (wires the real `rpc.Server`/SoroSwap-API transports into `ExecutionEngine`), `useExecutionRecovery` (runs reconciliation on mount) |
| `templates.ts` | The 4 spec'd templates (Swap → Vault Deposit, Leveraged Supply, Position Unwind, Single Asset Liquidity Position) as plain `Strategy` data (`isTemplate: true`) — "Use Template" clones the data, there's no separate template code path |

`src/features/strategies/` — the Composer UI:

| File | What it contains |
|---|---|
| `components/Strategies.tsx` | The page (My Strategies / Templates / Execution History tabs, wallet-gated), `StrategyList`, `TemplatePicker`, `ExecutionHistoryTable`, `ResumeExecutionBanner` |
| `components/StrategyComposer.tsx` | `StepPalette`, `StepCard` (keyboard-operable Move Up/Down + Remove — no drag-and-drop dependency, the standard accessible pattern for reorderable lists), `PortBindingEditor`/`StepParamsForm` (native `<select>`/`<input>`, screen-reader friendly by default), `ValidationPanel`, and the composer itself, which gates the Execute button behind a risk-acknowledgement modal when the projected assessment exceeds the configured thresholds |
| `components/ExecutionUI.tsx` | `SimulationSummary`, `SensitivityPanel` (slippage/price-shock scenario table), `RiskAcknowledgementModal`, `ExecutionProgress` (per-step prepare/sign/submit/confirm status), `DeviationPauseModal` |
| `hooks.ts` | `useStrategyComposerState` (local draft add/remove/reorder/rename; removing a step prunes any dangling downstream binding), `createEmptyStrategy`, `cloneAsEditable` |
| `utils.ts` | Tab config + number/percentage/bps/multiplier formatting helpers |

Each file above (both tables) has a matching `__tests__/*.test.ts(x)` file.

## Integration changes outside `strategy/`

- **`lib/orchestrator/adapters/NekoLendingAdapter.ts`** — adds `borrow`,
  `repay`, `supplyCollateral`, `withdrawCollateral`. The adapter only had
  `deposit`/`withdraw` even though `lending.ts` already exported the
  underlying `borrowFromPool`/`repayPool`/`addCollateral`/
  `removeCollateral` helpers — a real, pre-existing gap that also blocked
  `usePoolAction`/the orchestrator, not just this feature. Required for
  the Borrow/Repay/Supply(collateral) step types to work against Neko,
  not only Blend. Covered by 9 new test cases in the existing adapter
  test file.
- **`app/(app)/strategies/page.tsx` + `loading.tsx`** — new route,
  mirrors the `vaults` route's minimal pattern (metadata + render the
  feature component; shared chrome comes from `app/(app)/layout.tsx`).
- **`components/navigation/sidebarConfig.ts`** — adds the "Strategies"
  nav entry (`Workflow` icon from lucide-react).
- **`vitest.config.ts`** — adds `oxc.jsx` runtime config. No `.tsx`
  component test existed anywhere in this repo before this PR (only
  `renderHook`-based hook tests, which need no JSX transform); the
  shared tsconfig sets `jsx: "preserve"` for Next's own SWC pipeline,
  which Vitest's transform can't parse as-is.

## Acceptance criteria coverage

- [x] Users can compose reusable multi-step strategies using supported protocol actions — `StrategyComposer.tsx` + `useStrategyComposerState`
- [x] Strategy validation detects invalid workflows before execution — `validateStrategy` (`engine.test.ts`)
- [x] Strategy simulations produce complete execution projections before any transaction is signed — `simulateStrategy` never signs/submits, only calls each definition's `simulate()`
- [x] Projected outputs propagate automatically through every downstream strategy step — `simulateStrategy`'s upstream-output feed-forward (`engine.test.ts`)
- [x] Guided execution processes each strategy step sequentially while validating execution results — `ExecutionEngine.executeStrategy` + `checkDeviation` (`execution.test.ts`)
- [x] Interrupted executions can be resumed after reopening the application — `reconcileExecution` + `findResumableExecutions` + `ResumeExecutionBanner` (`execution.test.ts`)
- [x] Reusable strategies can be saved, edited, and executed multiple times — `useStrategyPersistence` (`hooks.test.ts`)
- [x] Strategy execution history records both projected and actual execution outcomes — `ExecutionRecord.projectedOutcome`/`actualOutputs` per step (`persistence.test.ts`)
- [x] Adding a new protocol requires implementing only the corresponding strategy step definitions without modifying the strategy engine — proven by `registerBuiltInStepDefinitions()` being the only registry touchpoint across all 11 definitions
- [x] Unknown strategy step types are handled gracefully without breaking previously saved strategies — `resolveOrUnknown` + forward-compatible zod schema (`registry.test.ts`, `persistence.test.ts`)
- [x] Comprehensive unit, integration, and interaction tests validate strategy composition, execution, persistence, recovery, and simulation — 267 tests across 23 files
- [x] All strategy interfaces remain responsive, keyboard accessible, and screen-reader friendly — keyboard-operable reorder buttons, native form controls, `aria-label`/`aria-expanded`/`role` throughout (`StrategyComposer.test.tsx`, `ExecutionUI.test.tsx`)

One capability is deliberately incomplete rather than faked: **LP Remove**
on SoroSwap has no underlying removal API in this codebase
(`SoroswapPoolAdapter.withdraw` already threw `UnsupportedActionError`
before this PR). `lpRemoveSoroswapDefinition` is registered but its
`validate()` always fails with a named, step-scoped message — a real
demonstration of the "unsupported protocol combinations" validation
requirement rather than a workaround.

## Test plan

- `npm test` — 267 tests passing across 23 files
- `npx tsc --noEmit` — no new type errors introduced
- `npx eslint` — no new lint errors introduced
- Manually verified: started the dev server and confirmed `/strategies`
  returns 200 and renders the wallet-gate screen ("Connect your wallet to
  build and run strategies"), and that the "Strategies" link appears in
  the sidebar nav on `/dashboard`. Full authenticated flows (composing a
  template, simulating, executing on testnet) were not exercised in this
  session — recommend a manual pass with a connected Freighter testnet
  wallet before merge.
