### PR TITLE
feat(web-app): add security headers (CSP, X-Frame-Options, HSTS, etc.)

### DIFF
--- a/apps/web-app/next.config.ts
+++ b/apps/web-app/next.config.ts
@@ -1,7 +1,100 @@
 import type { NextConfig } from "next";
 
+/**
+ * Security headers.
+ *
+ * This is a wallet-signing DeFi app, so we lock down clickjacking, MIME
+ * sniffing, referrer leakage and unused browser APIs, and ship a
+ * Content-Security-Policy scoped to the origins the app actually talks to.
+ *
+ * The CSP `connect-src` is derived from the configured Stellar RPC/Horizon
+ * URLs plus the fixed set of third-party hosts the app uses (SoroSwap,
+ * Aqua AMM, Etherfuse, WalletConnect). If you point the app at a new
+ * network, RPC, indexer or API host, add it here or the browser will block
+ * the request.
+ */
+
+// Origins the app connects to via fetch / XHR / WebSocket.
+const connectSrc = [
+  "'self'",
+  // Stellar RPC / Horizon — configurable, with testnet + mainnet fallbacks
+  process.env.NEXT_PUBLIC_STELLAR_RPC_URL,
+  process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL,
+  "https://rpc.stellar.org",
+  "https://horizon.stellar.org",
+  "https://soroban-testnet.stellar.org",
+  "https://horizon-testnet.stellar.org",
+  "https://friendbot.stellar.org",
+  "https://friendbot-futurenet.stellar.org",
+  // SoroSwap
+  "https://api.soroswap.finance",
+  // Aqua AMM
+  "https://amm-api.aqua.network",
+  "https://amm-api-testnet.aqua.network",
+  // Etherfuse FX anchor
+  "https://app.etherfuse.com",
+  "https://devnet.etherfuse.com",
+  "https://api.sand.etherfuse.com",
+  // WalletConnect (relay + API + verify)
+  "https://*.walletconnect.com",
+  "https://*.walletconnect.org",
+  "wss://*.walletconnect.com",
+  "wss://*.walletconnect.org",
+]
+  .filter(Boolean)
+  .join(" ");
+
+// Origins allowed to frame in (wallet modals / verify iframes).
+const frameSrc = [
+  "'self'",
+  "https://verify.walletconnect.com",
+  "https://verify.walletconnect.org",
+  "https://*.walletconnect.com",
+  "https://*.walletconnect.org",
+].join(" ");
+
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  // Next.js injects inline bootstrap scripts; the Stellar SDK uses WebAssembly.
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'",
+  // Tailwind / styled runtime styles are inlined.
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  `connect-src ${connectSrc}`,
+  `frame-src ${frameSrc}`,
+  "worker-src 'self' blob:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "upgrade-insecure-requests",
+].join("; ");
+
+const securityHeaders = [
+  { key: "Content-Security-Policy", value: contentSecurityPolicy },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=()",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Closes #271

## What

`apps/web-app/next.config.ts` was effectively empty, so the app shipped with none of Next.js's opt-in security headers. This adds a `headers()` function that applies them to every route.

## Headers added

| Header | Purpose |
|---|---|
| `Content-Security-Policy` | Allowlist of the origins the app actually uses — mitigates XSS / supply-chain script injection and data exfiltration |
| `X-Frame-Options: DENY` + `frame-ancestors 'none'` | Clickjacking protection (critical for a wallet-signing DeFi app) |
| `X-Content-Type-Options: nosniff` | Blocks MIME-sniffing |
| `Referrer-Policy: strict-origin-when-cross-origin` | Prevents full-URL referrer leakage |
| `Permissions-Policy` | Disables unused browser APIs (camera, mic, geolocation, payment) |
| `Strict-Transport-Security` | Forces HTTPS |

## CSP scoping

`connect-src` is derived from `NEXT_PUBLIC_STELLAR_RPC_URL` / `NEXT_PUBLIC_STELLAR_HORIZON_URL` plus the fixed set of hosts enumerated from the codebase, so wallet/swap/lending flows keep working:

- Stellar RPC / Horizon (mainnet + testnet + friendbot)
- SoroSwap (`api.soroswap.finance`)
- Aqua AMM (`amm-api(.testnet).aqua.network`)
- Etherfuse anchor
- WalletConnect relay + verify (`https://*` and `wss://*.walletconnect.com/.org`), plus `frame-src` for the verify iframe used by `@creit.tech/stellar-wallets-kit`

`script-src` keeps `'unsafe-inline'` / `'unsafe-eval'` / `'wasm-unsafe-eval'` because Next.js injects inline bootstrap scripts and the Stellar SDK uses WebAssembly. A stricter nonce-based CSP (via middleware) is a reasonable follow-up.

## Notes for reviewers

- If you point the app at a new network/RPC/indexer/API host, add it to `connect-src` or the browser will block the request.
- Verified the config's `headers()` executes and emits all six headers with the expected CSP directives.

## Acceptance criteria

- [x] Responses include CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy
- [x] CSP `connect-src` / `frame-src` scoped to the wallet-kit, RPC/Horizon and API hosts the app uses so wallet connect / swap / lending keep working