### PR TITLE
ci: add GitHub Actions pipeline (lint, typecheck, build, test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [dev]
+
+# Cancel superseded runs for the same PR / branch to save minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint · Typecheck · Build · Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Turbo cache keeps lint/build/typecheck incremental across runs.
+      - name: Restore turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,6 +246,27 @@ When opening a PR, fill out the [Pull Request template](.github/ISSUE_TEMPLATE/p
 3. **Address feedback** by pushing new commits to your branch
 4. **Once approved**, your PR will be merged
 
+### Continuous Integration (CI)
+
+Every pull request (and every push to `dev`) triggers the **CI** workflow
+(`.github/workflows/ci.yml`), which runs on GitHub Actions:
+
+- `npm run lint` — ESLint
+- `npm run typecheck` — `tsc --noEmit`
+- `npm run build` — production build
+- `npm run test` — Vitest suite
+
+If any step fails, the PR is marked with a red ❌ and **should not be
+merged** until it is green. You can reproduce the exact checks locally with:
+
+```bash
+npm run lint && npm run typecheck && npm run build && npm run test
+```
+
+> **Maintainers:** mark the `CI / Lint · Typecheck · Build · Test` check as a
+> required status check under **Settings → Branches → Branch protection**
+> for `dev` (and `main`) so failing PRs are blocked from merging.
+
 ## Commit Message Conventions
 
 We use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages:

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -7,6 +7,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build": "turbo run build",
     "start": "turbo run start",
     "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
+    "test": "turbo run test",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,scss,md,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,scss,md,yml,yaml}\"",
     "prepare": "npx husky"

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,10 @@
     "lint": {
       "outputs": []
     },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "test": {
       "cache": false,
       "outputs": []


### PR DESCRIPTION
Closes #270

## What

`.github/workflows/` contained only a `.gitkeep`, so nothing enforced lint / build / typecheck / tests on PRs — broken builds, lint violations and type errors could merge unnoticed. This adds a CI workflow.

## The workflow (`.github/workflows/ci.yml`)

Triggered on **`pull_request`** and **push to `dev`**, one job on `ubuntu-latest`:

1. `npm ci` — clean install from `package-lock.json` (respects the npm workspaces / turbo monorepo)
2. `npm run lint` — turbo → ESLint
3. `npm run typecheck` — turbo → `tsc --noEmit`
4. `npm run build` — turbo → `next build`
5. `npm run test` — turbo → `vitest run` (the Vitest harness already exists in `apps/web-app`)

## Supporting changes

- **Added the missing `typecheck` script** — it didn't exist. Added `tsc --noEmit` to `apps/web-app/package.json`, `turbo run typecheck` to the root, and a `typecheck` task to `turbo.json`. Also exposed a root `test` script.
- **Speed** (`< ~5 min` target): `actions/setup-node` npm cache + `actions/cache` for the turbo cache (`.turbo`), so lint/build/typecheck stay incremental. `concurrency` cancels superseded runs on the same PR.
- **Docs:** documented the new check in `CONTRIBUTING.md`, including the exact local reproduction command.

## Chose the simple approach

Ran the root scripts directly (turbo handles caching internally) rather than `turbo run ... --filter=...[origin/dev]`. It's more robust (no dependence on git history / base-ref resolution) and still hits the time budget via caching. `--filter` by affected packages is a reasonable follow-up optimization. The contract packages under `packages/contracts/*` only build via `tsc`, so the full pipeline stays fast and Rust-free.

## Acceptance criteria

- [x] PRs get a CI check that fails on lint / build / typecheck / test errors
- [x] Caching (turbo + npm) keeps a typical run within the time budget
- [x] `CONTRIBUTING.md` documents the new check

## Needs a maintainer (can't be done from the YAML)

To make the check **required** (block merges on failure), mark `CI / Lint · Typecheck · Build · Test` as a required status check under **Settings → Branches → Branch protection** for `dev` (and `main`). Noted in CONTRIBUTING.