### PR TITLE
fix(orchestrator): PoolRegistry drops all but the last adapter per pool type

### DIFF
--- a/apps/web-app/src/lib/orchestrator/core/PoolRegistry.ts
+++ b/apps/web-app/src/lib/orchestrator/core/PoolRegistry.ts
@@ -3,29 +3,22 @@ import type { PoolType } from "../types/pool.types";
 import { PoolNotFoundError } from "../types/errors";
 
 export class PoolRegistry {
-  private adapters = new Map<PoolType, BasePoolAdapter>();
-
-  private poolTypeMap = new Map<string, PoolType>();
+  private adapters = new Map<PoolType, BasePoolAdapter[]>();
 
   register(adapter: BasePoolAdapter): void {
-    this.adapters.set(adapter.type, adapter);
-  }
-
-  registerPool(poolId: string, type: PoolType): void {
-    this.poolTypeMap.set(poolId, type);
+    const existing = this.adapters.get(adapter.type);
+    if (existing) {
+      existing.push(adapter);
+    } else {
+      this.adapters.set(adapter.type, [adapter]);
+    }
   }
 
   resolve(poolId: string): BasePoolAdapter {
-    const explicitType = this.poolTypeMap.get(poolId);
-    if (explicitType) {
-      const adapter = this.adapters.get(explicitType);
-      if (adapter) return adapter;
-    }
-
     const prefixMatch = poolId.match(/^(\w+):/);
     if (prefixMatch) {
       const type = prefixMatch[1] as PoolType;
-      const adapter = this.adapters.get(type);
+      const adapter = this.adapters.get(type)?.[0];
       if (adapter) return adapter;
     }
 
@@ -38,15 +31,7 @@ export class PoolRegistry {
   }
 
   getAdapters(): BasePoolAdapter[] {
-    return [...this.adapters.values()];
-  }
-
-  listRegisteredPools(): string[] {
-    return [...this.poolTypeMap.keys()];
-  }
-
-  hasAdapter(type: PoolType): boolean {
-    return this.adapters.has(type);
+    return [...this.adapters.values()].flat();
   }
 }
 

--- a/apps/web-app/src/lib/orchestrator/core/__tests__/Orchestrator.multiPool.test.ts
+++ b/apps/web-app/src/lib/orchestrator/core/__tests__/Orchestrator.multiPool.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Proves issue #284's fix at the real Orchestrator + BlendPoolAdapter
+ * integration level (not just PoolRegistry in isolation with stub adapters).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  poolLoadMock,
+  tokenMetaLoadMock,
+  submitMock,
+  claimMock,
+  PoolContractV2Mock,
+  fromXDRMock,
+  loadAccountMock,
+  prepareTransactionMock,
+  builder,
+} = vi.hoisted(() => {
+  const submitMock = vi.fn(() => "OP_XDR");
+  const claimMock = vi.fn(() => "CLAIM_XDR");
+  const builder = {
+    addOperation: vi.fn(() => builder),
+    setTimeout: vi.fn(() => builder),
+    build: vi.fn(() => ({ __tx: true })),
+  };
+  return {
+    poolLoadMock: vi.fn(),
+    tokenMetaLoadMock: vi.fn(),
+    submitMock,
+    claimMock,
+    PoolContractV2Mock: vi.fn(function () {
+      return { submit: submitMock, claim: claimMock };
+    }),
+    fromXDRMock: vi.fn(() => ({ __op: true })),
+    loadAccountMock: vi.fn(async () => ({ __account: true })),
+    prepareTransactionMock: vi.fn(async () => ({
+      toXDR: () => "PREPARED_XDR",
+    })),
+    builder,
+  };
+});
+
+vi.mock("@blend-capital/blend-sdk", () => ({
+  RequestType: {
+    SupplyCollateral: 0,
+    WithdrawCollateral: 1,
+    Supply: 2,
+    Withdraw: 3,
+    Borrow: 4,
+    Repay: 5,
+  },
+  PoolV2: { load: poolLoadMock },
+  PoolContractV2: PoolContractV2Mock,
+  TokenMetadata: { load: tokenMetaLoadMock },
+}));
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  xdr: { Operation: { fromXDR: fromXDRMock } },
+  Horizon: {
+    Server: vi.fn(function () {
+      return { loadAccount: loadAccountMock };
+    }),
+  },
+  TransactionBuilder: vi.fn(function () {
+    return builder;
+  }),
+  rpc: {
+    Server: vi.fn(function () {
+      return { prepareTransaction: prepareTransactionMock };
+    }),
+  },
+}));
+
+// Orchestrator.ts has module-level registration of Neko/Soroswap (and Blend)
+// adapters onto the singleton registry. Stub those constructors so importing
+// the Orchestrator *class* does not pull real @neko/lending / soroswap deps.
+// Our tests never use that singleton — they build a fresh PoolRegistry.
+vi.mock("../../adapters/NekoLendingAdapter", () => ({
+  NekoLendingAdapter: vi.fn(function () {
+    return { type: "neko" };
+  }),
+}));
+vi.mock("../../adapters/SoroswapPoolAdapter", () => ({
+  SoroswapPoolAdapter: vi.fn(function () {
+    return { type: "soroswap" };
+  }),
+}));
+vi.mock("../../adapters/blend-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../adapters/blend-config")>();
+  return {
+    ...actual,
+    getBlendPoolIds: () => [],
+  };
+});
+
+import { PoolRegistry } from "../PoolRegistry";
+import { Orchestrator } from "../Orchestrator";
+import { BlendPoolAdapter } from "../../adapters/BlendPoolAdapter";
+
+const POOL_A = "CPOOLA";
+const ASSET_A = "CASSETA";
+const POOL_B = "CPOOLB";
+const ASSET_B = "CASSETB";
+const USER = "GUSER";
+
+const TVL_A = 1000n;
+const APY_A = 0.05;
+const TVL_B = 2000n;
+const APY_B = 0.08;
+
+function makeReserve(totalSupply: bigint, estSupplyApy: number) {
+  return {
+    totalSupply: () => totalSupply,
+    estSupplyApy,
+    estBorrowApy: estSupplyApy * 1.5,
+    config: { decimals: 7 },
+    getCollateralFactor: () => 0.75,
+    getLiabilityFactor: () => 1.25,
+    totalLiabilities: () => 0n,
+    getUtilizationFloat: () => 0.1,
+  };
+}
+
+function makePoolData(
+  assetAddress: string,
+  totalSupply: bigint,
+  estSupplyApy: number,
+  poolName: string
+) {
+  return {
+    reserves: new Map([[assetAddress, makeReserve(totalSupply, estSupplyApy)]]),
+    metadata: { status: 0, name: poolName },
+  };
+}
+
+let orchestrator: Orchestrator;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  submitMock.mockReturnValue("OP_XDR");
+  claimMock.mockReturnValue("CLAIM_XDR");
+
+  poolLoadMock.mockImplementation(
+    async (_network: unknown, poolContractId: string) => {
+      if (poolContractId === POOL_A) {
+        return makePoolData(ASSET_A, TVL_A, APY_A, "Pool A");
+      }
+      if (poolContractId === POOL_B) {
+        return makePoolData(ASSET_B, TVL_B, APY_B, "Pool B");
+      }
+      throw new Error(`Unexpected poolContractId: ${poolContractId}`);
+    }
+  );
+
+  tokenMetaLoadMock.mockImplementation(
+    async (_network: unknown, assetAddress: string) => {
+      if (assetAddress === ASSET_A) {
+        return { symbol: "AAA", name: "Asset A", decimals: 7 };
+      }
+      if (assetAddress === ASSET_B) {
+        return { symbol: "BBB", name: "Asset B", decimals: 7 };
+      }
+      return { symbol: "UNK", name: assetAddress, decimals: 7 };
+    }
+  );
+
+  const registry = new PoolRegistry();
+  registry.register(new BlendPoolAdapter(POOL_A));
+  registry.register(new BlendPoolAdapter(POOL_B));
+  orchestrator = new Orchestrator(registry);
+});
+
+describe("Orchestrator + multi BlendPoolAdapter (issue #284)", () => {
+  it("getAllPools() aggregates reserves from every registered Blend adapter", async () => {
+    const pools = await orchestrator.getAllPools();
+
+    expect(pools).toHaveLength(2);
+
+    const poolA = pools.find((p) => p.id === `blend:${POOL_A}:${ASSET_A}`);
+    const poolB = pools.find((p) => p.id === `blend:${POOL_B}:${ASSET_B}`);
+
+    expect(poolA).toBeDefined();
+    expect(poolA!.tvl).toBe(TVL_A);
+    expect(poolA!.apy).toBe(APY_A * 100);
+
+    expect(poolB).toBeDefined();
+    expect(poolB!.tvl).toBe(TVL_B);
+    expect(poolB!.apy).toBe(APY_B * 100);
+
+    const ids = pools.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("resolve()-driven getPoolInfo / deposit route by raw id, not adapter instance", async () => {
+    const infoA = await orchestrator.getPoolInfo(`blend:${POOL_A}:${ASSET_A}`);
+    expect(infoA.tvl).toBe(TVL_A);
+    expect(infoA.apy).toBe(APY_A * 100);
+
+    const infoB = await orchestrator.getPoolInfo(`blend:${POOL_B}:${ASSET_B}`);
+    expect(infoB.tvl).toBe(TVL_B);
+    expect(infoB.apy).toBe(APY_B * 100);
+
+    await orchestrator.deposit(`blend:${POOL_A}:${ASSET_A}`, USER, 100n);
+    expect(PoolContractV2Mock).toHaveBeenCalledWith(POOL_A);
+
+    PoolContractV2Mock.mockClear();
+
+    await orchestrator.deposit(`blend:${POOL_B}:${ASSET_B}`, USER, 100n);
+    expect(PoolContractV2Mock).toHaveBeenCalledWith(POOL_B);
+  });
+});

--- a/apps/web-app/src/lib/orchestrator/core/__tests__/PoolRegistry.test.ts
+++ b/apps/web-app/src/lib/orchestrator/core/__tests__/PoolRegistry.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { PoolRegistry } from "../PoolRegistry";
+import type { BasePoolAdapter } from "../../types/adapter.types";
+import type { PoolInfo, PoolType } from "../../types/pool.types";
+import { PoolNotFoundError } from "../../types/errors";
+
+function makeStub(type: PoolType, sentinelId: string): BasePoolAdapter {
+  const sentinel: PoolInfo = {
+    id: sentinelId,
+    type,
+    name: sentinelId,
+    tokens: [],
+    tvl: 0n,
+    apy: 0,
+    state: "active",
+    supportedActions: [],
+    metadata: {},
+  };
+
+  return {
+    type,
+    listPools: async () => [sentinel],
+  } as unknown as BasePoolAdapter;
+}
+
+describe("PoolRegistry", () => {
+  it("keeps every adapter when multiple of the same type are registered", () => {
+    const registry = new PoolRegistry();
+    const first = makeStub("blend", "blend-pool-a");
+    const second = makeStub("blend", "blend-pool-b");
+
+    registry.register(first);
+    registry.register(second);
+
+    const adapters = registry.getAdapters();
+    expect(adapters).toHaveLength(2);
+    expect(adapters).toContain(first);
+    expect(adapters).toContain(second);
+  });
+
+  it("resolve() returns a working adapter of the correct type when multiples are registered", () => {
+    const registry = new PoolRegistry();
+    const first = makeStub("blend", "blend-pool-a");
+    const second = makeStub("blend", "blend-pool-b");
+
+    registry.register(first);
+    registry.register(second);
+
+    const resolved = registry.resolve("blend:SOME_CONTRACT_ID");
+    expect(resolved.type).toBe("blend");
+    expect(resolved).toBe(first);
+  });
+
+  it("resolve() throws PoolNotFoundError for an unknown type/poolId", () => {
+    const registry = new PoolRegistry();
+    registry.register(makeStub("blend", "blend-pool-a"));
+
+    expect(() => registry.resolve("unknown:pool")).toThrow(PoolNotFoundError);
+    expect(() => registry.resolve("no-prefix-at-all")).toThrow(
+      PoolNotFoundError
+    );
+  });
+
+  it("getAdapters() returns adapters across different types", () => {
+    const registry = new PoolRegistry();
+    const blend = makeStub("blend", "blend-pool");
+    const neko = makeStub("neko", "neko-pool");
+    const soroswap = makeStub("soroswap", "soroswap-pool");
+
+    registry.register(blend);
+    registry.register(neko);
+    registry.register(soroswap);
+
+    const adapters = registry.getAdapters();
+    expect(adapters).toHaveLength(3);
+    expect(adapters).toEqual(expect.arrayContaining([blend, neko, soroswap]));
+  });
+
+  it("resolve() routes to the adapter matching the poolId prefix across types", () => {
+    const registry = new PoolRegistry();
+    const blend = makeStub("blend", "blend-pool");
+    const neko = makeStub("neko", "neko-pool");
+    const soroswap = makeStub("soroswap", "soroswap-pool");
+
+    registry.register(blend);
+    registry.register(neko);
+    registry.register(soroswap);
+
+    expect(registry.resolve("blend:ABC")).toBe(blend);
+    expect(registry.resolve("neko:XYZ")).toBe(neko);
+    expect(registry.resolve("soroswap:XLM-USDC")).toBe(soroswap);
+  });
+});


### PR DESCRIPTION
Closes #284

## Problem

`PoolRegistry` stored adapters in `Map<PoolType, BasePoolAdapter>`, keyed only by `.type`. Registering a second adapter of the same type overwrote the first instead of adding to it.

This is latent today since only one Blend pool per network is configured — but `Orchestrator.ts` already loops over `getBlendPoolIds()` registering one `BlendPoolAdapter` per pool ID, and `blend-config.ts`'s `BLEND_POOLS: Record<string, string[]>` is explicitly typed for multiple pool IDs per network, signaling multi-pool support was intended from the start. The moment a second Blend pool is configured, `getAllPools()` (used by the Pools page, Dashboard "Your Positions," and Discover Assets) would silently drop every pool but the last-registered one.

## What changed

**`PoolRegistry.ts`**
- `adapters` is now `Map<PoolType, BasePoolAdapter[]>` — an array per type instead of a single instance.
- `register()` pushes onto the type's array instead of overwriting.
- `resolve(poolId)` still parses the type from the `poolId` prefix and returns the first adapter registered for that type. This is safe: every adapter method besides `listPools()` re-derives all needed state from the `rawId` argument itself, so which specific same-type instance handles a `resolve()`-driven call doesn't affect correctness — proven explicitly in the new integration test (see below).
- `getAdapters()` now flattens every type's array, so `Orchestrator.getAllPools()` calls `.listPools()` on every registered instance, not just one per type.
- Removed `poolTypeMap`, `registerPool()`, `listRegisteredPools()`, `hasAdapter()` — confirmed dead code (grepped the whole `apps/web-app/src` tree, zero callers anywhere), sitting directly next to this bug as an unused, never-wired-up explicit-override mechanism.

`Orchestrator.ts` and `BlendPoolAdapter.ts` needed no changes — the registration loop and `getAllPools()`/dispatch logic were already written correctly against the `PoolRegistry` contract; the bug was entirely inside the registry's storage.

**Tests**
- `PoolRegistry.test.ts` — unit-level regression coverage using stub adapters: registering multiple same-type adapters keeps all of them, `getAdapters()` returns the full set across types, `resolve()` routes correctly by prefix, `PoolNotFoundError` still throws for unknown types.
- `Orchestrator.multiPool.test.ts` (new) — proves the fix at the real integration level per the acceptance criteria ("since this bug is invisible with only one pool configured"): two real `BlendPoolAdapter` instances (distinct pool contract IDs, distinct mocked reserve data) registered through a fresh `PoolRegistry` + `Orchestrator`:
  - `getAllPools()` aggregates both pools' reserves, no duplicate ids.
  - `getPoolInfo()`/`deposit()` dispatch by the raw pool-id string and correctly target the right pool's contract (verified via the `PoolContractV2` constructor spy) — even though `resolve()` always hands back the *same*, first-registered adapter instance for both calls. This is the specific correctness property the whole fix depends on.

**No regression in Pools page / Dashboard / PoolDetail**: `usePools()`, `usePoolInfo()`, `useUserPosition()` (the hooks all three surfaces consume) are pure pass-throughs to `orchestrator.getAllPools()` / `getPoolInfo()` / `getUserPosition()` — none of them assume a specific pool count or shape per type, so this fix is strictly additive (more pools surfaced, not fewer or reshaped).

## Test plan

- [x] `npx vitest run` on `PoolRegistry.test.ts`, `Orchestrator.multiPool.test.ts`, `BlendPoolAdapter.test.ts` together — 17/17 passing
- [x] Full suite — 262 passed, same pre-existing unrelated failures as `dev` baseline (missing `@neko/defindex-vault` workspace package, jsdom `localStorage` setup), no new failures
- [x] `tsc --noEmit` — clean on `PoolRegistry.ts` and the new test file
- [x] `eslint` on changed files — clean