### PR TITLE
chore(web-app): centralize and validate environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,19 +359,36 @@ This will build the Next.js app. Deploy the contents of `apps/web-app/.next` dir
 
 ## Environment Configuration
 
-The project uses environment variables with the `NEXT_PUBLIC_` prefix for client-side access.
+Environment variables are parsed and validated in one place — `apps/web-app/src/lib/env.client.ts` (public, `NEXT_PUBLIC_*`) and `apps/web-app/src/lib/env.server.ts` (server-only secrets). The rest of the app imports typed values from those modules instead of reading `process.env` directly.
 
-Create `apps/web-app/.env.local`:
+The **core Stellar network** vars are **required**: if any is missing or malformed, the app fails fast at build/startup with a single readable error, instead of silently falling back to testnet. Everything else is optional.
+
+Create `apps/web-app/.env.local` (the block below matches the validation schema):
 
 ```env
-# Stellar Network Configuration
+# --- Core Stellar network (REQUIRED — app won't start without these) ---
 NEXT_PUBLIC_STELLAR_NETWORK=TESTNET
 NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
-# SoroSwap ApiKey
+# --- Optional public config (NEXT_PUBLIC_, safe in the browser) ---
 NEXT_PUBLIC_SOROSWAP_API_KEY=your_api_key_here
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
+NEXT_PUBLIC_LENDING_ADMIN_ADDRESS=      # Stellar public key allowed into /dashboard/admin
+NEXT_PUBLIC_FAUCET_CONTRACT_ID=
+NEXT_PUBLIC_VERBOSE_LOGGING=false       # "true" | "false"
+
+# --- Server-only secrets (NO NEXT_PUBLIC_ prefix — never sent to the browser) ---
+# Optional: each integration surfaces a clear error only when its route is used.
+VAULT_MANAGER_SECRET_KEY=
+FAUCET_SECRET_KEY=
+FAUCET_CONTRACT_ID=
+ETHERFUSE_API_KEY=
+ETHERFUSE_BASE_URL=https://api.sand.etherfuse.com
+ALFREDPAY_API_KEY=
+ALFREDPAY_API_SECRET=
+ALFREDPAY_BASE_URL=https://api-service-co.alfredpay.app/api/v1/third-party-service/penny
 ```
 
 Available networks:

--- a/apps/web-app/src/app/api/analytics/earnings/route.ts
+++ b/apps/web-app/src/app/api/analytics/earnings/route.ts
@@ -7,13 +7,12 @@ import type {
   EarningsSourceId,
   TimeWindow,
 } from "@/features/analytics/types/analytics";
+import { clientEnv } from "@/lib/env.client";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
 
