### PR TITLE
perf(web-app): code-split heavy deps with next/dynamic + wire bundle analyzer

### DIFF
--- a/apps/web-app/next.config.ts
+++ b/apps/web-app/next.config.ts
@@ -1,7 +1,23 @@
 import type { NextConfig } from "next";
+import bundleAnalyzer from "@next/bundle-analyzer";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    // Improve tree-shaking / per-route splitting for large barrel-export
+    // packages so unused icons/components don't land in the shared bundle.
+    optimizePackageImports: [
+      "@mui/material",
+      "@mui/icons-material",
+      "lucide-react",
+      "chart.js",
+      "react-chartjs-2",
+    ],
+  },
 };
 
-export default nextConfig;
+// Run `ANALYZE=true npm run build` to emit an interactive bundle report.
+const withBundleAnalyzer = bundleAnalyzer({
+  enabled: process.env.ANALYZE === "true",
+});
+
+export default withBundleAnalyzer(nextConfig);

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -7,6 +7,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
+    "analyze": "ANALYZE=true next build",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -51,6 +52,7 @@
     "zustand": "^5.0.2"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "16.1.6",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/lodash": "^4.14.202",

--- a/apps/web-app/src/features/admin/components/AdminPageClient.tsx
+++ b/apps/web-app/src/features/admin/components/AdminPageClient.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useWallet } from "@/hooks/useWallet";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { BannerPage } from "@/components/ui/BannerPage";
-import { ConnectWalletModal } from "@/features/wallet/components/ConnectWalletModal";
+import { ConnectWalletModal } from "@/features/wallet/components/ConnectWalletModalLazy";
 import PoolStateToggle from "./PoolStateToggle";
 import TreasuryFeesTable from "./TreasuryFeesTable";
 import CollateralFactorForm from "./CollateralFactorForm";

--- a/apps/web-app/src/features/analytics/components/pages/Analytics.tsx
+++ b/apps/web-app/src/features/analytics/components/pages/Analytics.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import dynamic from "next/dynamic";
 import { BannerPage } from "@/components/ui/BannerPage";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { useWallet } from "@/hooks/useWallet";
@@ -13,18 +14,28 @@ import { SummaryCards } from "../ui/SummaryCards";
 import { TimeWindowSelector } from "../ui/TimeWindowSelector";
 import { NavChart } from "../ui/NavChart";
 import { EarningsBreakdownTable } from "../ui/EarningsBreakdownTable";
-import { AllocationDonut } from "../ui/AllocationDonut";
 import { CorrelationHeatmap } from "../ui/CorrelationHeatmap";
 import { RiskPanel } from "../ui/RiskPanel";
 import { StressSimulator } from "../ui/StressSimulator";
 import { YieldForecastPanel } from "../ui/YieldForecast";
 import type { TimeWindow } from "../../types/analytics";
 
