### PR TITLE
fix(web-app): show real USD pool liquidity via oracle prices

### DIFF
--- a/apps/web-app/src/features/borrowing/hooks/useBorrowPools.ts
+++ b/apps/web-app/src/features/borrowing/hooks/useBorrowPools.ts
@@ -9,18 +9,12 @@ import {
 import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
 import { getAvailableTokens } from "@/lib/helpers/stellar/soroswap";
 import { parseInterestRateFromContractResult } from "@/lib/helpers/lendingUtils";
+import { fetchUsdPriceMap } from "@/lib/helpers/priceUtils";
 import { RWA_TOKENS } from "@/lib/constants/wallet";
 import type { BorrowPool } from "../types/borrowing";
 
 /** Debt assets borrowable from Pool 2 (collateral = USDC/XLM) */
-const POOL2_DEBT_ASSETS = [
-  "USTRY",
-  "TESOURO",
-  "CETES",
-  "USDY",
-  "PYUSD",
-  "KTB",
-];
+const POOL2_DEBT_ASSETS = ["USTRY", "TESOURO", "CETES", "USDY", "PYUSD", "KTB"];
 /** Collateral assets accepted by Pool 2 */
 const POOL2_COLLATERAL_ASSETS = ["USDC", "XLM"];
 
@@ -30,7 +24,7 @@ async function fetchPoolPools(
   collateralCodes: string[],
   debtCodes: string[],
   availableTokens: ReturnType<typeof getAvailableTokens>
-): Promise<BorrowPool[]> {
+): Promise<Omit<BorrowPool, "poolBalanceUSD">[]> {
   let poolState;
   try {
     const poolStateTx = await client.get_pool_state({ simulate: true });
@@ -41,7 +35,7 @@ async function fetchPoolPools(
 
   if (poolState?.tag !== "Active") return [];
 
-  const pools: BorrowPool[] = [];
+  const pools: Omit<BorrowPool, "poolBalanceUSD">[] = [];
 
   for (const collateralCode of collateralCodes) {
     const collateralToken = availableTokens[collateralCode];
@@ -106,7 +100,6 @@ async function fetchPoolPools(
           collateralFactor,
           interestRate,
           poolBalance,
-          poolBalanceUSD: "Calculating...",
           isActive: true,
           contractId,
         });
@@ -159,7 +152,8 @@ export const useBorrowPools = () => {
         ...clientOptions,
       });
 
-      const [pool1Pools, pool2Pools] = await Promise.all([
+      const [priceMap, pool1Pools, pool2Pools] = await Promise.all([
+        fetchUsdPriceMap([...pool1DebtCodes, ...pool2DebtCodes]),
         fetchPoolPools(
           pool1Client,
           networks.testnet.pool1ContractId,
@@ -176,7 +170,14 @@ export const useBorrowPools = () => {
         ),
       ]);
 
-      return [...pool1Pools, ...pool2Pools];
+      return [...pool1Pools, ...pool2Pools].map((pool) => {
+        const price = priceMap[pool.assetCode] ?? null;
+        return {
+          ...pool,
+          poolBalanceUSD:
+            price !== null ? parseFloat(pool.poolBalance) * price : null,
+        };
+      });
     },
     [
       pool1CollateralCodes,

--- a/apps/web-app/src/features/borrowing/types/borrowing.ts
+++ b/apps/web-app/src/features/borrowing/types/borrowing.ts
@@ -6,7 +6,7 @@ export interface BorrowPool {
   collateralFactor: number;
   interestRate: number;
   poolBalance: string;
-  poolBalanceUSD: string;
+  poolBalanceUSD: number | null;
   isActive: boolean;
   contractId: string;
 }

--- a/apps/web-app/src/features/borrowing/utils/borrowUtils.ts
+++ b/apps/web-app/src/features/borrowing/utils/borrowUtils.ts
@@ -1,4 +1,4 @@
-import { formatLiquidity } from "@/lib/helpers/formatUtils";
+import { formatUsd } from "@/lib/helpers/formatUtils";
 import type { BorrowPool, BorrowTableAsset } from "../types/borrowing";
 
 export function calculateBorrowLimit(
@@ -13,7 +13,7 @@ export function calculateBorrowLimit(
 
 export function poolsToTableAssets(pools: BorrowPool[]): BorrowTableAsset[] {
   return pools.map((pool, index) => {
-    const liquidity = formatLiquidity(pool.poolBalance);
+    const liquidity = formatUsd(pool.poolBalanceUSD);
     return {
       id: `borrow-${index}`,
       pool: {

--- a/apps/web-app/src/features/lending/hooks/__tests__/useLend.test.ts
+++ b/apps/web-app/src/features/lending/hooks/__tests__/useLend.test.ts
@@ -34,7 +34,7 @@ const {
         asset: "CASSET",
         assetCode: "USDC",
         poolBalance: "1500",
-        poolBalanceUSD: "Calculating...",
+        poolBalanceUSD: 1500,
         interestRate: 5.5,
         bTokenRate: "1.0",
         isActive: true,

--- a/apps/web-app/src/features/lending/hooks/useLend.ts
+++ b/apps/web-app/src/features/lending/hooks/useLend.ts
@@ -19,7 +19,7 @@ import { waitForTransaction } from "@/lib/helpers/stellar/waitForTransaction";
 import { usePools, usePoolAction } from "@/lib/orchestrator";
 import type { PoolInfo } from "@/lib/orchestrator";
 import { fromSmallestUnit, toSmallestUnit } from "@/lib/helpers/tokenUtils";
-import { formatLiquidity } from "@/lib/helpers/formatUtils";
+import { formatLiquidity, formatUsd } from "@/lib/helpers/formatUtils";
 import type { PoolData } from "../types/lending";
 
 function toBTokens(tokensAmount: string, bTokenRate: string): string {
@@ -81,11 +81,7 @@ export function useLend() {
 
   const pools: PoolData[] = useMemo(() => {
     const nekoPools: PoolData[] = lendingPools.map((pool, index) => {
-      const balanceNum = parseFloat(pool.poolBalance);
-      const liquidity =
-        balanceNum >= 1000
-          ? `$${(balanceNum / 1000).toFixed(2)}k`
-          : `$${balanceNum.toFixed(2)}`;
+      const liquidity = formatUsd(pool.poolBalanceUSD);
       return {
         id: `pool-${index}`,
         name: `${pool.assetCode} Pool`,

--- a/apps/web-app/src/features/lending/hooks/useLendingPools.ts
+++ b/apps/web-app/src/features/lending/hooks/useLendingPools.ts
@@ -9,12 +9,13 @@ import {
 import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
 import { getAvailableTokens } from "@/lib/helpers/stellar/soroswap";
 import { parseInterestRateFromContractResult } from "@/lib/helpers/lendingUtils";
+import { fetchUsdPriceMap } from "@/lib/helpers/priceUtils";
 
 export interface LendingPool {
   asset: string;
   assetCode: string;
   poolBalance: string;
-  poolBalanceUSD: string;
+  poolBalanceUSD: number | null;
   interestRate: number;
   bTokenRate: string;
   isActive: boolean;
@@ -23,21 +24,14 @@ export interface LendingPool {
 
 /** Deposit assets for each pool */
 const POOL1_ASSETS = ["USDC", "XLM"];
-const POOL2_ASSETS = [
-  "USTRY",
-  "TESOURO",
-  "CETES",
-  "USDY",
-  "PYUSD",
-  "KTB",
-];
+const POOL2_ASSETS = ["USTRY", "TESOURO", "CETES", "USDY", "PYUSD", "KTB"];
 
 async function fetchLendingPools(
   client: RwaLendingClient,
   contractId: string,
   assetCodes: string[],
   availableTokens: ReturnType<typeof getAvailableTokens>
-): Promise<LendingPool[]> {
+): Promise<Omit<LendingPool, "poolBalanceUSD">[]> {
   let poolState;
   try {
     const poolStateTx = await client.get_pool_state({ simulate: true });
@@ -48,7 +42,7 @@ async function fetchLendingPools(
 
   if (poolState?.tag !== "Active") return [];
 
-  const pools: LendingPool[] = [];
+  const pools: Omit<LendingPool, "poolBalanceUSD">[] = [];
 
   for (const assetCode of assetCodes) {
     try {
@@ -106,7 +100,6 @@ async function fetchLendingPools(
         asset: token.contract,
         assetCode,
         poolBalance,
-        poolBalanceUSD: "Calculating...",
         interestRate,
         bTokenRate,
         isActive: true,
@@ -140,7 +133,8 @@ export const useLendingPools = () => {
         ...clientOptions,
       });
 
-      const [pool1Pools, pool2Pools] = await Promise.all([
+      const [priceMap, pool1Pools, pool2Pools] = await Promise.all([
+        fetchUsdPriceMap([...POOL1_ASSETS, ...POOL2_ASSETS]),
         fetchLendingPools(
           pool1Client,
           networks.testnet.pool1ContractId,
@@ -155,7 +149,14 @@ export const useLendingPools = () => {
         ),
       ]);
 
-      return [...pool1Pools, ...pool2Pools];
+      return [...pool1Pools, ...pool2Pools].map((pool) => {
+        const price = priceMap[pool.assetCode] ?? null;
+        return {
+          ...pool,
+          poolBalanceUSD:
+            price !== null ? parseFloat(pool.poolBalance) * price : null,
+        };
+      });
     },
     [availableTokens]
   );

--- a/apps/web-app/src/lib/helpers/formatUtils.ts
+++ b/apps/web-app/src/lib/helpers/formatUtils.ts
@@ -20,6 +20,17 @@ export function formatLiquidity(value: number | string): string {
 }
 
 /**
+ * Format a USD value for display. Values are genuinely USD (computed via oracle prices).
+ * `null` means no price source was available for the asset.
+ */
+export function formatUsd(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return "Price unavailable";
+  }
+  return formatLiquidity(value);
+}
+
+/**
  * Format a token amount for display, trimming trailing zeros and adapting
  * decimal places to the magnitude of the value.
  *

--- a/apps/web-app/src/lib/helpers/priceUtils.ts
+++ b/apps/web-app/src/lib/helpers/priceUtils.ts
@@ -1,0 +1,31 @@
+import { getAssetsConfig } from "@/lib/constants/assets.config";
+import { stellarPriceService } from "@/lib/services/stellar-price.service";
+
+/**
+ * Fetches USD prices for the given asset codes in parallel.
+ *
+ * Map values are `null` when no USD price source is available (the service
+ * returns 0 or the lookup throws). Callers must surface that state in the UI
+ * rather than treating it as a zero price.
+ */
+export async function fetchUsdPriceMap(
+  assetCodes: string[]
+): Promise<Record<string, number | null>> {
+  const uniqueCodes = [...new Set(assetCodes)];
+
+  const entries = await Promise.all(
+    uniqueCodes.map(async (code) => {
+      try {
+        const asset = getAssetsConfig()[code];
+        const contract =
+          asset?.priceSource === "oracle" ? asset.contract : undefined;
+        const price = await stellarPriceService.getPrice(code, contract);
+        return [code, price > 0 ? price : null] as const;
+      } catch {
+        return [code, null] as const;
+      }
+    })
+  );
+
+  return Object.fromEntries(entries);
+}


### PR DESCRIPTION
Closes #287

## Problem

Both the lending and borrow pool tables displayed pool liquidity as a dollar figure (e.g. `$500.00k`), but the underlying value was the raw on-chain token balance — not a USD conversion. Since pools hold non-USD-pegged RWAs (CETES, TESOURO, KTB, ...), the display was actively misleading. The `poolBalanceUSD: "Calculating..."` field was dead — set once, never computed, never consumed.

## Solution

Wires the existing oracle pricing infrastructure (`stellarPriceService`, same pattern as `usePortfolioValue`) into both pool hooks:

- **New `lib/helpers/priceUtils.ts`** — `fetchUsdPriceMap(assetCodes)` dedupes asset codes and batches one oracle lookup per unique asset via `Promise.all`, returning `Record<string, number | null>`. `null` (never `0`) means no price source is available, so callers can't mistake an outage for a zero value.
- **`useLendingPools` / `useBorrowPools`** — the price map is fetched *in parallel* with the two pool fetches inside the React Query `queryFn`, so prices are cached and refetched on the same 2-minute cycle as pool data. `poolBalanceUSD` is now `number | null`: the real computed USD value (`balance × oracle price`), replacing the dead `"Calculating..."` placeholder. Per-asset lookups mean multi-asset pools aggregate correctly row by row.
- **New `formatUsd()` in `formatUtils.ts`** — renders a genuine USD number in the existing `$X.XXk` style, and renders `null` as `"Price unavailable"` instead of a misleading figure. `formatLiquidity` is untouched, so pools/dashboard TVL paths are unaffected.
- **`useLend` / `borrowUtils`** — table liquidity now derives from `formatUsd(pool.poolBalanceUSD)`. Raw `poolBalance` is untouched and still drives deposit/withdraw math. Table components needed no changes — they render the pre-formatted string.

## Acceptance criteria

- [x] Pool liquidity in lending and borrow tables reflects actual USD value via `stellarPriceService`
- [x] Multi-asset pools aggregate correctly (per-asset oracle price × per-asset balance)
- [x] Assets without a price source show "Price unavailable" instead of a misleading number (note: XLM has no oracle feed in `stellarPriceService` — consistent with `usePortfolioValue` — so XLM rows show this state)
- [x] Dead `poolBalanceUSD: "Calculating..."` placeholder replaced with real computed data
- [x] No regression to non-USD figures (deposit/withdraw math uses raw `poolBalance`; `formatLiquidity` unchanged for other features)

## Verification

- `vitest`: `useLend.test.ts` — 10/10 pass (fixture updated to the new `number | null` type)
- Full suite: 255 passed / 30 failed — the 30 failures are pre-existing on `dev` (strategy + portfolio-history tests), confirmed identical with this change stashed
- `tsc --noEmit`: no errors in any touched file (pre-existing errors in `Swap.tsx` only)
- ESLint + Prettier clean on all touched files