### PR TITLE
Feat/unified activity feed

### DIFF
--- a/apps/web-app/src/app/(app)/activity/page.tsx
+++ b/apps/web-app/src/app/(app)/activity/page.tsx
@@ -1,0 +1,5 @@
+import { ActivityFeedPage } from "@/features/activity/components/pages/ActivityFeedPage";
+
+export default function ActivityPage() {
+  return <ActivityFeedPage />;
+}

--- a/apps/web-app/src/components/navigation/MobileHeader.tsx
+++ b/apps/web-app/src/components/navigation/MobileHeader.tsx
@@ -4,12 +4,14 @@ import React, { useState, useEffect, useRef, useMemo } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import { X, Menu, LogOut, ChevronDown } from "lucide-react";
+import { X, Menu, LogOut, ChevronDown, Bell } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { NAV_ITEMS } from "./sidebarConfig";
 import { useWalletType } from "@/hooks/useWalletType";
 import { useStellarWallet } from "@/hooks/useStellarWallet";
+import { useStellarWallet } from "@/hooks/useStellarWallet";
 import { truncateAddress } from "@/lib/utils";
+import { useActivityFeed } from "@/features/activity/hooks/useActivityFeed";
 
 const NETWORK = (
   process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "TESTNET"
@@ -23,6 +25,7 @@ export function MobileHeader() {
   const pathname = usePathname();
   const { isStellarConnected, stellarAddress } = useWalletType();
   const { connect, disconnect } = useStellarWallet();
+  const { unreadCount } = useActivityFeed();
   const menuRef = useRef<HTMLDivElement>(null);
   const walletButtonRef = useRef<HTMLDivElement>(null);
 
@@ -146,7 +149,19 @@ export function MobileHeader() {
             )}
           </div>
 
-          <div className="min-w-0 justify-end">
+          <div className="min-w-0 justify-end flex items-center gap-1 sm:gap-2">
+            <Link
+              href="/activity"
+              className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-white transition-colors hover:bg-white/10 sm:h-12 sm:w-12"
+            >
+              <Bell className="h-5 w-5 sm:h-6 sm:w-6" />
+              {unreadCount > 0 && (
+                <span className="absolute top-2 right-2 flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-blue-500 text-[9px] font-bold text-white border-2 border-[#121212]">
+                  {unreadCount > 99 ? "99+" : unreadCount}
+                </span>
+              )}
+            </Link>
+
             <button
               type="button"
               onClick={() => setIsOpen((v) => !v)}
@@ -207,7 +222,14 @@ export function MobileHeader() {
                     active ? "text-white" : "text-white/35"
                   )}
                 />
-                {label}
+                <div className="flex items-center justify-between w-full">
+                  <span>{label}</span>
+                  {label === "Activity" && unreadCount > 0 && (
+                    <span className="flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-blue-500 text-[10px] font-bold text-white">
+                      {unreadCount > 99 ? "99+" : unreadCount}
+                    </span>
+                  )}
+                </div>
               </Link>
             );
           })}

--- a/apps/web-app/src/components/navigation/NavItem.tsx
+++ b/apps/web-app/src/components/navigation/NavItem.tsx
@@ -7,17 +7,22 @@ interface NavItemProps {
   href: string;
   icon: React.ElementType;
   isActive: boolean;
+  badge?: number;
 }
 