-const HORIZON_URL =
-  process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL ??
-  "https://horizon-testnet.stellar.org";
+const HORIZON_URL = clientEnv.horizonUrl;
 
 const WINDOW_DAYS: Record<TimeWindow, number> = {
   "24h": 1,

--- a/apps/web-app/src/app/api/analytics/metrics/route.ts
+++ b/apps/web-app/src/app/api/analytics/metrics/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { Horizon } from "@stellar/stellar-sdk";
-import { hhi, diversificationScore } from "@/features/analytics/utils/concentration";
+import {
+  hhi,
+  diversificationScore,
+} from "@/features/analytics/utils/concentration";
 import { projectEarnings } from "@/features/analytics/utils/apy";
+import { clientEnv } from "@/lib/env.client";
 import type {
   MetricsApiResponse,
   AllocationEntry,
@@ -14,9 +18,7 @@ import type {
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
 
-const HORIZON_URL =
-  process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL ??
-  "https://horizon-testnet.stellar.org";
+const HORIZON_URL = clientEnv.horizonUrl;
 
 interface StellarBalance {
   asset_type: string;
@@ -96,7 +98,6 @@ function buildCorrelationMatrix(assets: string[]): CorrelationMatrix {
   return { assets, matrix };
 }
 
-
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const address = searchParams.get("address");
@@ -135,8 +136,7 @@ export async function GET(req: NextRequest) {
   const corrMatrix = buildCorrelationMatrix(assetCodes);
 
   // Synthetic risk metrics
-  const blendedApy =
-    vaultApy * 0.35 + 8.2 * 0.3 + 12.4 * 0.25 + 4.8 * 0.1;
+  const blendedApy = vaultApy * 0.35 + 8.2 * 0.3 + 12.4 * 0.25 + 4.8 * 0.1;
   const borrowCost = totalValue > 200 ? 5.5 : 0;
   const netApy = blendedApy - borrowCost;
 

--- a/apps/web-app/src/app/api/anchor/[provider]/offramp/sign/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/offramp/sign/route.ts
@@ -6,6 +6,7 @@ import {
   ProviderSchema,
 } from "@/lib/validation/schemas";
 import { rpc, Horizon, TransactionBuilder } from "@stellar/stellar-sdk";
+import { clientEnv } from "@/lib/env.client";
 
 export const dynamic = "force-dynamic";
 
@@ -27,15 +28,7 @@ export async function POST(
     if ("error" in parsed) return parsed.error;
     const { signedXdr, transactionId } = parsed.data;
 
-    const rpcUrl =
-      process.env.NEXT_PUBLIC_STELLAR_RPC_URL ||
-      "https://soroban-testnet.stellar.org";
-    const networkPassphrase =
-      process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ||
-      "Test SDF Network ; September 2015";
-    const horizonUrl =
-      process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL ||
-      "https://horizon-testnet.stellar.org";
+    const { rpcUrl, networkPassphrase, horizonUrl } = clientEnv;
 
     const sorobanServer = new rpc.Server(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);

--- a/apps/web-app/src/app/api/anchor/[provider]/sandbox/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/sandbox/route.ts
@@ -4,6 +4,7 @@ import { EtherfuseClient } from "@/lib/anchors/etherfuse";
 import { AlfredPayClient } from "@/lib/anchors/alfredpay";
 import { parseJsonBody, parseParam } from "@/lib/validation/parse";
 import { ProviderSchema, SandboxBodySchema } from "@/lib/validation/schemas";
+import { clientEnv } from "@/lib/env.client";
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +16,7 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ provider: string }> }
 ) {
-  if (process.env.NEXT_PUBLIC_STELLAR_NETWORK === "PUBLIC") {
+  if (clientEnv.stellarNetwork === "PUBLIC") {
     return NextResponse.json(
       { error: "Sandbox endpoints are not available on mainnet" },
       { status: 403 }

--- a/apps/web-app/src/app/api/faucet/route.ts
+++ b/apps/web-app/src/app/api/faucet/route.ts
@@ -15,6 +15,8 @@ import {
 } from "@/lib/constants/faucet";
 import { parseJsonBody } from "@/lib/validation/parse";
 import { FaucetBodySchema } from "@/lib/validation/schemas";
+import { clientEnv } from "@/lib/env.client";
+import { serverEnv } from "@/lib/env.server";
 
 export const dynamic = "force-dynamic";
 
@@ -138,7 +140,7 @@ async function mintTokenLegacy(
 
 export async function POST(request: NextRequest) {
   try {
-    const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "TESTNET";
+    const network = clientEnv.stellarNetwork;
     if (network === "PUBLIC") {
       return NextResponse.json(
         { error: "Faucet is not available on mainnet" },
@@ -146,7 +148,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const secretKey = process.env.FAUCET_SECRET_KEY;
+    const secretKey = serverEnv.FAUCET_SECRET_KEY;
     if (!secretKey) {
       return NextResponse.json(
         { error: "Faucet is not configured" },
@@ -171,15 +173,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const rpcUrl =
-      process.env.NEXT_PUBLIC_STELLAR_RPC_URL ??
-      "https://soroban-testnet.stellar.org";
-    const horizonUrl =
-      process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL ??
-      "https://horizon-testnet.stellar.org";
-    const passphrase =
-      process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ??
-      "Test SDF Network ; September 2015";
+    const { rpcUrl, horizonUrl, networkPassphrase: passphrase } = clientEnv;
 
     const adminKeypair = Keypair.fromSecret(secretKey);
     const sorobanServer = new rpc.Server(rpcUrl, {
@@ -187,7 +181,7 @@ export async function POST(request: NextRequest) {
     });
     const horizonServer = new Horizon.Server(horizonUrl);
 
-    const faucetContractId = process.env.FAUCET_CONTRACT_ID;
+    const faucetContractId = serverEnv.FAUCET_CONTRACT_ID;
 
     if (faucetContractId) {
       const { hash } = await bulkMint(

--- a/apps/web-app/src/app/api/vault/apy/route.ts
+++ b/apps/web-app/src/app/api/vault/apy/route.ts
@@ -9,6 +9,8 @@ import {
   rpc,
 } from "@stellar/stellar-sdk";
 import { Client as DefindexVaultClient } from "@neko/defindex-vault";
+import { clientEnv } from "@/lib/env.client";
+import { serverEnv } from "@/lib/env.server";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
@@ -30,12 +32,8 @@ const SCALAR_7 = 10_000_000;
 
 function getRpcConfig() {
   return {
-    rpcUrl:
-      process.env.NEXT_PUBLIC_STELLAR_RPC_URL ??
-      "https://soroban-testnet.stellar.org",
-    networkPassphrase:
-      process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ??
-      "Test SDF Network ; September 2015",
+    rpcUrl: clientEnv.rpcUrl,
+    networkPassphrase: clientEnv.networkPassphrase,
   };
 }
 
@@ -92,8 +90,7 @@ async function getNekoApy(
 
 async function getAquariusApy(): Promise<number | null> {
   try {
-    const isTestnet =
-      (process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "TESTNET") !== "PUBLIC";
+    const isTestnet = clientEnv.stellarNetwork !== "PUBLIC";
     const base = isTestnet
       ? "https://amm-api-testnet.aqua.network"
       : "https://amm-api.aqua.network";
@@ -150,7 +147,7 @@ async function getAllocations(
 
 export async function GET() {
   try {
-    const secretKey = process.env.VAULT_MANAGER_SECRET_KEY;
+    const secretKey = serverEnv.VAULT_MANAGER_SECRET_KEY;
     if (!secretKey) {
       return NextResponse.json({ error: "Not configured" }, { status: 503 });
     }

--- a/apps/web-app/src/app/api/vault/invest/route.ts
+++ b/apps/web-app/src/app/api/vault/invest/route.ts
@@ -10,6 +10,8 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 import { Client as DefindexVaultClient } from "@neko/defindex-vault";
+import { clientEnv } from "@/lib/env.client";
+import { requireServerEnv } from "@/lib/env.server";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -38,16 +40,13 @@ const COOLDOWN_MS = 5 * 60 * 1000;
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function getEnv() {
-  const secretKey = process.env.VAULT_MANAGER_SECRET_KEY;
-  if (!secretKey) throw new Error("VAULT_MANAGER_SECRET_KEY not configured");
+  const { VAULT_MANAGER_SECRET_KEY: secretKey } = requireServerEnv([
+    "VAULT_MANAGER_SECRET_KEY",
+  ]);
   return {
     secretKey,
-    rpcUrl:
-      process.env.NEXT_PUBLIC_STELLAR_RPC_URL ??
-      "https://soroban-testnet.stellar.org",
-    networkPassphrase:
-      process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ??
-      "Test SDF Network ; September 2015",
+    rpcUrl: clientEnv.rpcUrl,
+    networkPassphrase: clientEnv.networkPassphrase,
   };
 }
 

--- a/apps/web-app/src/components/navigation/ConnectedCard.tsx
+++ b/apps/web-app/src/components/navigation/ConnectedCard.tsx
@@ -4,12 +4,9 @@ import React from "react";
 import { ArrowRight, LogOut } from "lucide-react";
 import { truncateAddress } from "@/lib/utils";
 import { CARD_STYLES, CARD_BUTTON_STYLES } from "./sidebarConfig";
+import { clientEnv } from "@/lib/env.client";
 
-const NETWORK = (
-  process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "TESTNET"
-).toUpperCase();
-
-const IS_TESTNET = NETWORK === "TESTNET";
+const IS_TESTNET = clientEnv.stellarNetwork === "TESTNET";
 
 interface ConnectedCardProps {
   address: string;

--- a/apps/web-app/src/components/navigation/MobileHeader.tsx
+++ b/apps/web-app/src/components/navigation/MobileHeader.tsx
@@ -12,12 +12,10 @@ import { useStellarWallet } from "@/hooks/useStellarWallet";
 import { useStellarWallet } from "@/hooks/useStellarWallet";
 import { truncateAddress } from "@/lib/utils";
 import { useActivityFeed } from "@/features/activity/hooks/useActivityFeed";
+import { clientEnv } from "@/lib/env.client";
 
-const NETWORK = (
-  process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "TESTNET"
-).toUpperCase();
-const IS_TESTNET = NETWORK === "TESTNET";
-const ADMIN_ADDRESS = process.env.NEXT_PUBLIC_LENDING_ADMIN_ADDRESS ?? "";
+const IS_TESTNET = clientEnv.stellarNetwork === "TESTNET";
+const ADMIN_ADDRESS = clientEnv.lendingAdminAddress;
 
 export function MobileHeader() {
   const [isOpen, setIsOpen] = useState(false);

--- a/apps/web-app/src/components/navigation/Sidebar.tsx
+++ b/apps/web-app/src/components/navigation/Sidebar.tsx
@@ -10,10 +10,11 @@ import { NavItem } from "./NavItem";
 import { ConnectedCard } from "./ConnectedCard";
 import { SetupCard } from "./SetupCard";
 import { useActivityFeed } from "@/features/activity/hooks/useActivityFeed";
+import { clientEnv } from "@/lib/env.client";
 
 export const SIDEBAR_WIDTH = "270px";
 
-const ADMIN_ADDRESS = process.env.NEXT_PUBLIC_LENDING_ADMIN_ADDRESS ?? "";
+const ADMIN_ADDRESS = clientEnv.lendingAdminAddress;
 
 export function Sidebar() {
   const pathname = usePathname();

--- a/apps/web-app/src/features/admin/components/AdminPageClient.tsx
+++ b/apps/web-app/src/features/admin/components/AdminPageClient.tsx
@@ -10,8 +10,9 @@ import PoolStateToggle from "./PoolStateToggle";
 import TreasuryFeesTable from "./TreasuryFeesTable";
 import CollateralFactorForm from "./CollateralFactorForm";
 import InterestRateParamsForm from "./InterestRateParamsForm";
+import { clientEnv } from "@/lib/env.client";
 
-const ADMIN_ADDRESS = process.env.NEXT_PUBLIC_LENDING_ADMIN_ADDRESS ?? "";
+const ADMIN_ADDRESS = clientEnv.lendingAdminAddress;
 
 function ConnectWalletPrompt() {
   const [showModal, setShowModal] = React.useState(false);

--- a/apps/web-app/src/features/on-off-ramps/components/pages/OnOffRamps.tsx
+++ b/apps/web-app/src/features/on-off-ramps/components/pages/OnOffRamps.tsx
@@ -28,8 +28,9 @@ import { KycBanner } from "../ui/KycBanner";
 import { PaymentInstructionsDisplay } from "../ui/PaymentInstructions";
 import { FiatAccountSelector } from "../ui/FiatAccountSelector";
 import { TransactionStatusDisplay } from "../ui/TransactionStatus";
+import { clientEnv } from "@/lib/env.client";
 
-const isSandbox = process.env.NEXT_PUBLIC_STELLAR_NETWORK !== "PUBLIC";
+const isSandbox = clientEnv.stellarNetwork !== "PUBLIC";
 const etherfusePortalUrl = isSandbox
   ? "https://devnet.etherfuse.com"
   : "https://app.etherfuse.com";
@@ -293,143 +294,145 @@ const OnOffRamps: React.FC = () => {
           tabIndex={0}
           className="flex flex-col gap-4"
         >
-        {/* KYC Banner */}
-        {address && customerId && (
-          <KycBanner
-            status={kycStatus}
-            onStartKyc={() => void openKycFlow()}
-            isLoading={isCheckingKyc}
-          />
-        )}
+          {/* KYC Banner */}
+          {address && customerId && (
+            <KycBanner
+              status={kycStatus}
+              onStartKyc={() => void openKycFlow()}
+              isLoading={isCheckingKyc}
+            />
+          )}
 
-        {/* Trustline warning — shown after quote, before confirming on-ramp */}
-        {isOnRamp && quote && !currentTx && !hasTrustline && (
-          <div className="flex items-center justify-between gap-3 bg-orange-400/10 border border-orange-400/20 rounded-xl px-4 py-3">
-            <div>
-              <p className="text-orange-400 text-sm font-medium">
-                CETES trustline not enabled
-              </p>
-              <p className="text-white/40 text-xs">
-                You need a trustline to receive CETES in your wallet.
-              </p>
+          {/* Trustline warning — shown after quote, before confirming on-ramp */}
+          {isOnRamp && quote && !currentTx && !hasTrustline && (
+            <div className="flex items-center justify-between gap-3 bg-orange-400/10 border border-orange-400/20 rounded-xl px-4 py-3">
+              <div>
+                <p className="text-orange-400 text-sm font-medium">
+                  CETES trustline not enabled
+                </p>
+                <p className="text-white/40 text-xs">
+                  You need a trustline to receive CETES in your wallet.
+                </p>
+              </div>
+              <button
+                onClick={() => addTrustline()}
+                disabled={isAddingTrustline}
+                className="shrink-0 px-4 py-2 rounded-lg bg-orange-400 hover:bg-orange-500 text-white text-sm font-medium transition-colors disabled:opacity-50"
+              >
+                {isAddingTrustline ? "Enabling..." : "Enable Trustline"}
+              </button>
             </div>
+          )}
+
+          {/* Polling KYC banner - let user know to refresh */}
+          {kycStatus === "pending" && (
             <button
-              onClick={() => addTrustline()}
-              disabled={isAddingTrustline}
-              className="shrink-0 px-4 py-2 rounded-lg bg-orange-400 hover:bg-orange-500 text-white text-sm font-medium transition-colors disabled:opacity-50"
+              onClick={() => refetchKycStatus()}
+              className="text-xs text-white/40 hover:text-white/60 text-center"
             >
-              {isAddingTrustline ? "Enabling..." : "Enable Trustline"}
+              Refresh KYC status
             </button>
-          </div>
-        )}
+          )}
 
-        {/* Polling KYC banner - let user know to refresh */}
-        {kycStatus === "pending" && (
-          <button
-            onClick={() => refetchKycStatus()}
-            className="text-xs text-white/40 hover:text-white/60 text-center"
-          >
-            Refresh KYC status
-          </button>
-        )}
+          {/* Active transaction status */}
+          {currentTx &&
+            (isPollingTx ||
+              currentTx.status === "completed" ||
+              ["failed", "expired", "cancelled"].includes(
+                currentTx.status
+              )) && (
+              <TransactionStatusDisplay
+                status={currentTx.status}
+                type={isOnRamp ? "onramp" : "offramp"}
+                transactionId={currentTx.id}
+                onDone={() => {
+                  dispatch({ type: "RESET" });
+                  clearQuote();
+                }}
+              />
+            )}
 
-        {/* Active transaction status */}
-        {currentTx &&
-          (isPollingTx ||
-            currentTx.status === "completed" ||
-            ["failed", "expired", "cancelled"].includes(currentTx.status)) && (
-            <TransactionStatusDisplay
-              status={currentTx.status}
-              type={isOnRamp ? "onramp" : "offramp"}
-              transactionId={currentTx.id}
-              onDone={() => {
-                dispatch({ type: "RESET" });
-                clearQuote();
-              }}
+          {/* On-ramp: Payment instructions — shown while awaiting payment */}
+          {isOnRamp &&
+            onRampTx &&
+            onRampTx.paymentInstructions &&
+            onRampTx.status !== "completed" && (
+              <PaymentInstructionsDisplay
+                instructions={onRampTx.paymentInstructions}
+                statusPage={onRampTx.statusPage}
+                onSimulateFiat={isSandbox ? handleSimulateFiat : undefined}
+                isSandbox={isSandbox}
+                isSimulating={isSimulating}
+              />
+            )}
+
+          {/* Quote display */}
+          {quote && !currentTx && (
+            <QuoteDisplay
+              quote={quote}
+              isExpired={isExpired}
+              secondsLeft={secondsLeft}
+              onConfirm={isOnRamp ? handleConfirmOnRamp : handleConfirmOffRamp}
+              onRefresh={handleGetQuote}
+              onCancel={clearQuote}
+              isLoading={isLoadingTx}
             />
           )}
 
-        {/* On-ramp: Payment instructions — shown while awaiting payment */}
-        {isOnRamp &&
-          onRampTx &&
-          onRampTx.paymentInstructions &&
-          onRampTx.status !== "completed" && (
-            <PaymentInstructionsDisplay
-              instructions={onRampTx.paymentInstructions}
-              statusPage={onRampTx.statusPage}
-              onSimulateFiat={isSandbox ? handleSimulateFiat : undefined}
-              isSandbox={isSandbox}
-              isSimulating={isSimulating}
+          {/* Off-ramp: bank account selector (shown before confirming) */}
+          {!isOnRamp && quote && !offRampTx && (
+            <FiatAccountSelector
+              accounts={accounts}
+              selected={state.selectedFiatAccount}
+              onSelect={(account) =>
+                dispatch({ type: "SET_FIAT_ACCOUNT", account })
+              }
+              isLoading={isLoadingAccounts}
+              addAccountUrl={
+                state.provider === "etherfuse" ? etherfusePortalUrl : undefined
+              }
             />
           )}
 
-        {/* Quote display */}
-        {quote && !currentTx && (
-          <QuoteDisplay
-            quote={quote}
-            isExpired={isExpired}
-            secondsLeft={secondsLeft}
-            onConfirm={isOnRamp ? handleConfirmOnRamp : handleConfirmOffRamp}
-            onRefresh={handleGetQuote}
-            onCancel={clearQuote}
-            isLoading={isLoadingTx}
-          />
-        )}
+          {/* Amount input + get quote button */}
+          {!currentTx && !quote && (
+            <>
+              <AmountInput
+                value={state.amount}
+                onChange={(value) =>
+                  dispatch({ type: "SET_AMOUNT", amount: value })
+                }
+                currency={fromCurrency}
+                label={
+                  isOnRamp
+                    ? "You send (MXN)"
+                    : `You send (${config.supportedAssets[0]})`
+                }
+                disabled={!address || isLoadingTx}
+              />
 
-        {/* Off-ramp: bank account selector (shown before confirming) */}
-        {!isOnRamp && quote && !offRampTx && (
-          <FiatAccountSelector
-            accounts={accounts}
-            selected={state.selectedFiatAccount}
-            onSelect={(account) =>
-              dispatch({ type: "SET_FIAT_ACCOUNT", account })
-            }
-            isLoading={isLoadingAccounts}
-            addAccountUrl={
-              state.provider === "etherfuse" ? etherfusePortalUrl : undefined
-            }
-          />
-        )}
-
-        {/* Amount input + get quote button */}
-        {!currentTx && !quote && (
-          <>
-            <AmountInput
-              value={state.amount}
-              onChange={(value) =>
-                dispatch({ type: "SET_AMOUNT", amount: value })
-              }
-              currency={fromCurrency}
-              label={
-                isOnRamp
-                  ? "You send (MXN)"
-                  : `You send (${config.supportedAssets[0]})`
-              }
-              disabled={!address || isLoadingTx}
-            />
-
-            <button
-              onClick={handleGetQuote}
-              disabled={
-                !canGetQuote ||
-                isLoadingQuote ||
-                isEnsuring ||
-                (isKycRequired && !!customerId)
-              }
-              className="w-full py-4 rounded-2xl bg-[#229EDF] hover:bg-[#1a8bc7] text-white font-semibold text-base transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {!address
-                ? "Connect Wallet"
-                : isEnsuring
-                  ? "Setting up..."
-                  : isKycRequired && !!customerId
-                    ? "Complete KYC First"
-                    : isLoadingQuote
-                      ? "Getting quote..."
-                      : "Get Quote"}
-            </button>
-          </>
-        )}
+              <button
+                onClick={handleGetQuote}
+                disabled={
+                  !canGetQuote ||
+                  isLoadingQuote ||
+                  isEnsuring ||
+                  (isKycRequired && !!customerId)
+                }
+                className="w-full py-4 rounded-2xl bg-[#229EDF] hover:bg-[#1a8bc7] text-white font-semibold text-base transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {!address
+                  ? "Connect Wallet"
+                  : isEnsuring
+                    ? "Setting up..."
+                    : isKycRequired && !!customerId
+                      ? "Complete KYC First"
+                      : isLoadingQuote
+                        ? "Getting quote..."
+                        : "Get Quote"}
+              </button>
+            </>
+          )}
         </div>
         <div
           id={isOnRamp ? "off-ramp-panel" : "on-ramp-panel"}

--- a/apps/web-app/src/lib/anchors/index.ts
+++ b/apps/web-app/src/lib/anchors/index.ts
@@ -2,6 +2,7 @@ import type { Anchor, AnchorProvider } from "./types";
 import { AnchorError } from "./types";
 import { EtherfuseClient } from "./etherfuse";
 import { AlfredPayClient } from "./alfredpay";
+import { serverEnv } from "@/lib/env.server";
 
 export * from "./types";
 export { EtherfuseClient } from "./etherfuse";
@@ -19,8 +20,8 @@ export function getAnchorClient(provider: AnchorProvider): Anchor {
   if (!anchor) {
     switch (provider) {
       case "etherfuse": {
-        const apiKey = process.env.ETHERFUSE_API_KEY;
-        const baseUrl = process.env.ETHERFUSE_BASE_URL;
+        const { ETHERFUSE_API_KEY: apiKey, ETHERFUSE_BASE_URL: baseUrl } =
+          serverEnv;
         if (!apiKey || !baseUrl) {
           throw new AnchorError(
             "Etherfuse is not configured (missing ETHERFUSE_API_KEY or ETHERFUSE_BASE_URL)",
@@ -32,9 +33,11 @@ export function getAnchorClient(provider: AnchorProvider): Anchor {
         break;
       }
       case "alfredpay": {
-        const apiKey = process.env.ALFREDPAY_API_KEY;
-        const apiSecret = process.env.ALFREDPAY_API_SECRET;
-        const baseUrl = process.env.ALFREDPAY_BASE_URL;
+        const {
+          ALFREDPAY_API_KEY: apiKey,
+          ALFREDPAY_API_SECRET: apiSecret,
+          ALFREDPAY_BASE_URL: baseUrl,
+        } = serverEnv;
         if (!apiKey || !apiSecret || !baseUrl) {
           throw new AnchorError(
             "Alfred Pay is not configured (missing ALFREDPAY_API_KEY, ALFREDPAY_API_SECRET, or ALFREDPAY_BASE_URL)",

--- a/apps/web-app/src/lib/config/stellar.config.ts
+++ b/apps/web-app/src/lib/config/stellar.config.ts
@@ -1,5 +1,4 @@
-import { z } from "zod";
-import { Networks as WalletNetwork } from "@creit.tech/stellar-wallets-kit/types";
+import { clientEnv } from "@/lib/env.client";
 
 type NetworkType = "mainnet" | "testnet" | "futurenet" | "custom";
 interface Network {
@@ -10,42 +9,8 @@ interface Network {
   horizonUrl: string;
 }
 
-const envSchema = z.object({
-  PUBLIC_STELLAR_NETWORK: z.enum([
-    "PUBLIC",
-    "FUTURENET",
-    "TESTNET",
-    "LOCAL",
-    "STANDALONE", // deprecated in favor of LOCAL
-  ] as const),
-  PUBLIC_STELLAR_NETWORK_PASSPHRASE: z.nativeEnum(WalletNetwork),
-  PUBLIC_STELLAR_RPC_URL: z.string(),
-  PUBLIC_STELLAR_HORIZON_URL: z.string(),
-});
-
-const envVars = {
-  PUBLIC_STELLAR_NETWORK: process.env.NEXT_PUBLIC_STELLAR_NETWORK,
-  PUBLIC_STELLAR_NETWORK_PASSPHRASE:
-    process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE,
-  PUBLIC_STELLAR_RPC_URL: process.env.NEXT_PUBLIC_STELLAR_RPC_URL,
-  PUBLIC_STELLAR_HORIZON_URL: process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL,
-};
-const parsed = envSchema.safeParse(envVars);
-
-const env: z.infer<typeof envSchema> = parsed.success
-  ? parsed.data
-  : {
-      PUBLIC_STELLAR_NETWORK: "LOCAL",
-      PUBLIC_STELLAR_NETWORK_PASSPHRASE: WalletNetwork.STANDALONE,
-      PUBLIC_STELLAR_RPC_URL: "http://localhost:8000/rpc",
-      PUBLIC_STELLAR_HORIZON_URL: "http://localhost:8000",
-    };
-
-export const stellarNetwork =
-  env.PUBLIC_STELLAR_NETWORK === "STANDALONE"
-    ? "LOCAL"
-    : env.PUBLIC_STELLAR_NETWORK;
-export const networkPassphrase = env.PUBLIC_STELLAR_NETWORK_PASSPHRASE;
+export const stellarNetwork = clientEnv.stellarNetwork;
+export const networkPassphrase = clientEnv.networkPassphrase;
 
 const stellarEncode = (str: string) => {
   return str.replace(/\//g, "//").replace(/;/g, "/;");
@@ -66,9 +31,9 @@ export const labPrefix = () => {
   }
 };
 
-export const rpcUrl = env.PUBLIC_STELLAR_RPC_URL;
+export const rpcUrl = clientEnv.rpcUrl;
 
-export const horizonUrl = env.PUBLIC_STELLAR_HORIZON_URL;
+export const horizonUrl = clientEnv.horizonUrl;
 
 export const XLM_TESTNET_ADDRESS =
   "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";

--- a/apps/web-app/src/lib/constants/faucet.ts
+++ b/apps/web-app/src/lib/constants/faucet.ts
@@ -7,6 +7,7 @@ import {
   rpc,
   Horizon,
 } from "@stellar/stellar-sdk";
+import { clientEnv } from "@/lib/env.client";
 export interface FaucetToken {
   symbol: string;
   contractId: string;
@@ -58,8 +59,7 @@ const TESTNET_FAUCET_TOKENS: {
   },
 ];
 
-export const FAUCET_CONTRACT_ID =
-  process.env.NEXT_PUBLIC_FAUCET_CONTRACT_ID ?? "";
+export const FAUCET_CONTRACT_ID = clientEnv.faucetContractId;
 
 export const FAUCET_COOLDOWN_MS = 5 * 60 * 1000;
 

--- a/apps/web-app/src/lib/constants/network.ts
+++ b/apps/web-app/src/lib/constants/network.ts
@@ -1,5 +1,4 @@
-import { z } from "zod";
-import { Networks as WalletNetwork } from "@creit.tech/stellar-wallets-kit/types";
+import { clientEnv } from "@/lib/env.client";
 
 export type NetworkType = "mainnet" | "testnet" | "futurenet" | "custom";
 export interface Network {
@@ -10,42 +9,8 @@ export interface Network {
   horizonUrl: string;
 }
 
-const envSchema = z.object({
-  PUBLIC_STELLAR_NETWORK: z.enum([
-    "PUBLIC",
-    "FUTURENET",
-    "TESTNET",
-    "LOCAL",
-    "STANDALONE", // deprecated in favor of LOCAL
-  ] as const),
-  PUBLIC_STELLAR_NETWORK_PASSPHRASE: z.nativeEnum(WalletNetwork),
-  PUBLIC_STELLAR_RPC_URL: z.string(),
-  PUBLIC_STELLAR_HORIZON_URL: z.string(),
-});
-
-const envVars = {
-  PUBLIC_STELLAR_NETWORK: process.env.NEXT_PUBLIC_STELLAR_NETWORK,
-  PUBLIC_STELLAR_NETWORK_PASSPHRASE:
-    process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE,
-  PUBLIC_STELLAR_RPC_URL: process.env.NEXT_PUBLIC_STELLAR_RPC_URL,
-  PUBLIC_STELLAR_HORIZON_URL: process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL,
-};
-const parsed = envSchema.safeParse(envVars);
-
-const env: z.infer<typeof envSchema> = parsed.success
-  ? parsed.data
-  : {
-      PUBLIC_STELLAR_NETWORK: "LOCAL",
-      PUBLIC_STELLAR_NETWORK_PASSPHRASE: WalletNetwork.STANDALONE,
-      PUBLIC_STELLAR_RPC_URL: "http://localhost:8000/rpc",
-      PUBLIC_STELLAR_HORIZON_URL: "http://localhost:8000",
-    };
-
-export const stellarNetwork =
-  env.PUBLIC_STELLAR_NETWORK === "STANDALONE"
-    ? "LOCAL"
-    : env.PUBLIC_STELLAR_NETWORK;
-export const networkPassphrase = env.PUBLIC_STELLAR_NETWORK_PASSPHRASE;
+export const stellarNetwork = clientEnv.stellarNetwork;
+export const networkPassphrase = clientEnv.networkPassphrase;
 
 const stellarEncode = (str: string) => {
   return str.replace(/\//g, "//").replace(/;/g, "/;");
@@ -66,12 +31,12 @@ export const labPrefix = () => {
   }
 };
 
-export const rpcUrl = env.PUBLIC_STELLAR_RPC_URL;
+export const rpcUrl = clientEnv.rpcUrl;
 
 export const allowHttpForSoroban =
   typeof rpcUrl === "string" && rpcUrl.startsWith("http:");
 
-export const horizonUrl = env.PUBLIC_STELLAR_HORIZON_URL;
+export const horizonUrl = clientEnv.horizonUrl;
 
 const networkToId = (network: string): NetworkType => {
   switch (network) {

--- a/apps/web-app/src/lib/env.client.ts
+++ b/apps/web-app/src/lib/env.client.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+import { Networks as WalletNetwork } from "@creit.tech/stellar-wallets-kit/types";
+
+/**
+ * Centralized, validated CLIENT environment.
+ *
+ * Single source of truth for every `NEXT_PUBLIC_*` variable the app reads.
+ * These values are inlined into the browser bundle by Next.js, so ONLY
+ * non-secret configuration lives here. Server-only secrets belong in
+ * `env.server.ts`.
+ *
+ * The core Stellar network vars are REQUIRED and fail fast at import time
+ * with a single aggregated error, instead of each call site silently
+ * falling back to testnet / an empty string. Optional public vars are
+ * typed but may be undefined.
+ *
+ * IMPORTANT: every `process.env.NEXT_PUBLIC_*` access below is written as a
+ * static literal so Next.js can statically replace it at build time. Do not
+ * refactor these into a dynamic lookup.
+ */
+
+const clientSchema = z.object({
+  // --- Core Stellar network (REQUIRED — fail fast) ---
+  NEXT_PUBLIC_STELLAR_NETWORK: z.enum([
+    "PUBLIC",
+    "FUTURENET",
+    "TESTNET",
+    "LOCAL",
+    "STANDALONE", // deprecated in favor of LOCAL
+  ] as const),
+  NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE: z.nativeEnum(WalletNetwork),
+  NEXT_PUBLIC_STELLAR_RPC_URL: z.string().url(),
+  NEXT_PUBLIC_STELLAR_HORIZON_URL: z.string().url(),
+
+  // --- Optional public config ---
+  NEXT_PUBLIC_LENDING_ADMIN_ADDRESS: z.string().optional(),
+  NEXT_PUBLIC_FAUCET_CONTRACT_ID: z.string().optional(),
+  NEXT_PUBLIC_SOROSWAP_API_KEY: z.string().optional(),
+  NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: z.string().optional(),
+  NEXT_PUBLIC_VERBOSE_LOGGING: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((v) => v === "true"),
+});
+
+// Static references so Next.js inlines them into the client bundle.
+const rawClientEnv = {
+  NEXT_PUBLIC_STELLAR_NETWORK: process.env.NEXT_PUBLIC_STELLAR_NETWORK,
+  NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE:
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE,
+  NEXT_PUBLIC_STELLAR_RPC_URL: process.env.NEXT_PUBLIC_STELLAR_RPC_URL,
+  NEXT_PUBLIC_STELLAR_HORIZON_URL: process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL,
+  NEXT_PUBLIC_LENDING_ADMIN_ADDRESS:
+    process.env.NEXT_PUBLIC_LENDING_ADMIN_ADDRESS,
+  NEXT_PUBLIC_FAUCET_CONTRACT_ID: process.env.NEXT_PUBLIC_FAUCET_CONTRACT_ID,
+  NEXT_PUBLIC_SOROSWAP_API_KEY: process.env.NEXT_PUBLIC_SOROSWAP_API_KEY,
+  NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID:
+    process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID,
+  NEXT_PUBLIC_VERBOSE_LOGGING: process.env.NEXT_PUBLIC_VERBOSE_LOGGING,
+};
+
+const parsed = clientSchema.safeParse(rawClientEnv);
+
+if (!parsed.success) {
+  const issues = parsed.error.issues
+    .map((i) => `  - ${i.path.join(".") || "(root)"}: ${i.message}`)
+    .join("\n");
+  throw new Error(
+    `Invalid or missing public environment variables:\n${issues}\n\n` +
+      `Set these in apps/web-app/.env.local (see README "Environment configuration").`
+  );
+}
+
+const parsedEnv = parsed.data;
+
+/**
+ * Validated, typed public environment.
+ * Import these instead of touching `process.env.NEXT_PUBLIC_*` directly.
+ */
+export const clientEnv = {
+  stellarNetwork:
+    parsedEnv.NEXT_PUBLIC_STELLAR_NETWORK === "STANDALONE"
+      ? ("LOCAL" as const)
+      : parsedEnv.NEXT_PUBLIC_STELLAR_NETWORK,
+  networkPassphrase: parsedEnv.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE,
+  rpcUrl: parsedEnv.NEXT_PUBLIC_STELLAR_RPC_URL,
+  horizonUrl: parsedEnv.NEXT_PUBLIC_STELLAR_HORIZON_URL,
+  lendingAdminAddress: parsedEnv.NEXT_PUBLIC_LENDING_ADMIN_ADDRESS ?? "",
+  faucetContractId: parsedEnv.NEXT_PUBLIC_FAUCET_CONTRACT_ID ?? "",
+  soroswapApiKey: parsedEnv.NEXT_PUBLIC_SOROSWAP_API_KEY ?? "",
+  walletConnectProjectId: parsedEnv.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? "",
+  verboseLogging: parsedEnv.NEXT_PUBLIC_VERBOSE_LOGGING ?? false,
+} as const;
+
+export type ClientEnv = typeof clientEnv;

--- a/apps/web-app/src/lib/env.server.ts
+++ b/apps/web-app/src/lib/env.server.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+
+/**
+ * Centralized, validated SERVER environment.
+ *
+ * Single source of truth for server-only variables — signing keys and
+ * third-party credentials that must NEVER reach the browser bundle. The
+ * runtime guard below throws if this module is ever imported in the
+ * browser, so an accidental client import fails loudly.
+ *
+ * Per the project decision, only the core Stellar network config fails
+ * fast (see `env.client.ts`). Integration secrets here are optional at the
+ * schema level so the app can boot without every anchor / faucet / vault
+ * configured; each integration still surfaces a clear error when its route
+ * is actually used (see `requireServerEnv`).
+ */
+
+if (typeof window !== "undefined") {
+  throw new Error(
+    "env.server.ts was imported in the browser. Server-only secrets must " +
+      "never reach the client bundle — import from env.client.ts instead."
+  );
+}
+
+const serverSchema = z.object({
+  // Vault manager signing key (server-only)
+  VAULT_MANAGER_SECRET_KEY: z.string().optional(),
+
+  // Faucet (server-only)
+  FAUCET_SECRET_KEY: z.string().optional(),
+  FAUCET_CONTRACT_ID: z.string().optional(),
+
+  // Etherfuse anchor
+  ETHERFUSE_API_KEY: z.string().optional(),
+  ETHERFUSE_BASE_URL: z.string().url().optional(),
+
+  // Alfred Pay anchor
+  ALFREDPAY_API_KEY: z.string().optional(),
+  ALFREDPAY_API_SECRET: z.string().optional(),
+  ALFREDPAY_BASE_URL: z.string().url().optional(),
+});
+
+const parsed = serverSchema.safeParse({
+  VAULT_MANAGER_SECRET_KEY: process.env.VAULT_MANAGER_SECRET_KEY,
+  FAUCET_SECRET_KEY: process.env.FAUCET_SECRET_KEY,
+  FAUCET_CONTRACT_ID: process.env.FAUCET_CONTRACT_ID,
+  ETHERFUSE_API_KEY: process.env.ETHERFUSE_API_KEY,
+  ETHERFUSE_BASE_URL: process.env.ETHERFUSE_BASE_URL,
+  ALFREDPAY_API_KEY: process.env.ALFREDPAY_API_KEY,
+  ALFREDPAY_API_SECRET: process.env.ALFREDPAY_API_SECRET,
+  ALFREDPAY_BASE_URL: process.env.ALFREDPAY_BASE_URL,
+});
+
+if (!parsed.success) {
+  // Only malformed values (e.g. a non-URL base URL) land here, since every
+  // field is optional. Still fail fast with a readable, aggregated error.
+  const issues = parsed.error.issues
+    .map((i) => `  - ${i.path.join(".") || "(root)"}: ${i.message}`)
+    .join("\n");
+  throw new Error(`Invalid server environment variables:\n${issues}`);
+}
+
+/**
+ * Validated, typed server environment. Import instead of `process.env.X`.
+ */
+export const serverEnv = parsed.data;
+
+export type ServerEnv = typeof serverEnv;
+
+/**
+ * Assert that the given server env vars are present, throwing a clear error
+ * naming the missing ones. Use at the start of a route/handler that needs
+ * them, so a misconfiguration fails with a readable message instead of an
+ * opaque downstream crash.
+ */
+export function requireServerEnv<K extends keyof ServerEnv>(
+  keys: readonly K[]
+): { [P in K]: NonNullable<ServerEnv[P]> } {
+  const missing = keys.filter((k) => !serverEnv[k]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required server environment variables: ${missing.join(", ")}`
+    );
+  }
+  return Object.fromEntries(keys.map((k) => [k, serverEnv[k]])) as {
+    [P in K]: NonNullable<ServerEnv[P]>;
+  };
+}

--- a/apps/web-app/src/lib/helpers/stellar/soroswap/quotes.ts
+++ b/apps/web-app/src/lib/helpers/stellar/soroswap/quotes.ts
@@ -10,6 +10,7 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 import { rpcUrl, networkPassphrase } from "@/lib/constants/network";
+import { clientEnv } from "@/lib/env.client";
 import { getCurrentNetwork, getAvailableTokens } from "./tokens";
 import { toSmallestUnit } from "@/lib/helpers/tokenUtils";
 import {
@@ -203,10 +204,7 @@ export const getPool = async (request: GetPoolRequest): Promise<PoolInfo[]> => {
   try {
     const pools = await makeAPIRequest<PoolInfo[]>(endpoint, { method: "GET" });
 
-    if (
-      process.env.NODE_ENV === "development" &&
-      process.env.NEXT_PUBLIC_VERBOSE_LOGGING === "true"
-    ) {
+    if (process.env.NODE_ENV === "development" && clientEnv.verboseLogging) {
       console.log("💧 Pool information received:", pools);
     }
 

--- a/apps/web-app/src/lib/helpers/stellar/soroswap/utils.ts
+++ b/apps/web-app/src/lib/helpers/stellar/soroswap/utils.ts
@@ -1,13 +1,13 @@
 import { SoroswapSDK, SupportedNetworks } from "@soroswap/sdk";
 import type { Token } from "../../../types/soroswapTypes";
 import { getCurrentNetwork, getAvailableTokens, getTokens } from "./tokens";
+import { clientEnv } from "@/lib/env.client";
 
 const SOROSWAP_API_URL = "https://api.soroswap.finance";
 const DEFAULT_TIMEOUT = 50000;
 
 export const getApiKey = (): string | null => {
-  const envKey = process.env.NEXT_PUBLIC_SOROSWAP_API_KEY;
-  const envKeyStr = typeof envKey === "string" ? envKey : "";
+  const envKeyStr = clientEnv.soroswapApiKey;
   if (envKeyStr && envKeyStr.trim() !== "") {
     return envKeyStr.trim();
   }

--- a/apps/web-app/src/lib/helpers/stellar/wallet/walletKit.ts
+++ b/apps/web-app/src/lib/helpers/stellar/wallet/walletKit.ts
@@ -3,6 +3,7 @@
 import type { StellarWalletsKit as StellarWalletsKitClass } from "@creit.tech/stellar-wallets-kit";
 import { Networks } from "@creit.tech/stellar-wallets-kit/types";
 import { getCurrentNetworkPassphrase } from "../network";
+import { clientEnv } from "@/lib/env.client";
 
 type Kit = typeof StellarWalletsKitClass;
 
@@ -56,7 +57,7 @@ export async function getStellarWalletKit(): Promise<Kit> {
           new LedgerModule(),
           new LobstrModule(),
           new WalletConnectModule({
-            projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || "",
+            projectId: clientEnv.walletConnectProjectId,
             metadata: {
               name: "Neko",
               description: "Neko — All-in-one platform for RWAs on Stellar",


### PR DESCRIPTION
Closes #273

## Problem

`process.env` was read directly in 40+ places across `apps/web-app/src`, each with its own ad hoc (or missing) fallback. Misconfiguration failed in inconsistent, silent ways — e.g. RPC silently falling back to testnet in a prod deploy, the admin gate redirecting *everyone* away when `NEXT_PUBLIC_LENDING_ADMIN_ADDRESS` is unset/typo'd, anchors 503-ing only when their route is hit. There was no single source of truth and no startup validation.

## Solution

A single, validated source of truth using zod (already used for API validation):

- **`lib/env.client.ts`** — schema for every `NEXT_PUBLIC_*` var, parsed once at import. The **core Stellar network** vars (`NETWORK`, `NETWORK_PASSPHRASE`, `RPC_URL`, `HORIZON_URL`) are **required and fail fast** with a single aggregated, readable error instead of a silent testnet fallback. Other public vars are typed and optional. Values are inlined by Next.js (static `process.env.NEXT_PUBLIC_*` references preserved).
- **`lib/env.server.ts`** — schema for server-only secrets (signing keys, anchor credentials). A browser guard throws if the module is ever imported client-side, so secrets never reach the bundle. Exposes `serverEnv` and a `requireServerEnv([...])` helper for a clear per-route error.

All ~15 call sites now import typed values instead of touching `process.env`. The two duplicated Stellar config files (`lib/constants/network.ts`, `lib/config/stellar.config.ts`) keep their exact exports but now derive from `env.client.ts`.

## Scope decision (fail-fast)

Per discussion, **only the core Stellar config fails fast**. Integration secrets (vault key, faucet, Etherfuse, AlfredPay) stay optional at the schema level so the app still boots without every integration configured, and each still surfaces a clear error when its route is actually used. This keeps local dev and partial deploys working.

## Verification

- `tsc --noEmit`: **no new type errors** from this change (the only failures are pre-existing JSX errors in `features/swap/components/pages/Swap.tsx`, untouched here).
- `eslint`: **no new lint errors** (the one `no-explicit-any` in `vault/apy/route.ts` pre-exists on `dev`).
- Ran the zod schema at runtime: valid config parses (with `VERBOSE_LOGGING` coerced to boolean); missing/malformed required vars are caught and aggregated.
- Grep confirms no remaining `process.env.*` reads in `src` except `NODE_ENV` and the two `env.*` modules.

## Acceptance criteria

- [x] One module owns env parsing/validation; call sites import typed values
- [x] Missing required var fails fast with a readable error, not a silent fallback/redirect
- [x] `.env.local` example in README updated to match the schema

## Note

Because core vars now fail fast, `next build` / startup requires the 4 core `NEXT_PUBLIC_*` vars to be present (they're already in `.env.example`). Worth ensuring CI (#270) provides them.