+// Chart.js is heavy and only needed here — load it in its own chunk,
+// client-side only, with a skeleton while it streams in.
+const AllocationDonut = dynamic(
+  () => import("../ui/AllocationDonut").then((m) => m.AllocationDonut),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="min-h-[220px] animate-pulse rounded-xl bg-white/5" />
+    ),
+  }
+);
+
 const Analytics: React.FC = () => {
   const { address } = useWallet();
-  const [activeWindow, setActiveWindow] = useState<TimeWindow>(
-    DEFAULT_TIME_WINDOW
-  );
+  const [activeWindow, setActiveWindow] =
+    useState<TimeWindow>(DEFAULT_TIME_WINDOW);
 
   const { data: earnings, isLoading: earningsLoading } =
     useEarnings(activeWindow);
@@ -70,7 +81,9 @@ const Analytics: React.FC = () => {
 
       {/* Time window + summary cards */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <h2 className="text-white/60 text-sm font-medium">Portfolio Overview</h2>
+        <h2 className="text-white/60 text-sm font-medium">
+          Portfolio Overview
+        </h2>
         <TimeWindowSelector value={activeWindow} onChange={setActiveWindow} />
       </div>
 
@@ -87,10 +100,7 @@ const Analytics: React.FC = () => {
         <NavChart data={nav?.series ?? []} isLoading={navLoading} />
 
         {/* Earnings breakdown table */}
-        <EarningsBreakdownTable
-          data={earnings}
-          isLoading={earningsLoading}
-        />
+        <EarningsBreakdownTable data={earnings} isLoading={earningsLoading} />
 
         {/* Allocation + Correlation — side by side on wide screens */}
         <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">

--- a/apps/web-app/src/features/borrowing/components/ui/LiquidationsSection.tsx
+++ b/apps/web-app/src/features/borrowing/components/ui/LiquidationsSection.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import { Gavel, Wallet, RefreshCw, X } from "lucide-react";
 import { useBadDebt, type ActiveBadDebtAuction } from "../../hooks/useBadDebt";
-import { ConnectWalletModal } from "@/features/wallet/components/ConnectWalletModal";
+import { ConnectWalletModal } from "@/features/wallet/components/ConnectWalletModalLazy";
 import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
 
 // ---------------------------------------------------------------------------

--- a/apps/web-app/src/features/dashboard/components/ui/MainStats.tsx
+++ b/apps/web-app/src/features/dashboard/components/ui/MainStats.tsx
@@ -1,13 +1,28 @@
 "use client";
 
 import React from "react";
+import dynamic from "next/dynamic";
 import { DollarSign, Coins, TrendingUp } from "lucide-react";
 import { useWallet } from "@/hooks/useWallet";
 import { usePortfolioValue } from "@/features/dashboard/hooks/usePortfolioValue";
 import { useDashboardPools } from "@/features/dashboard/hooks/useDashboardPools";
 import { useUnifiedPositions } from "@/features/dashboard/hooks/useUnifiedPositions";
-import { HoldingsPieChart } from "@/features/dashboard/components/HoldingsPieChart";
 import { StatCard } from "@/features/stocks/components/ui/StatCard";
+
+// Chart.js is heavy and only needed here — load it in its own chunk,
+// client-side only, with a skeleton while it streams in.
+const HoldingsPieChart = dynamic(
+  () =>
+    import("@/features/dashboard/components/HoldingsPieChart").then(
+      (m) => m.HoldingsPieChart
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="min-h-[220px] animate-pulse rounded-xl bg-white/5" />
+    ),
+  }
+);
 
 function formatUsd(value: number): string {
   return value.toLocaleString("en-US", {

--- a/apps/web-app/src/features/dashboard/components/ui/QuickActions.tsx
+++ b/apps/web-app/src/features/dashboard/components/ui/QuickActions.tsx
@@ -10,7 +10,7 @@ import {
   Gavel,
 } from "lucide-react";
 import { useWallet } from "@/hooks/useWallet";
-import { ConnectWalletModal } from "@/features/wallet/components/ConnectWalletModal";
+import { ConnectWalletModal } from "@/features/wallet/components/ConnectWalletModalLazy";
 
 const actions = [
   {

--- a/apps/web-app/src/features/wallet/components/ConnectWalletModal.tsx
+++ b/apps/web-app/src/features/wallet/components/ConnectWalletModal.tsx
@@ -3,7 +3,7 @@
 import { X } from "lucide-react";
 import { useStellarWallet } from "@/hooks/useStellarWallet";
 
-interface ConnectWalletModalProps {
+export interface ConnectWalletModalProps {
   isOpen: boolean;
   onClose: () => void;
 }

--- a/apps/web-app/src/features/wallet/components/ConnectWalletModalLazy.tsx
+++ b/apps/web-app/src/features/wallet/components/ConnectWalletModalLazy.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { ConnectWalletModalProps } from "./ConnectWalletModal";
+
+/**
+ * Code-split wrapper around ConnectWalletModal.
+ *
+ * The modal pulls in the wallet-kit connection flow, which no visitor needs
+ * until they actually open it. `ssr: false` keeps it out of the initial
+ * bundle and out of server rendering (it's client-only and returns null
+ * while closed anyway). Import this instead of ConnectWalletModal directly.
+ */
+export const ConnectWalletModal = dynamic<ConnectWalletModalProps>(
+  () => import("./ConnectWalletModal").then((m) => m.ConnectWalletModal),
+  { ssr: false }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "zustand": "^5.0.2"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "16.1.6",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/lodash": "^4.14.202",
@@ -760,6 +761,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2296,6 +2307,16 @@
       "resolved": "packages/contracts/oracle",
       "link": true
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.1.6.tgz",
+      "integrity": "sha512-ee2kagdTaeEWPlotgdTOqFHYcD3e2m2bbE3I9Rq2i6ABYi5OgopmtEUe8NM23viaYxLV2tDH/2nd5+qKoEr6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.1.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
@@ -2545,6 +2566,13 @@
       "dependencies": {
         "lit": "^3"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -10119,6 +10147,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -11616,6 +11657,13 @@
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -11865,6 +11913,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -13135,6 +13190,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/h3": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
@@ -13842,6 +13913,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -15056,6 +15137,16 @@
       "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
       "license": "MIT"
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -15443,6 +15534,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -16900,6 +17001,21 @@
         }
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/slow-redact": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
@@ -17482,6 +17598,16 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
@@ -18750,6 +18876,66 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",


### PR DESCRIPTION
Closes #274

## Problem

The app used `next/dynamic` **nowhere** (`grep "dynamic(" ... | wc -l` → 0), so heavy feature-specific libraries loaded eagerly in the shared bundle on every route — most notably `chart.js` and the wallet-kit connect flow, which a visitor on a simple page never needs.

## Changes

**Code-splitting (the clearest, lowest-risk wins):**
- `HoldingsPieChart` (dashboard) and `AllocationDonut` (analytics) — the **only** two `chart.js` consumers — now load via `next/dynamic(..., { ssr: false })` with a skeleton, keeping `chart.js` / `react-chartjs-2` out of the initial bundle.
- `ConnectWalletModal` now loads through a `next/dynamic` wrapper (`ConnectWalletModalLazy`); no one pays for the connect flow until they open the modal. Its 3 call sites (dashboard `QuickActions`, borrowing `LiquidationsSection`, `AdminPageClient`) were repointed — JSX/props unchanged.

`ssr: false` is safe here: both charts and the modal are client-only visuals (the modal even returns `null` while closed), so there's no SSR/hydration to regress.

**Tooling:**
- `next.config.ts`: `experimental.optimizePackageImports` for `@mui/material`, `@mui/icons-material`, `lucide-react`, `chart.js`, `react-chartjs-2`; and `@next/bundle-analyzer` wired behind `ANALYZE=true` (new `analyze` script + devDependency) to measure and catch regressions going forward.

## Verification

- `tsc --noEmit`: no new type errors from this change.
- `eslint`: clean on all changed files.
- Confirmed the `next.config.ts` analyzer wiring loads and wraps the config.

## ⚠️ Bundle-analyzer report blocked by pre-existing build failures

I could not attach a before/after report because **`dev` does not currently build**, due to two issues in files this PR does not touch:

1. `features/swap/components/pages/Swap.tsx:587` — a JSX syntax error (`Expected '</', got 'ident'`).
2. `features/activity/components/ui/ActivityFeedItem.tsx:7` — imports `date-fns`, which is **not a declared dependency** (`Module not found`).

Both pre-exist on `dev`. Once they're fixed, `npm run analyze` (added here) will emit the interactive report. Worth fixing these as part of / before the CI work, since they also break any `next build` check.

## Acceptance criteria

- [ ] Bundle analyzer report attached — **blocked** by the pre-existing build failures above; analyzer is wired and ready (`npm run analyze`).
- [x] No SSR/hydration regressions (dynamic targets are client-only; `ssr:false`).
- [x] Follow-up addressed: `experimental.optimizePackageImports` added for MUI / lucide-react.

## Follow-up

Admin panel forms and the chain-specific (Stellar/EVM) SDK splitting are left as separate follow-ups to keep this PR focused and reviewable.