-export function NavItem({ label, href, icon: Icon, isActive }: NavItemProps) {
+export function NavItem({
+  label,
+  href,
+  icon: Icon,
+  isActive,
+  badge,
+}: NavItemProps) {
   return (
     <Link
       href={href}
       className={cn(
         "flex items-center gap-3 px-4 py-3 text-base font-medium transition-colors duration-150",
-        isActive
-          ? "text-white"
-          : "text-white/35 hover:text-white/65"
+        isActive ? "text-white" : "text-white/35 hover:text-white/65"
       )}
       style={
         isActive
@@ -31,7 +36,14 @@ export function NavItem({ label, href, icon: Icon, isActive }: NavItemProps) {
           isActive ? "text-white" : "text-white/35"
         )}
       />
-      {label}
+      <div className="flex items-center justify-between w-full">
+        <span>{label}</span>
+        {!!badge && badge > 0 && (
+          <span className="flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-blue-500 text-[10px] font-bold text-white ml-2">
+            {badge > 99 ? "99+" : badge}
+          </span>
+        )}
+      </div>
     </Link>
   );
 }

--- a/apps/web-app/src/components/navigation/Sidebar.tsx
+++ b/apps/web-app/src/components/navigation/Sidebar.tsx
@@ -9,6 +9,7 @@ import { SidebarLogo } from "./SidebarLogo";
 import { NavItem } from "./NavItem";
 import { ConnectedCard } from "./ConnectedCard";
 import { SetupCard } from "./SetupCard";
+import { useActivityFeed } from "@/features/activity/hooks/useActivityFeed";
 
 export const SIDEBAR_WIDTH = "270px";
 
@@ -18,6 +19,7 @@ export function Sidebar() {
   const pathname = usePathname();
   const { isStellarConnected, stellarAddress } = useWalletType();
   const { disconnect: disconnectStellar } = useStellarWallet();
+  const { unreadCount } = useActivityFeed();
 
   const isConnected = isStellarConnected;
   const activeAddress = stellarAddress ?? "";
@@ -54,6 +56,7 @@ export function Sidebar() {
             href={href}
             icon={icon}
             isActive={isActive(href)}
+            badge={label === "Activity" ? unreadCount : undefined}
           />
         ))}
       </nav>

--- a/apps/web-app/src/components/navigation/sidebarConfig.ts
+++ b/apps/web-app/src/components/navigation/sidebarConfig.ts
@@ -10,6 +10,7 @@ import {
   TrendingUp,
   PieChart,
   Zap,
+  Bell,
 } from "lucide-react";
 
 export const NAV_ITEMS = [
@@ -22,6 +23,7 @@ export const NAV_ITEMS = [
   { label: "Vault", href: "/vaults", icon: Vault },
   { label: "Analytics", href: "/analytics", icon: PieChart },
   { label: "Automation", href: "/automation", icon: Zap },
+  { label: "Activity", href: "/activity", icon: Bell },
   { label: "Ramps", href: "/ramps", icon: Banknote },
   { label: "Settings", href: "/settings", icon: Settings },
   { label: "Admin", href: "/dashboard/admin", icon: Shield, adminOnly: true },

--- a/apps/web-app/src/features/activity/components/pages/ActivityFeedPage.tsx
+++ b/apps/web-app/src/features/activity/components/pages/ActivityFeedPage.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import {
+  useActivityFeed,
+  type ActivityFilters,
+} from "../../hooks/useActivityFeed";
+import { ActivityFeedItem } from "../ui/ActivityFeedItem";
+import { ActivityFiltersControl } from "../ui/ActivityFilters";
+import { useWalletType } from "@/hooks/useWalletType";
+import { Check } from "lucide-react";
+
+export function ActivityFeedPage() {
+  const { isStellarConnected } = useWalletType();
+  const [filters, setFilters] = useState<ActivityFilters>({
+    sources: [],
+    dateRange: "all",
+  });
+
+  const { events, unreadCount, markAllRead } = useActivityFeed(filters);
+
+  if (!isStellarConnected) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[50vh] text-center p-6">
+        <h2 className="text-2xl font-bold font-klein text-white mb-2">
+          Activity Feed
+        </h2>
+        <p className="text-white/60">
+          Connect your wallet to see your activity across Neko DApp.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-4xl mx-auto p-4 sm:p-6 lg:p-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
+        <div>
+          <h1 className="text-3xl font-bold font-klein text-white tracking-tight">
+            Activity Feed
+          </h1>
+          <p className="text-white/60 mt-1">
+            Track your limit orders, automation strategies, and vault
+            transactions.
+          </p>
+        </div>
+
+        {unreadCount > 0 && (
+          <button
+            onClick={markAllRead}
+            className="flex items-center gap-2 px-4 py-2 bg-white/5 hover:bg-white/10 text-white text-sm rounded-lg transition-colors border border-white/5"
+          >
+            <Check className="w-4 h-4" />
+            Mark all as read ({unreadCount})
+          </button>
+        )}
+      </div>
+
+      <ActivityFiltersControl filters={filters} onChange={setFilters} />
+
+      <div className="flex flex-col gap-3">
+        {events.length === 0 ? (
+          <div className="text-center py-12 px-4 border border-dashed border-white/10 rounded-2xl bg-white/5">
+            <p className="text-white/60">No activity matches your filters.</p>
+          </div>
+        ) : (
+          events.map((event) => (
+            <ActivityFeedItem key={event.id} event={event} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-app/src/features/activity/components/ui/ActivityFeedItem.tsx
+++ b/apps/web-app/src/features/activity/components/ui/ActivityFeedItem.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeftRight, Zap, Vault, ExternalLink } from "lucide-react";
+import type { ActivityEvent } from "../../types/activityEvent";
+import { useActivityStore } from "@/stores/activityStore";
+import { formatDistanceToNow } from "date-fns";
+
+const SOURCE_ICONS = {
+  swap: ArrowLeftRight,
+  automation: Zap,
+  vault: Vault,
+};
+
+const SOURCE_COLORS = {
+  swap: "text-blue-400 border-blue-400",
+  automation: "text-amber-400 border-amber-400",
+  vault: "text-green-400 border-green-400",
+};
+
+export function ActivityFeedItem({ event }: { event: ActivityEvent }) {
+  const markRead = useActivityStore((state) => state.markRead);
+  const Icon = SOURCE_ICONS[event.source] || ExternalLink;
+  const colorClass =
+    SOURCE_COLORS[event.source] || "text-gray-400 border-gray-400";
+
+  const timeAgo = formatDistanceToNow(event.timestamp, { addSuffix: true });
+
+  return (
+    <Link
+      href={event.link}
+      onClick={() => {
+        if (!event.read) markRead(event.id);
+      }}
+      className="group flex items-start gap-4 p-4 rounded-xl bg-[#1a1a1a] border border-white/5 hover:border-white/20 transition-colors relative"
+    >
+      {!event.read && (
+        <div className="absolute top-4 right-4 w-2 h-2 rounded-full bg-blue-500" />
+      )}
+
+      <div
+        className={`p-2 rounded-lg bg-[#2a2a2a] border ${colorClass.split(" ")[1]}`}
+      >
+        <Icon className={`w-5 h-5 ${colorClass.split(" ")[0]}`} />
+      </div>
+
+      <div className="flex-1 min-w-0 pr-4">
+        <p className="text-sm text-white/60 mb-1">{timeAgo}</p>
+        <p className="text-base text-white font-medium">{event.summary}</p>
+        <div className="mt-2 text-sm text-white/40 capitalize">
+          {event.source} • {event.type.replace(/-/g, " ")}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web-app/src/features/activity/components/ui/ActivityFilters.tsx
+++ b/apps/web-app/src/features/activity/components/ui/ActivityFilters.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { ActivityFilters } from "../../hooks/useActivityFeed";
+
+interface ActivityFiltersProps {
+  filters: ActivityFilters;
+  onChange: (filters: ActivityFilters) => void;
+}
+
+export function ActivityFiltersControl({
+  filters,
+  onChange,
+}: ActivityFiltersProps) {
+  const sources = [
+    { value: "swap", label: "Swap" },
+    { value: "automation", label: "Automation" },
+    { value: "vault", label: "Vault" },
+  ];
+
+  const dateRanges = [
+    { value: "today", label: "Today" },
+    { value: "7d", label: "Last 7 Days" },
+    { value: "30d", label: "Last 30 Days" },
+    { value: "all", label: "All Time" },
+  ];
+
+  const toggleSource = (source: "swap" | "automation" | "vault") => {
+    const currentSources = filters.sources || [];
+    let newSources: ("swap" | "automation" | "vault")[];
+
+    if (currentSources.includes(source)) {
+      newSources = currentSources.filter((s) => s !== source);
+    } else {
+      newSources = [...currentSources, source];
+    }
+
+    onChange({ ...filters, sources: newSources });
+  };
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center justify-between mb-6">
+      <div className="flex flex-wrap gap-2">
+        {sources.map((source) => {
+          const isActive = (filters.sources || []).includes(
+            source.value as any
+          );
+          return (
+            <button
+              key={source.value}
+              onClick={() => toggleSource(source.value as any)}
+              className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
+                isActive
+                  ? "bg-white text-black font-medium"
+                  : "bg-white/5 text-white/60 hover:bg-white/10"
+              }`}
+            >
+              {source.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex bg-white/5 rounded-lg p-1">
+        {dateRanges.map((range) => {
+          const isActive = (filters.dateRange || "all") === range.value;
+          return (
+            <button
+              key={range.value}
+              onClick={() =>
+                onChange({ ...filters, dateRange: range.value as any })
+              }
+              className={`px-3 py-1 text-sm rounded-md transition-colors ${
+                isActive
+                  ? "bg-[#2a2a2a] text-white"
+                  : "text-white/40 hover:text-white/80"
+              }`}
+            >
+              {range.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-app/src/features/activity/hooks/useActivityFeed.ts
+++ b/apps/web-app/src/features/activity/hooks/useActivityFeed.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useMemo } from "react";
+import { useActivityStore } from "@/stores/activityStore";
+import { useStellarWalletStore } from "@/stores/stellarWalletStore";
+
+export interface ActivityFilters {
+  sources?: ("swap" | "automation" | "vault")[];
+  dateRange?: "today" | "7d" | "30d" | "all";
+}
+
+export function useActivityFeed(filters?: ActivityFilters) {
+  const address = useStellarWalletStore((state) => state.address);
+  const eventsByWallet = useActivityStore((state) => state.eventsByWallet);
+  const markAllRead = useActivityStore((state) => state.markAllRead);
+  const markRead = useActivityStore((state) => state.markRead);
+
+  const allEvents = useMemo(() => {
+    if (!address) return [];
+    return eventsByWallet[address] || [];
+  }, [address, eventsByWallet]);
+
+  const filteredEvents = useMemo(() => {
+    let result = allEvents;
+    const now = Date.now();
+
+    if (filters?.sources && filters.sources.length > 0) {
+      const allowedSources = new Set(filters.sources);
+      result = result.filter((e) => allowedSources.has(e.source));
+    }
+
+    if (filters?.dateRange && filters.dateRange !== "all") {
+      let msRange = 0;
+      if (filters.dateRange === "today") msRange = 24 * 60 * 60 * 1000;
+      else if (filters.dateRange === "7d") msRange = 7 * 24 * 60 * 60 * 1000;
+      else if (filters.dateRange === "30d") msRange = 30 * 24 * 60 * 60 * 1000;
+
+      result = result.filter((e) => now - e.timestamp <= msRange);
+    }
+
+    return result;
+  }, [allEvents, filters]);
+
+  const unreadCount = useMemo(() => {
+    return allEvents.filter((e) => !e.read).length;
+  }, [allEvents]);
+
+  return {
+    events: filteredEvents,
+    allEvents,
+    unreadCount,
+    markAllRead,
+    markRead,
+  };
+}

--- a/apps/web-app/src/features/activity/types/activityEvent.ts
+++ b/apps/web-app/src/features/activity/types/activityEvent.ts
@@ -1,0 +1,10 @@
+export interface ActivityEvent {
+  id: string; // UUID
+  source: "swap" | "automation" | "vault"; // extensible union
+  type: string; // e.g. "limit-order-ready", "limit-order-expired", "plan-confirmed", "plan-cancelled", "deposit", "withdraw"
+  timestamp: number; // UTC ms
+  summary: string; // Human-readable description
+  link: string; // Route to navigate to (e.g. "/swap", "/automation")
+  metadata?: Record<string, string | number | boolean | null>; // Optional extra data
+  read: boolean; // Has user seen this?
+}

--- a/apps/web-app/src/features/automation/hooks/useExecutionQueue.ts
+++ b/apps/web-app/src/features/automation/hooks/useExecutionQueue.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { RebalancePlan } from "../types/automation";
 import { STRATEGY_QUERY_KEYS } from "../const/automation";
+import { useActivityStore } from "@/stores/activityStore";
 
 async function fetchQueue(strategyId: string): Promise<RebalancePlan[]> {
   const res = await fetch(`/api/automation/execute?strategyId=${strategyId}`);
@@ -40,6 +41,13 @@ export function useConfirmPlan() {
       return res.json() as Promise<RebalancePlan>;
     },
     onSuccess: (_data, { strategyId }) => {
+      useActivityStore.getState().pushEvent({
+        source: "automation",
+        type: "plan-confirmed",
+        timestamp: Date.now(),
+        summary: "Strategy execution plan confirmed",
+        link: "/automation",
+      });
       qc.invalidateQueries({ queryKey: STRATEGY_QUERY_KEYS.queue(strategyId) });
       qc.invalidateQueries({
         queryKey: STRATEGY_QUERY_KEYS.simulate(strategyId),
@@ -66,6 +74,13 @@ export function useCancelPlan() {
       if (!res.ok) throw new Error("Failed to cancel plan");
     },
     onSuccess: (_data, { strategyId }) => {
+      useActivityStore.getState().pushEvent({
+        source: "automation",
+        type: "plan-cancelled",
+        timestamp: Date.now(),
+        summary: "Strategy execution plan cancelled",
+        link: "/automation",
+      });
       qc.invalidateQueries({ queryKey: STRATEGY_QUERY_KEYS.queue(strategyId) });
     },
   });

--- a/apps/web-app/src/features/swap/hooks/useLimitOrderMonitor.ts
+++ b/apps/web-app/src/features/swap/hooks/useLimitOrderMonitor.ts
@@ -20,6 +20,7 @@ import {
 import type { UseLimitOrdersReturn } from "./useLimitOrders";
 import type { LimitOrder } from "../types/limitOrder";
 import type { Token } from "@/lib/helpers/stellar/soroswap";
+import { useActivityStore } from "@/stores/activityStore";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -135,6 +136,13 @@ export function useLimitOrderMonitor({
       // ── Expiry check ────────────────────────────────────────────────────
       if (order.expiresAt !== null && now >= order.expiresAt) {
         markExpired(order.id);
+        useActivityStore.getState().pushEvent({
+          source: "swap",
+          type: "limit-order-expired",
+          timestamp: Date.now(),
+          summary: `Limit order expired: Sell ${order.amountIn} ${order.tokenInSymbol} for ${order.tokenOutSymbol}`,
+          link: "/swap",
+        });
         continue;
       }
 
@@ -173,6 +181,13 @@ export function useLimitOrderMonitor({
 
         if (confirmations >= LIMIT_ORDER_CONFIRM_POLLS) {
           markReady(order.id);
+          useActivityStore.getState().pushEvent({
+            source: "swap",
+            type: "limit-order-ready",
+            timestamp: Date.now(),
+            summary: `Limit order ready: Sell ${order.amountIn} ${order.tokenInSymbol} for ${order.tokenOutSymbol}`,
+            link: "/swap",
+          });
           onOrderReadyRef.current?.(order);
         }
       } else {

--- a/apps/web-app/src/features/vault/hooks/useVaultAction.ts
+++ b/apps/web-app/src/features/vault/hooks/useVaultAction.ts
@@ -20,6 +20,7 @@ import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors
 import { toSmallestUnit } from "@/lib/helpers/tokenUtils";
 import { useVaultBalance } from "./useVaultBalance";
 import { useVaultData } from "./useVaultData";
+import { useActivityStore } from "@/stores/activityStore";
 
 const VAULT_CONTRACT_ID =
   "CBHGX6TCHHVYJ7P3UZS7WI5TRAAA7GQA2L2Y7P2LCPIXWWD5FKDF2Z5S";
@@ -124,6 +125,13 @@ export function useVaultAction() {
 
         await new Promise((r) => setTimeout(r, 3000));
         await Promise.all([refetchBalance(), refetchVaultData()]);
+        useActivityStore.getState().pushEvent({
+          source: "vault",
+          type: "deposit",
+          timestamp: Date.now(),
+          summary: `Deposited ${amount} CETES to vault`,
+          link: "/vaults",
+        });
         showSuccess(`Successfully deposited ${amount} CETES`);
       } catch (err) {
         const msg = extractContractErrorOrNull(err);
@@ -178,6 +186,13 @@ export function useVaultAction() {
 
         await new Promise((r) => setTimeout(r, 3000));
         await Promise.all([refetchBalance(), refetchVaultData()]);
+        useActivityStore.getState().pushEvent({
+          source: "vault",
+          type: "withdraw",
+          timestamp: Date.now(),
+          summary: `Withdrew ${shares} dfTokens from vault`,
+          link: "/vaults",
+        });
         showSuccess(`Successfully withdrew ${shares} dfTokens`);
       } catch (err) {
         const msg = extractContractErrorOrNull(err);

--- a/apps/web-app/src/stores/activityStore.ts
+++ b/apps/web-app/src/stores/activityStore.ts
@@ -1,0 +1,98 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { ActivityEvent } from "../features/activity/types/activityEvent";
+import { useStellarWalletStore } from "./stellarWalletStore";
+
+export interface ActivityState {
+  eventsByWallet: Record<string, ActivityEvent[]>;
+  pushEvent: (event: Omit<ActivityEvent, "id" | "read">) => void;
+  markAllRead: () => void;
+  markRead: (id: string) => void;
+  clearEvents: () => void; // Clears for current wallet
+}
+
+const MAX_EVENTS = 500;
+const MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+export const useActivityStore = create<ActivityState>()(
+  persist(
+    (set) => ({
+      eventsByWallet: {},
+
+      pushEvent: (eventData) =>
+        set((state) => {
+          const walletKey = useStellarWalletStore.getState().address;
+          if (!walletKey) return state; // Don't record if no wallet
+
+          const now = Date.now();
+          const newEvent: ActivityEvent = {
+            ...eventData,
+            id: crypto.randomUUID(),
+            read: false,
+          };
+
+          const currentEvents = state.eventsByWallet[walletKey] || [];
+
+          // Filter out expired events
+          let newEvents = [newEvent, ...currentEvents].filter(
+            (e) => now - e.timestamp < MAX_AGE_MS
+          );
+
+          // Enforce max size
+          if (newEvents.length > MAX_EVENTS) {
+            newEvents = newEvents.slice(0, MAX_EVENTS);
+          }
+
+          return {
+            eventsByWallet: {
+              ...state.eventsByWallet,
+              [walletKey]: newEvents,
+            },
+          };
+        }),
+
+      markAllRead: () =>
+        set((state) => {
+          const walletKey = useStellarWalletStore.getState().address;
+          if (!walletKey) return state;
+          const currentEvents = state.eventsByWallet[walletKey] || [];
+          return {
+            eventsByWallet: {
+              ...state.eventsByWallet,
+              [walletKey]: currentEvents.map((e) => ({ ...e, read: true })),
+            },
+          };
+        }),
+
+      markRead: (id) =>
+        set((state) => {
+          const walletKey = useStellarWalletStore.getState().address;
+          if (!walletKey) return state;
+          const currentEvents = state.eventsByWallet[walletKey] || [];
+          return {
+            eventsByWallet: {
+              ...state.eventsByWallet,
+              [walletKey]: currentEvents.map((e) =>
+                e.id === id ? { ...e, read: true } : e
+              ),
+            },
+          };
+        }),
+
+      clearEvents: () =>
+        set((state) => {
+          const walletKey = useStellarWalletStore.getState().address;
+          if (!walletKey) return state;
+          return {
+            eventsByWallet: {
+              ...state.eventsByWallet,
+              [walletKey]: [],
+            },
+          };
+        }),
+    }),
+    {
+      name: "neko-activity-feed",
+    }
+  )
+);


### PR DESCRIPTION
## Description

This PR introduces the **Unified Activity Feed** feature, allowing users to track their discrete events across the DApp (Swaps, Automation, and Vaults) in a single, durable, reverse-chronological feed scoped to their connected wallet. 

Closes #259 

## Changes Made

- **Activity Feed Module (`/activity`)**: Added a new route to display the feed with filtering support (by source and date range). 
- **Zustand Store**: Created `useActivityStore` using `localStorage` persistence. The store correctly partitions events by wallet address and includes garbage collection (caps at 500 events, auto-expires after 90 days) to prevent storage bloat.
- **App Shell Integration**: 
  - Added an "Activity" tab to the `Sidebar` with an unread notification badge.
  - Added a dedicated bell icon with a notification pill to the `MobileHeader`.
- **Event Integrations (Non-intrusive)**: 
  - `useLimitOrderMonitor`: Logs when a limit order expires or becomes ready to execute.
  - `useExecutionQueue`: Logs when an automation plan is confirmed or cancelled.
  - `useVaultAction`: Logs successful deposit and withdraw operations.

## Testing Instructions

1. Connect your Stellar wallet and open the Sidebar or Mobile Header.
2. Perform any tracked action (e.g., execute a vault deposit/withdrawal or mock a limit order state change).
3. Observe the unread badge appear on the Activity icon/tab.
4. Navigate to `/activity` to view the feed, ensure filtering works, and verify that clicking the events routes correctly and clears the unread badge.
